### PR TITLE
Fix SpotReclaimer deleting all spot allocations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,7 @@ jobs:
             package/src/inferia/services/inference/tests/test_routing_logic.py \
             package/src/inferia/services/orchestration/test/adapter_test/test_adapter_error_handling.py \
             package/src/inferia/services/orchestration/test/test_grpc_abort_return.py \
+            package/src/inferia/services/orchestration/test/spot/test_spot_reclaimer_filter.py \
             -p no:twisted -p no:trio -p no:tornasync \
             --junitxml=junit/test-results.xml \
             --cov=package/src/inferia \

--- a/package/src/inferia/services/orchestration/infra/spot_reclaimer.py
+++ b/package/src/inferia/services/orchestration/infra/spot_reclaimer.py
@@ -18,6 +18,7 @@ class SpotReclaimer:
                     FROM allocations a
                     JOIN compute_inventory n ON a.node_id = n.id
                     WHERE n.node_class = 'spot'
+                      AND n.state = 'terminated'
                     FOR UPDATE
                     """
                 )

--- a/package/src/inferia/services/orchestration/test/spot/test_spot_reclaimer_filter.py
+++ b/package/src/inferia/services/orchestration/test/spot/test_spot_reclaimer_filter.py
@@ -1,0 +1,91 @@
+"""Tests for SpotReclaimer node-state filtering (issue #29).
+
+The reclaimer must only delete allocations on spot nodes that have
+actually been reclaimed (state='terminated'), not all spot allocations.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from inferia.services.orchestration.infra.spot_reclaimer import SpotReclaimer
+
+
+def make_mock_db():
+    """Create a mock DB pool with acquire/transaction context managers."""
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock()
+
+    # conn.transaction() returns an async context manager
+    tx = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=tx)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+
+    # db.acquire() returns an async context manager yielding conn
+    acq = AsyncMock()
+    acq.__aenter__ = AsyncMock(return_value=conn)
+    acq.__aexit__ = AsyncMock(return_value=False)
+
+    db = MagicMock()
+    db.acquire = MagicMock(return_value=acq)
+
+    return db, conn
+
+
+class TestSpotReclaimerFilter:
+
+    @pytest.mark.asyncio
+    async def test_reclaim_query_filters_by_terminated_state(self):
+        """The SQL query must include a WHERE clause filtering for terminated nodes."""
+        db, conn = make_mock_db()
+        conn.fetch = AsyncMock(return_value=[])
+
+        reclaimer = SpotReclaimer(db)
+        await reclaimer.reclaim()
+
+        conn.fetch.assert_called_once()
+        sql = conn.fetch.call_args[0][0]
+
+        # The query must filter for terminated state, not select ALL spot nodes
+        assert "state" in sql.lower(), \
+            "Query must filter by node state to avoid reclaiming healthy spot allocations"
+
+    @pytest.mark.asyncio
+    async def test_reclaim_only_processes_terminated_spot_victims(self):
+        """Only allocations on terminated spot nodes should be deleted."""
+        db, conn = make_mock_db()
+
+        # Simulate: DB returns one victim from a terminated spot node
+        victim = {
+            "allocation_id": "alloc-1",
+            "node_id": "node-1",
+            "gpu": 1,
+            "vcpu": 4,
+            "ram_gb": 8,
+            "owner_type": "user",
+            "owner_id": "user-1",
+        }
+        conn.fetch = AsyncMock(return_value=[victim])
+
+        reclaimer = SpotReclaimer(db)
+        await reclaimer.reclaim()
+
+        # Should have executed: resource release, billing event, and delete
+        assert conn.execute.call_count == 3
+
+        # Verify the DELETE was for the correct allocation
+        delete_call = conn.execute.call_args_list[2]
+        assert "DELETE FROM allocations" in delete_call[0][0]
+        assert delete_call[0][1] == "alloc-1"
+
+    @pytest.mark.asyncio
+    async def test_reclaim_no_victims_means_no_writes(self):
+        """If no terminated spot nodes exist, no DB writes should happen."""
+        db, conn = make_mock_db()
+        conn.fetch = AsyncMock(return_value=[])
+
+        reclaimer = SpotReclaimer(db)
+        await reclaimer.reclaim()
+
+        conn.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- SpotReclaimer SQL query had no node state filter — every 300s it deleted **all** allocations on **all** spot nodes, not just terminated ones
- Added `AND n.state = 'terminated'` so only allocations on nodes actually reclaimed by the cloud provider are cleaned up
- Single line change in `spot_reclaimer.py`

## Test plan
- [x] Added `test_spot_reclaimer_filter.py` with 3 unit tests verifying the query filters by state
- [x] Key test verified RED before fix (query lacked `state` filter), GREEN after
- [x] Tests pass locally (3/3) and in Docker container
- [x] New test file added to CI workflow

Closes #29