### PR TITLE
feat: upstream proxy security hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,7 @@ jobs:
             package/src/inferia/services/orchestration/test/adapter_test/test_sdl_injection.py \
             package/src/inferia/services/orchestration/test/compute_pools_nodes/test_pool_manager.py \
             package/src/inferia/services/api_gateway/tests/test_gateway_error_handling.py \
+            package/src/inferia/services/inference/tests/test_upstream_security.py \
             -p no:twisted -p no:trio -p no:tornasync \
             --junitxml=junit/test-results.xml \
             --cov=package/src/inferia \

--- a/package/src/inferia/services/inference/config.py
+++ b/package/src/inferia/services/inference/config.py
@@ -102,6 +102,20 @@ class Settings(BaseSettings):
         validation_alias="UPSTREAM_SLOT_ACQUIRE_TIMEOUT_SECONDS",
     )
 
+    # Upstream Security
+    upstream_allowed_internal_hosts: str = Field(
+        default="",
+        alias="UPSTREAM_ALLOWED_INTERNAL_HOSTS",
+        validation_alias="UPSTREAM_ALLOWED_INTERNAL_HOSTS",
+        description="Comma-separated hostnames that bypass private-IP SSRF checks",
+    )
+    upstream_max_response_bytes: int = Field(
+        default=52_428_800,
+        alias="UPSTREAM_MAX_RESPONSE_BYTES",
+        validation_alias="UPSTREAM_MAX_RESPONSE_BYTES",
+        description="Maximum upstream response body size (default 50MB)",
+    )
+
     # Context Cache Settings
     # Cache duration for resolved API key contexts (deployment, guardrails, etc.)
     context_cache_ttl: int = Field(

--- a/package/src/inferia/services/inference/core/http_client.py
+++ b/package/src/inferia/services/inference/core/http_client.py
@@ -1,7 +1,11 @@
+import logging
+
 import httpx
 from typing import Optional
 
 from inferia.services.inference.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 class HttpClientManager:
@@ -22,6 +26,11 @@ class HttpClientManager:
                 ),
                 verify=settings.verify_ssl,
             )
+            if not settings.verify_ssl:
+                logger.warning(
+                    "TLS verification disabled for upstream connections. "
+                    "Do not use in production."
+                )
         return cls._client
 
     @classmethod

--- a/package/src/inferia/services/inference/core/service.py
+++ b/package/src/inferia/services/inference/core/service.py
@@ -1,11 +1,13 @@
 from fastapi import HTTPException
 from inferia.services.inference.client import api_gateway_client
+from inferia.services.inference.config import settings
 from typing import Dict, Any, List, AsyncGenerator
 import logging
 import httpx
 from .http_client import http_client
 from .providers import get_adapter
 from .concurrency_limiter import upstream_concurrency_limiter
+from .validators import validate_upstream_url, sanitize_headers, check_response_size
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +226,14 @@ class GatewayService:
         return endpoint + chat_path
 
     @staticmethod
+    def _get_allowed_hosts() -> list[str]:
+        """Parse allowed internal hosts from config."""
+        raw = settings.upstream_allowed_internal_hosts
+        if not raw:
+            return []
+        return [h.strip() for h in raw.split(",") if h.strip()]
+
+    @staticmethod
     async def stream_upstream(
         endpoint_url: str,
         payload: Dict,
@@ -236,6 +246,18 @@ class GatewayService:
         transformed_payload = adapter.transform_request(payload)
         full_url = GatewayService._build_full_url(endpoint_url, chat_path)
 
+        # Validate URL and headers before making upstream request
+        try:
+            full_url = validate_upstream_url(
+                full_url, GatewayService._get_allowed_hosts()
+            )
+            headers = sanitize_headers(headers)
+        except ValueError as e:
+            logger.error(f"Upstream validation failed: {e}")
+            yield b'data: {"error": "Invalid upstream configuration"}\n\n'
+            return
+
+        max_bytes = settings.upstream_max_response_bytes
         client = http_client.get_client()
         try:
             async with upstream_concurrency_limiter.limit(concurrency_key):
@@ -243,8 +265,12 @@ class GatewayService:
                     "POST", full_url, json=transformed_payload, headers=headers
                 ) as response:
                     response.raise_for_status()
-                    # Use aiter_raw() for unbuffered streaming (important for SSE)
+                    total_bytes = 0
                     async for chunk in response.aiter_raw():
+                        total_bytes += len(chunk)
+                        if total_bytes > max_bytes:
+                            yield b'data: {"error": "Upstream response exceeded size limit"}\n\n'
+                            return
                         yield chunk
         except httpx.HTTPStatusError as e:
             logger.error(f"Upstream Error {e.response.status_code}: {e.response.text}")
@@ -270,7 +296,17 @@ class GatewayService:
             chat_path = adapter.get_chat_path()
             full_url = GatewayService._build_full_url(endpoint_url, chat_path)
 
+        # Validate URL and headers before making upstream request
+        try:
+            full_url = validate_upstream_url(
+                full_url, GatewayService._get_allowed_hosts()
+            )
+            headers = sanitize_headers(headers)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
         transformed_payload = adapter.transform_request(payload)
+        max_bytes = settings.upstream_max_response_bytes
 
         client = http_client.get_client()
         try:
@@ -279,10 +315,23 @@ class GatewayService:
                     full_url, json=transformed_payload, headers=headers
                 )
                 resp.raise_for_status()
+
+                # Check response size before parsing
+                content_length = resp.headers.get("content-length")
+                if content_length:
+                    check_response_size(int(content_length), max_bytes)
+                body = resp.content
+                if len(body) > max_bytes:
+                    raise HTTPException(
+                        status_code=502,
+                        detail="Upstream response exceeded size limit",
+                    )
                 raw_response = resp.json()
 
                 # Transform response back to OpenAI format
                 return adapter.transform_response(raw_response)
+        except HTTPException:
+            raise
         except httpx.HTTPStatusError as e:
             logger.error(f"Provider error {e.response.status_code}: {e.response.text}")
             raise HTTPException(

--- a/package/src/inferia/services/inference/core/validators.py
+++ b/package/src/inferia/services/inference/core/validators.py
@@ -1,0 +1,126 @@
+"""Upstream proxy security validators.
+
+Validates URLs, headers, and response sizes before forwarding
+requests to upstream LLM providers.
+"""
+
+import ipaddress
+import logging
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+]
+
+_HOP_BY_HOP_HEADERS = frozenset(
+    h.lower()
+    for h in [
+        "Connection",
+        "Keep-Alive",
+        "Proxy-Authenticate",
+        "Proxy-Authorization",
+        "TE",
+        "Trailers",
+        "Transfer-Encoding",
+        "Upgrade",
+    ]
+)
+
+
+def validate_upstream_url(url: str, allowed_hosts: list[str]) -> str:
+    """Validate an upstream URL for scheme, format, and SSRF.
+
+    Args:
+        url: The full upstream URL to validate.
+        allowed_hosts: Hostnames that bypass private-IP checks.
+
+    Returns:
+        The validated URL string (unchanged).
+
+    Raises:
+        ValueError: If the URL is invalid or targets a blocked host.
+    """
+    if "\r" in url or "\n" in url:
+        raise ValueError("URL contains illegal characters")
+
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"URL scheme '{parsed.scheme}' not allowed")
+
+    if parsed.username or parsed.password:
+        raise ValueError("URL must not contain embedded credentials")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL has no hostname")
+
+    # Check if hostname is a private IP
+    try:
+        addr = ipaddress.ip_address(hostname)
+        is_private = any(addr in net for net in _PRIVATE_NETWORKS)
+        if is_private:
+            if hostname not in allowed_hosts:
+                raise ValueError(f"Upstream host '{hostname}' is not allowed")
+    except ValueError as e:
+        # Not a valid IP address — it's a DNS name.
+        # Re-raise if it's our own "not allowed" error.
+        if "not allowed" in str(e) or "illegal" in str(e):
+            raise
+        # Otherwise it's a hostname, which is fine (no IP check needed).
+
+    return url
+
+
+def sanitize_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Remove headers with CRLF injection attempts.
+
+    Args:
+        headers: Request headers dict.
+
+    Returns:
+        Cleaned headers dict with dangerous entries removed.
+    """
+    cleaned = {}
+    for key, value in headers.items():
+        if "\r" in key or "\n" in key or "\r" in value or "\n" in value:
+            logger.warning("Dropped header with CRLF characters: %s", key)
+            continue
+        cleaned[key] = value
+    return cleaned
+
+
+def strip_hop_by_hop_headers(headers: dict) -> dict:
+    """Remove hop-by-hop headers that must not be forwarded by proxies.
+
+    Args:
+        headers: Response headers dict.
+
+    Returns:
+        Headers dict with hop-by-hop entries removed.
+    """
+    return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP_HEADERS}
+
+
+def check_response_size(content_length: int | None, max_bytes: int) -> None:
+    """Check Content-Length header against the configured limit.
+
+    Args:
+        content_length: Value from Content-Length header, or None.
+        max_bytes: Maximum allowed response size.
+
+    Raises:
+        ValueError: If content_length exceeds max_bytes.
+    """
+    if content_length is not None and content_length > max_bytes:
+        raise ValueError(
+            f"Response size {content_length} exceeds limit {max_bytes}"
+        )

--- a/package/src/inferia/services/inference/tests/test_upstream_security.py
+++ b/package/src/inferia/services/inference/tests/test_upstream_security.py
@@ -1,0 +1,304 @@
+"""Tests for upstream proxy security validators and integration."""
+
+import logging
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from contextlib import asynccontextmanager
+
+from fastapi import HTTPException
+
+from inferia.services.inference.core.validators import (
+    validate_upstream_url,
+    sanitize_headers,
+    strip_hop_by_hop_headers,
+    check_response_size,
+)
+
+
+# ---------------------------------------------------------------------------
+# URL Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUpstreamUrl:
+    """Verify upstream URL validation catches injection and SSRF."""
+
+    def test_valid_http_url_passes(self):
+        url = "http://provider.example.com:8080/v1/chat/completions"
+        assert validate_upstream_url(url, []) == url
+
+    def test_valid_https_url_passes(self):
+        url = "https://api.openai.com/v1/chat/completions"
+        assert validate_upstream_url(url, []) == url
+
+    def test_non_http_scheme_rejected(self):
+        for scheme in ("ftp", "file", "gopher", "data"):
+            with pytest.raises(ValueError, match="scheme"):
+                validate_upstream_url(f"{scheme}://evil.com/path", [])
+
+    def test_crlf_in_url_rejected(self):
+        with pytest.raises(ValueError, match="illegal characters"):
+            validate_upstream_url("http://legit.com\r\nHost: evil.com/path", [])
+
+        with pytest.raises(ValueError, match="illegal characters"):
+            validate_upstream_url("http://legit.com\nX-Injected: true", [])
+
+    def test_embedded_credentials_rejected(self):
+        with pytest.raises(ValueError, match="credentials"):
+            validate_upstream_url("http://user:pass@provider.com/v1", [])
+
+    def test_private_ipv4_rejected(self):
+        private_ips = [
+            "http://127.0.0.1:8080/v1",
+            "http://10.0.0.5:8080/v1",
+            "http://172.16.0.1:8080/v1",
+            "http://192.168.1.1:8080/v1",
+            "http://169.254.169.254/latest/meta-data",
+        ]
+        for url in private_ips:
+            with pytest.raises(ValueError, match="not allowed"):
+                validate_upstream_url(url, [])
+
+    def test_private_ipv6_rejected(self):
+        with pytest.raises(ValueError, match="not allowed"):
+            validate_upstream_url("http://[::1]:8080/v1", [])
+
+    def test_allowlisted_private_ip_passes(self):
+        url = "http://10.0.1.50:8080/v1/chat/completions"
+        result = validate_upstream_url(url, ["10.0.1.50"])
+        assert result == url
+
+    def test_non_allowlisted_private_ip_still_blocked(self):
+        """Allowlist for one host doesn't open all private IPs."""
+        with pytest.raises(ValueError, match="not allowed"):
+            validate_upstream_url("http://10.0.0.99:8080/v1", ["10.0.1.50"])
+
+
+# ---------------------------------------------------------------------------
+# Header Sanitization
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeHeaders:
+    """Verify CRLF injection in headers is blocked."""
+
+    def test_clean_headers_unchanged(self):
+        headers = {"Content-Type": "application/json", "Authorization": "Bearer xyz"}
+        assert sanitize_headers(headers) == headers
+
+    def test_crlf_in_value_dropped(self):
+        headers = {
+            "Content-Type": "application/json",
+            "X-Evil": "value\r\nInjected: true",
+        }
+        result = sanitize_headers(headers)
+        assert "X-Evil" not in result
+        assert result["Content-Type"] == "application/json"
+
+    def test_crlf_in_key_dropped(self):
+        headers = {"Good-Header": "ok", "Bad\r\nHeader": "value"}
+        result = sanitize_headers(headers)
+        assert "Bad\r\nHeader" not in result
+        assert result["Good-Header"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Hop-by-Hop Header Stripping
+# ---------------------------------------------------------------------------
+
+
+class TestStripHopByHopHeaders:
+    """Verify hop-by-hop headers are removed."""
+
+    def test_hop_by_hop_removed_others_preserved(self):
+        headers = {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+            "Keep-Alive": "timeout=5",
+            "Transfer-Encoding": "chunked",
+            "X-Request-Id": "abc123",
+        }
+        result = strip_hop_by_hop_headers(headers)
+        assert "Connection" not in result
+        assert "Keep-Alive" not in result
+        assert "Transfer-Encoding" not in result
+        assert result["Content-Type"] == "application/json"
+        assert result["X-Request-Id"] == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# Response Size Check
+# ---------------------------------------------------------------------------
+
+
+class TestCheckResponseSize:
+    """Verify response size limit enforcement."""
+
+    def test_within_limit_passes(self):
+        check_response_size(1000, 50_000_000)  # No exception
+
+    def test_none_content_length_passes(self):
+        check_response_size(None, 50_000_000)  # No exception
+
+    def test_exceeding_limit_raises(self):
+        with pytest.raises(ValueError, match="exceeds limit"):
+            check_response_size(100_000_000, 50_000_000)
+
+
+# ---------------------------------------------------------------------------
+# TLS Warning
+# ---------------------------------------------------------------------------
+
+
+class TestTLSWarning:
+    """Verify TLS disable warning is logged."""
+
+    def test_tls_disabled_logs_warning(self):
+        from inferia.services.inference.core.http_client import HttpClientManager
+
+        with patch(
+            "inferia.services.inference.core.http_client.settings"
+        ) as mock_settings, patch(
+            "inferia.services.inference.core.http_client.logger"
+        ) as mock_logger:
+            mock_settings.verify_ssl = False
+            mock_settings.upstream_http_timeout_seconds = 60.0
+            mock_settings.upstream_http_connect_timeout_seconds = 10.0
+            mock_settings.upstream_http_max_connections = 500
+            mock_settings.upstream_http_max_keepalive_connections = 100
+
+            # Force new client creation
+            HttpClientManager._client = None
+            HttpClientManager.get_client()
+            HttpClientManager._client = None  # Clean up
+
+            mock_logger.warning.assert_called_once()
+            assert "TLS verification disabled" in mock_logger.warning.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Integration: call_upstream with SSRF
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _noop_limit(key):
+    yield
+
+
+class TestCallUpstreamSecurity:
+    """Verify security checks integrate into call_upstream."""
+
+    @pytest.mark.asyncio
+    async def test_call_upstream_private_ip_raises_400(self):
+        from inferia.services.inference.core.service import GatewayService
+
+        with patch(
+            "inferia.services.inference.core.service.settings"
+        ) as mock_settings, patch(
+            "inferia.services.inference.core.service.upstream_concurrency_limiter"
+        ) as mock_limiter:
+            mock_settings.upstream_allowed_internal_hosts = ""
+            mock_settings.upstream_max_response_bytes = 52_428_800
+            mock_limiter.limit = _noop_limit
+
+            with pytest.raises(HTTPException) as exc:
+                await GatewayService.call_upstream(
+                    endpoint_url="http://127.0.0.1:8080",
+                    payload={"messages": []},
+                    headers={"Content-Type": "application/json"},
+                )
+            assert exc.value.status_code == 400
+            assert "not allowed" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_call_upstream_with_path_param_also_validates(self):
+        """The path= parameter branch also gets URL validation."""
+        from inferia.services.inference.core.service import GatewayService
+
+        with patch(
+            "inferia.services.inference.core.service.settings"
+        ) as mock_settings, patch(
+            "inferia.services.inference.core.service.upstream_concurrency_limiter"
+        ) as mock_limiter:
+            mock_settings.upstream_allowed_internal_hosts = ""
+            mock_settings.upstream_max_response_bytes = 52_428_800
+            mock_limiter.limit = _noop_limit
+
+            with pytest.raises(HTTPException) as exc:
+                await GatewayService.call_upstream(
+                    endpoint_url="http://10.0.0.1:8080",
+                    payload={"messages": []},
+                    headers={"Content-Type": "application/json"},
+                    path="/v1/embeddings",
+                )
+            assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_stream_upstream_private_ip_yields_error(self):
+        """stream_upstream yields SSE error for blocked hosts."""
+        from inferia.services.inference.core.service import GatewayService
+
+        with patch(
+            "inferia.services.inference.core.service.settings"
+        ) as mock_settings:
+            mock_settings.upstream_allowed_internal_hosts = ""
+            mock_settings.upstream_max_response_bytes = 52_428_800
+
+            chunks = []
+            async for chunk in GatewayService.stream_upstream(
+                endpoint_url="http://192.168.1.1:8080",
+                payload={"messages": []},
+                headers={"Content-Type": "application/json"},
+            ):
+                chunks.append(chunk)
+
+            assert len(chunks) == 1
+            assert b"Invalid upstream configuration" in chunks[0]
+
+    @pytest.mark.asyncio
+    async def test_stream_upstream_oversized_response_aborted(self):
+        """Streaming aborts when byte counter exceeds limit."""
+        from inferia.services.inference.core.service import GatewayService
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+        # Simulate chunks that exceed a small limit
+        mock_response.aiter_raw = MagicMock(
+            return_value=self._async_iter([b"x" * 500, b"x" * 500, b"x" * 500])
+        )
+
+        @asynccontextmanager
+        async def mock_stream(*args, **kwargs):
+            yield mock_response
+
+        mock_client = MagicMock()
+        mock_client.stream = mock_stream
+
+        with patch(
+            "inferia.services.inference.core.service.settings"
+        ) as mock_settings, patch(
+            "inferia.services.inference.core.service.http_client"
+        ) as mock_hc, patch(
+            "inferia.services.inference.core.service.upstream_concurrency_limiter"
+        ) as mock_limiter:
+            mock_settings.upstream_allowed_internal_hosts = ""
+            mock_settings.upstream_max_response_bytes = 1000  # Small limit
+            mock_hc.get_client.return_value = mock_client
+            mock_limiter.limit = _noop_limit
+
+            chunks = []
+            async for chunk in GatewayService.stream_upstream(
+                endpoint_url="https://api.example.com",
+                payload={"messages": []},
+                headers={"Content-Type": "application/json"},
+            ):
+                chunks.append(chunk)
+
+            # Should have first two data chunks (1000 bytes) then error
+            assert any(b"exceeded size limit" in c for c in chunks)
+
+    @staticmethod
+    async def _async_iter(items):
+        for item in items:
+            yield item


### PR DESCRIPTION
## Summary

- **URL validation**: Reject non-http schemes, CRLF injection, embedded credentials in upstream URLs
- **SSRF protection**: Block private IP ranges (127.x, 10.x, 172.16.x, 192.168.x, 169.254.x, ::1) with configurable allowlist via `UPSTREAM_ALLOWED_INTERNAL_HOSTS`
- **Header sanitization**: Strip headers containing CRLF injection attempts before forwarding to upstream
- **Response size limits**: Configurable max body size (`UPSTREAM_MAX_RESPONSE_BYTES`, default 50MB) enforced in both streaming and non-streaming paths
- **TLS warning**: Log WARNING at startup when `VERIFY_SSL=false`
- **Hop-by-hop stripping**: Utility for future response header forwarding

New config env vars: `UPSTREAM_ALLOWED_INTERNAL_HOSTS`, `UPSTREAM_MAX_RESPONSE_BYTES`

## Test plan

- [x] 21 new tests in `test_upstream_security.py` — all passing
- [x] Existing inference tests pass with no regressions (25 tests)
- [x] Verify deployments using internal IPs add their hosts to `UPSTREAM_ALLOWED_INTERNAL_HOSTS`
- [x] Smoke test streaming + non-streaming inference in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)