### PR TITLE
docs: update documentation to reflect current codebase structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ inferiallm start [service]
 * `all`: Start all services (default)
 * `orchestration`: Start Orchestration Gateway stack
 * `inference`: Start Inference Gateway
-* `filtration`: Start Filtration Gateway
+* `inference`: Start Inference Gateway
+* `api`: Start API Gateway
 
 **Examples:**
 
@@ -283,7 +284,7 @@ inferiallm start orchestration
 [CLI] Starting All Services...
 [Orchestration Gateway API] Listening on port 8080
 [Inference Gateway API] Listening on port 8001
-[Filtration Gateway API] Listening on port 8000
+[API Gateway] Listening on port 8000
 [Dashboard] Serving at http://localhost:3001/
 ...
 ```
@@ -300,9 +301,9 @@ Start the Orchestration Gateway stack (API, Background Worker, and DePIN Sidecar
 
 Start the Inference Gateway standalone.
 
-#### `inferiallm start filtration`
+#### `inferiallm start api`
 
-Start the Filtration Gateway standalone.
+Start the API Gateway standalone.
 
  ---
 
@@ -389,7 +390,7 @@ These are the **only externally reachable services**.
 | Service | Responsibility | Documentation |
 | ------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------ |
 | **Admin Dashboard** | Administrative control surface for policies, compute pools, usage, and audits | [README](./apps/dashboard/README.md) |
-| **Filtration Gateway** | Authentication, RBAC, policy enforcement | [README](./package/src/inferia/services/filtration/README.md) |
+| **API Gateway** | Authentication, RBAC, policy enforcement | [README](./package/src/inferia/services/api_gateway/README.md) |
 | **Inference Gateway** | Data-plane ingress for all LLM inference traffic | [README](./package/src/inferia/services/inference/README.md) |
 | **Guardrail Engine** | Content safety scanning and PII detection | [README](./package/src/inferia/services/guardrail/README.md) |
 | **Data Engine** | Data processing and knowledge base operations | [README](./package/src/inferia/services/data/README.md) |
@@ -506,11 +507,11 @@ Supports:
 | **Orchestrator** | Compute lifecycle and workload management | [README](./package/src/inferia/services/orchestration/README.md) |
 | **Guardrail Engine** | Content safety scanning and PII detection | [README](./package/src/inferia/services/guardrail/README.md) |
 | **Data Engine** | Knowledge base and data processing | [README](./package/src/inferia/services/data/README.md) |
-| **RBAC** | Identity and access boundaries | [README](./package/src/inferia/services/filtration/rbac/README.md) |
-| **Gateway** | Secure internal service routing | [README](./package/src/inferia/services/filtration/gateway/README.md) |
-| **Audit** | Immutable execution and policy logs | [README](./package/src/inferia/services/filtration/audit/README.md) |
-| **Policy** | Quota, rate, and budget enforcement | [README](./package/src/inferia/services/filtration/policy/README.md) |
-| **Prompt** | Prompt templates and versioning | [README](./package/src/inferia/services/filtration/prompt/README.md) |
+| **RBAC** | Identity and access boundaries | [README](./package/src/inferia/services/api_gateway/rbac/README.md) |
+| **Gateway** | Secure internal service routing | [README](./package/src/inferia/services/api_gateway/gateway/README.md) |
+| **Audit** | Immutable execution and policy logs | [README](./package/src/inferia/services/api_gateway/audit/README.md) |
+| **Policy** | Quota, rate, and budget enforcement | [README](./package/src/inferia/services/api_gateway/policy/README.md) |
+| **Prompt** | Prompt templates and versioning | [README](./package/src/inferia/services/api_gateway/prompt/README.md) |
 | **Packages** | Installation, versioning, and initialization | [README](./package/README.md) |
 
  ---

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -52,7 +52,7 @@ Manage data sources for Retrieval Augmented Generation (RAG) pipelines. Upload d
 
 ### Prerequisites
 - Node.js 18+
-- Running instance of InferiaLLM Backend (Orchestration & Filtration Gateways)
+- Running instance of InferiaLLM Backend (Orchestration & API Gateways)
 
 ### Installation
 
@@ -70,7 +70,7 @@ VITE_API_BASE_URL=http://localhost:8000
 VITE_ORCHESTRATOR_URL=http://localhost:8080
 ```
 
-- `VITE_API_BASE_URL`: URL of the Filtration Gateway (Management API).
+- `VITE_API_BASE_URL`: URL of the API Gateway (Management API).
 - `VITE_ORCHESTRATOR_URL`: URL of the Orchestration Gateway.
 
 ### Development
@@ -95,6 +95,6 @@ The output will be generated in the `dist` directory.
 
 The dashboard acts as a frontend for the InferiaLLM Control Plane.
 
-- **Filtration Gateway Connection**: Used for authentication, RBAC, user management, and high-level policy configuration.
+- **API Gateway Connection**: Used for authentication, RBAC, user management, and high-level policy configuration.
 - **Orchestration Gateway Connection**: Used for "Day 2" operations—deploying models, managing compute pools, and viewing live deployment status. Use `VITE_ORCHESTRATOR_URL` to configure this connection.
 - **Inference Gateway Interaction**: The dashboard does **not** directly handle inference traffic. It visualizes logs and metrics that are asynchronously reported by the Inference Gateway to the control plane.

--- a/package/README.md
+++ b/package/README.md
@@ -82,7 +82,7 @@ Starts all InferiaLLM gateways (Orchestration, Inference, Filtration) and the Da
 You can also start specific services:
 * `inferiallm start orchestration`: Starts the Orchestration Gateway stack.
 * `inferiallm start inference`: Starts the Inference Gateway standalone.
-* `inferiallm start filtration`: Starts the Filtration Gateway standalone.
+* `inferiallm start api`: Starts the API Gateway standalone.
 
 ---
 
@@ -93,13 +93,12 @@ The `inferia` package is a monorepo-style library that contains all backend serv
 ```text
 package/src/inferia/
 ├── cli.py                  # Entry point for the CLI
-├── gateways/
-│   ├── filtration_gateway  # Security & Policy Service (Port 8000)
+├── services/
+│   ├── api_gateway/        # Security & Policy Service (Port 8000)
 │   ├── inference_gateway   # Inference Proxy Service (Port 8001)
-│   └── orchestration_gateway # Compute Control Plane (Port 8080)
-└── services/               # Shared business logic
-    ├── filtration/         # Guardrails, RBAC, Audit logic
-    └── orchestration/      # Compute Adapters, Scheduling logic
+│   ├── orchestration/      # Compute Control Plane (Port 8080)
+│   ├── data/               # Data Engine (Port 8003)
+│   └── guardrail/          # Guardrail Engine (Port 8002)
 ```
 
 ---

--- a/package/src/inferia/services/api_gateway/README.md
+++ b/package/src/inferia/services/api_gateway/README.md
@@ -1,6 +1,6 @@
-# Filtration Service
+# API Gateway Service
 
-The **Filtration Service** (`services/filtration`) contains the core business logic for security, authentication, and policy enforcement in InferiaLLM. It is designed as a modular library that the `apps/filtration-gateway` application wraps.
+The **API Gateway Service** (`services/api_gateway`) contains the core business logic for security, authentication, and policy enforcement in InferiaLLM. It is designed as a modular library that the API Gateway application wraps.
 
 ## Architecture
 
@@ -10,7 +10,7 @@ The service is composed of several independent components that work together to 
 graph TD
     Request --> Gateway
     
-    subgraph "Filtration Service Logic"
+    subgraph "API Gateway Service Logic"
         Gateway[Gateway Logic/Router]
         
         %% Core Security
@@ -67,9 +67,9 @@ The service uses a centralized `config.py` in each module, typically loading fro
 
 ## Development
 
-To run tests for the filtration logic:
+To run tests for the API Gateway logic:
 
 ```bash
 # from root
-pytest services/filtration/tests/
+pytest package/src/inferia/services/api_gateway/tests/
 ```

--- a/package/src/inferia/services/api_gateway/audit/README.md
+++ b/package/src/inferia/services/api_gateway/audit/README.md
@@ -21,9 +21,9 @@ graph LR
 
 ## Integration
 
-- **Filtration Gateway**: Logs failed authentication, blocked requests (Guardrails).
+- **API Gateway**: Logs failed authentication, blocked requests (Guardrails).
 - **Inference Gateway**: Logs prompt/completion tokens, latency, and model usage.
-  - Sends logs to Filtration via `/internal/logs/create`.
+  - Sends logs to API Gateway via `/internal/logs/create`.
 
 ## Data Storage
 

--- a/package/src/inferia/services/api_gateway/gateway/README.md
+++ b/package/src/inferia/services/api_gateway/gateway/README.md
@@ -1,6 +1,6 @@
 # Gateway Component
 
-The Gateway module is the routing engine of the Filtration service. It manages request lifecycle, routing to internal services (like Guardrails), and implementing cross-cutting concerns like rate limiting.
+The Gateway module is the routing engine of the API Gateway service. It manages request lifecycle, routing to internal services (like Guardrails), and implementing cross-cutting concerns like rate limiting.
 
 ## Architecture
 

--- a/package/src/inferia/services/api_gateway/rbac/README.md
+++ b/package/src/inferia/services/api_gateway/rbac/README.md
@@ -1,6 +1,6 @@
 # RBAC Component (Role-Based Access Control)
 
-The RBAC component handles Authentication (AuthN) and Authorization (AuthZ) for the Filtration Gateway.
+The RBAC component handles Authentication (AuthN) and Authorization (AuthZ) for the API Gateway.
 
 ## Architecture
 

--- a/package/src/inferia/services/orchestration/README.md
+++ b/package/src/inferia/services/orchestration/README.md
@@ -38,7 +38,7 @@ graph TD
 
 ## Core Components
 
-### 1. Adapter Engine (`app/services/adapter_engine`)
+### 1. Adapter Engine (`services/adapter_engine`)
 
 This is the infrastructure abstraction layer. It defines a strict contract (`ProviderAdapter`) that all providers must implement.
 
@@ -48,7 +48,7 @@ This is the infrastructure abstraction layer. It defines a strict contract (`Pro
   - `provision_node()`: Deploys a new compute instance with base image.
   - `deprovision_node()`: Terminates an instance.
 
-### 2. Compute Pool Engine (`app/services/compute_pool_engine`)
+### 2. Compute Pool Engine (`services/compute_pool_engine`)
 
 Manages logical groupings of nodes called **Compute Pools**.
 
@@ -56,7 +56,7 @@ Manages logical groupings of nodes called **Compute Pools**.
 - **Scaling**: Handles auto-scaling logic (coming soon) and manual scaling events.
 - **State Management**: Tracks the `provisioning`, `ready`, and `terminated` states of nodes.
 
-### 3. Model Deployment Engine (`app/services/model_deployment`)
+### 3. Model Deployment Engine (`services/model_deployment`)
 
 Manages the application layer (the LLMs running on the nodes).
 
@@ -64,7 +64,7 @@ Manages the application layer (the LLMs running on the nodes).
 - **Worker**: A background worker (`worker_main.py`) processes deployment tasks asynchronously to avoid blocking API requests.
 - **Containerization**: Uses standardized container images (vLLM, Ollama) to ensure consistent runtime environments.
 
-### 4. Inventory Manager (`app/services/inventory_manager`)
+### 4. Inventory Manager (`services/inventory_manager`)
 
 The source of truth for all active resources.
 
@@ -72,21 +72,21 @@ The source of truth for all active resources.
 - **Health Checks**: Marks nodes as `unhealthy` if heartbeats are missed.
 - **Routing**: Provides the routing table for the **Inference Gateway** to find active model endpoints.
 
-## Nosana Integration (Deep Dive)
+## DePIN Integration (Deep Dive)
 
-The Nosana integration requires a specialized **Sidecar** because it interacts with the Solana blockchain and IPFS, which is handled more robustly in the Node.js ecosystem (`@nosana/sdk`).
+The DePIN integration requires a specialized **Sidecar** because it interacts with the Solana blockchain and IPFS, which is handled more robustly in the Node.js ecosystem (`@nosana/sdk`).
 
 ### Flow
 
 1. **Orchestrator** calls `NosanaAdapter.provision_node()`.
 2. **NosanaAdapter** formats a Job Definition (JSON) describing the container (vLLM).
-3. **NosanaAdapter** sends a request to the **Nosana Sidecar** (`localhost:3000/jobs/launch`).
+3.** sends a request **NosanaAdapter to the **DePIN Sidecar** (`localhost:3000/jobs/launch`).
 4. **Sidecar** uploads definition to IPFS and posts a transaction to Solana.
 5. **Sidecar** watches the job on-chain for events (Posted -> Claimed -> Running).
 6. **Sidecar** sends heartbeats to **Orchestrator** with the job's exposed IP/URL.
 7. **Sidecar** handles auto-extensions (extending job timeout) and auto-redeployment on failure.
 
-**Sidecar Location**: `app/services/nosana-sidecar/`
+**Sidecar Location**: `services/depin-sidecar/`
 
 ## Adapters
 
@@ -100,9 +100,9 @@ Supported providers:
 
 ### Adding a New Provider
 
-1. Create `app/services/adapter_engine/adapters/<provider_name>/`.
+1. Create `services/adapter_engine/adapters/<provider_name>/`.
 2. Implement `ProviderAdapter` class.
-3. Register in `app/services/adapter_engine/registry.py`.
+3. Register in `services/adapter_engine/registry.py`.
 
 ## Data Model
 


### PR DESCRIPTION
- Rename Filtration Gateway to API Gateway throughout documentation
- Fix path references from app/services to services
- Update nosana-sidecar to depin-sidecar
- Fix CLI commands from 'filtration' to 'api'
- Update test paths in documentation