### PR TITLE
Fix gRPC context.abort() not stopping execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
             package/src/inferia/services/api_gateway/tests/test_inference_routing.py \
             package/src/inferia/services/inference/tests/test_routing_logic.py \
             package/src/inferia/services/orchestration/test/adapter_test/test_adapter_error_handling.py \
+            package/src/inferia/services/orchestration/test/test_grpc_abort_return.py \
             -p no:twisted -p no:trio -p no:tornasync \
             --junitxml=junit/test-results.xml \
             --cov=package/src/inferia \

--- a/package/src/inferia/services/orchestration/services/compute_node/service.py
+++ b/package/src/inferia/services/orchestration/services/compute_node/service.py
@@ -20,6 +20,7 @@ class ComputeNodeService(
         node = await self.inventory.get(node_id)
         if not node:
             context.abort(5, "Node not found")
+            return
 
         now = utcnow_naive()
 

--- a/package/src/inferia/services/orchestration/services/inventory_manager/service.py
+++ b/package/src/inferia/services/orchestration/services/inventory_manager/service.py
@@ -56,6 +56,7 @@ class InventoryManagerService(
         node = await self.repo.get(node_id)
         if not node:
             context.abort(5, "Node not found")
+            return
 
         # ---------- STATE TRANSITION ----------
         if node["state"] == "provisioning":

--- a/package/src/inferia/services/orchestration/services/model_registry/service.py
+++ b/package/src/inferia/services/orchestration/services/model_registry/service.py
@@ -19,6 +19,7 @@ class ModelRegistryService(
                 code=3,  # INVALID_ARGUMENT
                 details=f"Unsupported backend: {request.backend}",
             )
+            return
 
         config = (
             json.loads(request.config_json)
@@ -47,6 +48,7 @@ class ModelRegistryService(
                 code=5,  # NOT_FOUND
                 details="Model not found",
             )
+            return
 
         return model_registry_pb2.GetModelResponse(
             model_id=str(model["model_id"]),

--- a/package/src/inferia/services/orchestration/test/test_grpc_abort_return.py
+++ b/package/src/inferia/services/orchestration/test/test_grpc_abort_return.py
@@ -1,0 +1,129 @@
+"""Tests for gRPC context.abort() execution-stop bug (issue #34).
+
+In gRPC-aio, context.abort() does NOT raise an exception — the handler
+must return explicitly. These tests use a non-raising mock to verify
+that execution stops after abort (no invalid DB writes, no crashes).
+"""
+
+import json
+import pytest
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock
+
+
+def make_non_raising_context():
+    """Mock gRPC context where abort() does NOT raise (real gRPC-aio behavior)."""
+    ctx = MagicMock()
+    ctx.abort = MagicMock()  # does not raise, just records the call
+    return ctx
+
+
+# ── ModelRegistryService ──────────────────────────────────────────
+
+
+from inferia.services.orchestration.services.model_registry.service import (
+    ModelRegistryService,
+)
+
+
+class TestModelRegistryAbortReturn:
+    @pytest.mark.asyncio
+    async def test_register_model_invalid_backend_does_not_write_db(self):
+        """After aborting for invalid backend, repo.register_model must NOT be called."""
+        repo = AsyncMock()
+        svc = ModelRegistryService(repo)
+
+        request = MagicMock()
+        request.backend = "INVALID_BACKEND"
+        request.name = "test"
+        request.version = "v1"
+        request.config_json = ""
+        request.artifact_uri = "s3://bucket/model"
+
+        ctx = make_non_raising_context()
+        await svc.RegisterModel(request, ctx)
+
+        ctx.abort.assert_called_once()
+        repo.register_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_model_not_found_does_not_crash(self):
+        """After aborting for model not found, must not access None dict keys."""
+        repo = AsyncMock()
+        repo.get_model = AsyncMock(return_value=None)
+        svc = ModelRegistryService(repo)
+
+        request = MagicMock()
+        request.name = "nonexistent"
+        request.version = "v1"
+
+        ctx = make_non_raising_context()
+        # Should NOT raise TypeError from None["model_id"]
+        await svc.GetModel(request, ctx)
+
+        ctx.abort.assert_called_once()
+
+
+# ── ComputeNodeService ────────────────────────────────────────────
+
+
+from inferia.services.orchestration.services.compute_node.service import (
+    ComputeNodeService,
+)
+
+
+class TestComputeNodeAbortReturn:
+    @pytest.mark.asyncio
+    async def test_heartbeat_node_not_found_does_not_crash(self):
+        """After aborting for node not found, must not access None['state']."""
+        inventory_repo = AsyncMock()
+        inventory_repo.get = AsyncMock(return_value=None)
+        svc = ComputeNodeService(inventory_repo)
+
+        request = MagicMock()
+        request.node_id = str(uuid4())
+        request.used = {}
+
+        ctx = make_non_raising_context()
+        # Should NOT raise TypeError from None["state"]
+        await svc.Heartbeat(request, ctx)
+
+        ctx.abort.assert_called_once()
+        inventory_repo.mark_ready.assert_not_called()
+        inventory_repo.update_heartbeat.assert_not_called()
+        inventory_repo.update_usage.assert_not_called()
+
+
+# ── InventoryManagerService ───────────────────────────────────────
+
+
+from inferia.services.orchestration.services.inventory_manager.service import (
+    InventoryManagerService,
+)
+
+
+class TestInventoryManagerAbortReturn:
+    @pytest.mark.asyncio
+    async def test_heartbeat_node_not_found_does_not_crash(self):
+        """After aborting for node not found, must not access None['state']."""
+        repo = AsyncMock()
+        repo.get = AsyncMock(return_value=None)
+        event_bus = AsyncMock()
+        svc = InventoryManagerService(repo, event_bus)
+
+        request = MagicMock()
+        request.node_id = str(uuid4())
+        request.gpu_allocated = 0
+        request.vcpu_allocated = 0
+        request.ram_gb_allocated = 0
+        request.health_score = 100
+
+        ctx = make_non_raising_context()
+        # Should NOT raise TypeError from None["state"]
+        await svc.InvenHeartbeat(request, ctx)
+
+        ctx.abort.assert_called_once()
+        repo.mark_ready.assert_not_called()
+        repo.update_heartbeat.assert_not_called()
+        repo.update_usage.assert_not_called()
+        event_bus.publish.assert_not_called()


### PR DESCRIPTION
## Summary
- In gRPC-aio, `context.abort()` does **not** raise an exception — the handler must `return` explicitly
- Without a `return`, execution falls through causing invalid data written to DB and `TypeError` crashes on `None` access
- Added `return` after `context.abort()` in 4 locations across 3 service files:
  - `ModelRegistryService.RegisterModel` — invalid backend was written to DB
  - `ModelRegistryService.GetModel` — `TypeError` on `None["model_id"]`
  - `ComputeNodeService.Heartbeat` — `TypeError` on `None["state"]`
  - `InventoryManagerService.InvenHeartbeat` — `TypeError` on `None["state"]`

## Test plan
- [x] Added `test_grpc_abort_return.py` with 4 unit tests using non-raising mock (matches real gRPC-aio behavior)
- [x] All 4 new tests verified RED before fix, GREEN after fix
- [x] Existing `test_pool_manager.py` tests still pass (9/9 total)
- [x] Tests pass inside Docker container (`inferia-test` image)
- [x] New test file added to CI workflow

Closes #34