### PR TITLE
fix: sidecar service failing autostart

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,6 +77,7 @@ WORKDIR /app/package
 
 RUN rm -rf /app/package/src/inferia/dashboard
 COPY --from=node-builder /build/dashboard/dist /app/package/src/inferia/dashboard
+COPY --from=node-builder /build/depin-sidecar/dist /app/package/src/inferia/services/orchestration/services/depin-sidecar/dist
 
 # 1. Install CPU-only Torch first to prevent downloading the 2GB CUDA version
 RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
@@ -84,10 +85,6 @@ RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/wh
 # 2. Install the package WITHOUT [all-providers] (removes AWS/GCP/Azure SDKs)
 #    We install with --no-deps for torch to avoid overwriting the CPU version
 RUN pip install --no-cache-dir .
-
-# Final Cleanup of build artifacts
-RUN find /usr/local/lib/python3.12/site-packages -name "*.pyc" -delete && \
-    find /usr/local/lib/python3.12/site-packages -name "__pycache__" -delete
 
 # Copy entrypoint script
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -120,8 +117,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy built sidecar from node-builder
-COPY --from=node-builder /build/depin-sidecar /app/package/src/inferia/services/orchestration/services/depin-sidecar
 
 EXPOSE 8080 3000 50051
 

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -142,13 +142,13 @@ inferia = [
   "infra/schema/migrations/*.sql",
   "services/orchestration/services/depin-sidecar/package.json",
   "services/orchestration/services/depin-sidecar/tsconfig.json",
-  "services/orchestration/services/depin-sidecar/src/**/*"
+  "services/orchestration/services/depin-sidecar/src/**/*",
+  "services/orchestration/services/depin-sidecar/dist/**/*",
 ]
 
 [tool.setuptools.exclude-package-data]
 inferia = [
     "**/node_modules/**/*",
-    "**/dist/**/*",
     "**/.env",
     "**/*.pyc",
     "**/__pycache__/**/*"

--- a/package/src/inferia/cli.py
+++ b/package/src/inferia/cli.py
@@ -189,8 +189,6 @@ def run_nosana_sidecar(queue=None):
         subprocess.Popen(
             ["npm", "start"],
             cwd=sidecar_dir,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             env=env,
         )
         if queue:


### PR DESCRIPTION
1. The DePin sidecar service was failing to start automatically on inferiallm start because the packaged version was not shipping dist directory, required to start sidecar. Made the pyproject.toml NOT ignore dist directory to fix that.

2. Moved COPY instruction to before installing inferiallm as a python package to allow dist to be copied along with the package which is supposed to be a prerequisite.

3. The find and delete instructions have also been removed from the dockerfile since we are already passing the PYTHONDONTWRITEBYTECODE=1 env variable which prevents .pyc bytecode file creation reducing the overall image compile times.

4. Disabled piping the sidecar subprocess to /dev/null for easier debugging.