### PR TITLE
fix: prevent open redirect via unvalidated returnUrl

### DIFF
--- a/apps/dashboard/src/pages/Login.tsx
+++ b/apps/dashboard/src/pages/Login.tsx
@@ -35,8 +35,11 @@ export default function Login() {
 
       const { data } = await api.post("/auth/login", payload);
       await login(data.access_token);
-      const returnUrl = searchParams.get("returnUrl");
-      navigate(returnUrl || "/dashboard");
+      // Validate returnUrl is a safe relative path (prevents open redirect via //evil.com)
+      const rawReturn = searchParams.get("returnUrl");
+      const returnUrl =
+        rawReturn && /^\/[^/\\]/.test(rawReturn) ? rawReturn : "/dashboard";
+      navigate(returnUrl);
     } catch (error: unknown) {
       console.error(error);
       const axiosError = error as AxiosError<{ detail?: string }>;


### PR DESCRIPTION
## Summary
- Validates `returnUrl` query parameter in `Login.tsx` before passing to `navigate()`
- Rejects protocol-relative URLs (`//evil.com`), backslash tricks (`/\evil.com`), and absolute URLs
- Uses regex `/^\/[^/\\]/` — requires path to start with `/` followed by a non-`/`, non-`\` character
- Invalid values fall back to `/dashboard`

Closes #31

## Test plan
- [ ] Navigate to `/auth/login?returnUrl=/dashboard/settings` — should redirect to `/dashboard/settings` after login
- [ ] Navigate to `/auth/login?returnUrl=//evil.com` — should redirect to `/dashboard` after login
- [ ] Navigate to `/auth/login?returnUrl=/\evil.com` — should redirect to `/dashboard` after login  
- [ ] Navigate to `/auth/login?returnUrl=https://evil.com` — should redirect to `/dashboard` after login
- [ ] Navigate to `/auth/login` (no returnUrl) — should redirect to `/dashboard` after login

> Note: Dashboard has no test framework (vitest/jest) — manual verification required.