### PR TITLE
fix: tighten internal endpoint auth — prefix match + fail closed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
             package/src/inferia/services/api_gateway/tests/test_config_security.py \
             package/src/inferia/services/api_gateway/tests/test_rate_limit_bypass.py \
             package/src/inferia/tests/test_cli_init_sql_injection.py \
+            package/src/inferia/services/api_gateway/tests/test_internal_auth_bypass.py \
             -p no:twisted -p no:trio -p no:tornasync \
             --junitxml=junit/test-results.xml \
             --cov=package/src/inferia \

--- a/package/src/inferia/common/middleware.py
+++ b/package/src/inferia/common/middleware.py
@@ -44,6 +44,17 @@ def create_internal_auth_middleware(
                 return response
             
             # 3. Validate internal API key
+            # Explicitly reject if no key is configured — fail closed.
+            if not internal_api_key:
+                logger.error(
+                    f"Internal endpoint {path} accessed but INTERNAL_API_KEY is not configured"
+                )
+                from fastapi.responses import JSONResponse
+                return JSONResponse(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    content={"detail": "Internal API key not configured"},
+                )
+
             # Support both standard header and custom one
             api_key = request.headers.get("X-Internal-API-Key") or request.headers.get(
                 "X-Internal-Key"
@@ -61,7 +72,7 @@ def create_internal_auth_middleware(
                 logger.warning(f"Unauthorized access attempt to {path}: Invalid API Key")
                 from fastapi.responses import JSONResponse
                 return JSONResponse(
-                    status_code=status.HTTP_403_FORBIDDEN, 
+                    status_code=status.HTTP_403_FORBIDDEN,
                     content={"detail": "Invalid internal API key"},
                 )
 

--- a/package/src/inferia/services/api_gateway/gateway/internal_middleware.py
+++ b/package/src/inferia/services/api_gateway/gateway/internal_middleware.py
@@ -9,5 +9,5 @@ from inferia.services.api_gateway.config import settings
 # This middleware only checks routes starting with /internal
 internal_api_key_middleware = create_internal_auth_middleware(
     internal_api_key=settings.internal_api_key,
-    check_path_prefix="/internal"
+    check_path_prefix="/internal/"
 )

--- a/package/src/inferia/services/api_gateway/rbac/middleware.py
+++ b/package/src/inferia/services/api_gateway/rbac/middleware.py
@@ -39,7 +39,7 @@ async def auth_middleware(request: Request, call_next):
     ]
     if (
         request.url.path in public_paths
-        or request.url.path.startswith("/internal")
+        or request.url.path.startswith("/internal/")
         or request.url.path.startswith("/auth/invitations/")
         or request.method == "OPTIONS"
     ):

--- a/package/src/inferia/services/api_gateway/tests/test_internal_auth_bypass.py
+++ b/package/src/inferia/services/api_gateway/tests/test_internal_auth_bypass.py
@@ -1,0 +1,211 @@
+"""
+Tests for internal endpoint auth bypass prevention.
+
+Verifies that:
+1. The /internal prefix match uses trailing slash to avoid matching unintended paths
+2. Internal endpoints are explicitly rejected when INTERNAL_API_KEY is not configured
+3. Valid API key grants access, invalid/missing key blocks access
+"""
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from httpx import AsyncClient, ASGITransport
+import asyncio
+
+from inferia.common.middleware import create_internal_auth_middleware
+
+
+def _make_test_app(internal_api_key, check_path_prefix="/internal/"):
+    """Create a minimal FastAPI app with the internal auth middleware."""
+    app = FastAPI()
+
+    middleware_fn = create_internal_auth_middleware(
+        internal_api_key=internal_api_key,
+        check_path_prefix=check_path_prefix,
+    )
+    app.middleware("http")(middleware_fn)
+
+    @app.get("/internal/secret")
+    async def internal_secret():
+        return {"data": "secret"}
+
+    @app.get("/internalized")
+    async def internalized():
+        return {"data": "not-internal"}
+
+    @app.get("/public")
+    async def public_route():
+        return {"data": "public"}
+
+    return app
+
+
+class TestInternalPrefixMatch:
+    """Verify trailing slash prevents matching unintended paths."""
+
+    def test_internalized_path_not_blocked(self):
+        """Path /internalized must NOT be caught by /internal/ prefix check."""
+        app = _make_test_app(internal_api_key="test-key-32chars-aaaaaaaaaaaaaaaa")
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                # /internalized should NOT require internal API key
+                resp = await client.get("/internalized")
+                assert resp.status_code == 200, (
+                    f"/internalized was blocked by internal middleware: {resp.status_code}"
+                )
+                assert resp.json()["data"] == "not-internal"
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_internal_slash_path_requires_key(self):
+        """Path /internal/secret MUST require the internal API key."""
+        app = _make_test_app(internal_api_key="test-key-32chars-aaaaaaaaaaaaaaaa")
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                # Without key → 401
+                resp = await client.get("/internal/secret")
+                assert resp.status_code == 401
+
+                # With valid key → 200
+                resp = await client.get(
+                    "/internal/secret",
+                    headers={"X-Internal-API-Key": "test-key-32chars-aaaaaaaaaaaaaaaa"},
+                )
+                assert resp.status_code == 200
+                assert resp.json()["data"] == "secret"
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+
+class TestFailClosedWhenKeyNotConfigured:
+    """Verify internal endpoints are blocked when INTERNAL_API_KEY is None/empty."""
+
+    def test_none_key_returns_503(self):
+        """When internal_api_key is None, internal endpoints return 503."""
+        app = _make_test_app(internal_api_key=None)
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/internal/secret",
+                    headers={"X-Internal-API-Key": "anything"},
+                )
+                assert resp.status_code == 503
+                assert "not configured" in resp.json()["detail"]
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_empty_key_returns_503(self):
+        """When internal_api_key is empty string, internal endpoints return 503."""
+        app = _make_test_app(internal_api_key="")
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/internal/secret",
+                    headers={"X-Internal-API-Key": "anything"},
+                )
+                assert resp.status_code == 503
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_non_internal_paths_still_work_when_key_not_configured(self):
+        """Public paths must work even when internal_api_key is None."""
+        app = _make_test_app(internal_api_key=None)
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.get("/public")
+                assert resp.status_code == 200
+                assert resp.json()["data"] == "public"
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+
+class TestInternalKeyValidation:
+    """Verify correct API key validation behavior."""
+
+    def test_missing_key_returns_401(self):
+        """No X-Internal-API-Key header → 401."""
+        app = _make_test_app(internal_api_key="valid-key-32chars-aaaaaaaaaaaaaaaa")
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.get("/internal/secret")
+                assert resp.status_code == 401
+                assert "Missing" in resp.json()["detail"]
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_wrong_key_returns_403(self):
+        """Invalid X-Internal-API-Key header → 403."""
+        app = _make_test_app(internal_api_key="valid-key-32chars-aaaaaaaaaaaaaaaa")
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/internal/secret",
+                    headers={"X-Internal-API-Key": "wrong-key"},
+                )
+                assert resp.status_code == 403
+                assert "Invalid" in resp.json()["detail"]
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_valid_key_returns_200(self):
+        """Correct X-Internal-API-Key header → 200."""
+        app = _make_test_app(internal_api_key="valid-key-32chars-aaaaaaaaaaaaaaaa")
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/internal/secret",
+                    headers={"X-Internal-API-Key": "valid-key-32chars-aaaaaaaaaaaaaaaa"},
+                )
+                assert resp.status_code == 200
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_alternative_header_name_works(self):
+        """X-Internal-Key (alternative) header should also work."""
+        app = _make_test_app(internal_api_key="valid-key-32chars-aaaaaaaaaaaaaaaa")
+
+        async def _run():
+            async with AsyncClient(
+                transport=ASGITransport(app=app, raise_app_exceptions=False),
+                base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/internal/secret",
+                    headers={"X-Internal-Key": "valid-key-32chars-aaaaaaaaaaaaaaaa"},
+                )
+                assert resp.status_code == 200
+
+        asyncio.get_event_loop().run_until_complete(_run())


### PR DESCRIPTION
## Summary
- Changed `startswith("/internal")` to `startswith("/internal/")` in both the auth middleware and internal API key middleware to prevent matching unintended paths like `/internalized`
- Added explicit 503 rejection in `create_internal_auth_middleware` when `INTERNAL_API_KEY` is not configured — previously relied on accidental comparison behavior (`key != None`)
- Non-internal paths remain unaffected when the key is unconfigured

## Test plan
- [x] 9 new tests in `test_internal_auth_bypass.py`:
  - `/internalized` path not blocked by `/internal/` prefix
  - `/internal/secret` requires API key
  - `None` API key → 503 for internal endpoints
  - Empty API key → 503 for internal endpoints
  - Non-internal paths work when key is unconfigured
  - Missing key → 401, wrong key → 403, valid key → 200
  - Alternative `X-Internal-Key` header works
- [x] All 90 tests pass locally
- [x] Test added to CI workflow