### PR TITLE
Fix auth bypass via prefix match on /auth/invitations/

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
             package/src/inferia/services/orchestration/test/adapter_test/test_adapter_error_handling.py \
             package/src/inferia/services/orchestration/test/test_grpc_abort_return.py \
             package/src/inferia/services/orchestration/test/spot/test_spot_reclaimer_filter.py \
+            package/src/inferia/services/api_gateway/tests/test_invitation_auth_bypass.py \
             -p no:twisted -p no:trio -p no:tornasync \
             --junitxml=junit/test-results.xml \
             --cov=package/src/inferia \

--- a/package/src/inferia/services/api_gateway/rbac/middleware.py
+++ b/package/src/inferia/services/api_gateway/rbac/middleware.py
@@ -37,10 +37,18 @@ async def auth_middleware(request: Request, call_next):
         "/auth/register-invite",
         "/audit/internal/log",
     ]
+    # Allow /auth/invitations/{token} (exactly one segment after prefix)
+    invitation_prefix = "/auth/invitations/"
+    is_invitation_lookup = (
+        request.url.path.startswith(invitation_prefix)
+        and "/" not in request.url.path[len(invitation_prefix):]
+        and len(request.url.path) > len(invitation_prefix)
+    )
+
     if (
         request.url.path in public_paths
         or request.url.path.startswith("/internal/")
-        or request.url.path.startswith("/auth/invitations/")
+        or is_invitation_lookup
         or request.method == "OPTIONS"
     ):
         return await call_next(request)

--- a/package/src/inferia/services/api_gateway/tests/test_invitation_auth_bypass.py
+++ b/package/src/inferia/services/api_gateway/tests/test_invitation_auth_bypass.py
@@ -1,0 +1,79 @@
+"""Tests for auth middleware invitation path bypass (issue #63).
+
+The middleware must only skip auth for the specific public invitation
+lookup route, not for any arbitrary path under /auth/invitations/.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from inferia.services.api_gateway.rbac.middleware import auth_middleware
+
+
+def make_request(path: str, method: str = "GET") -> MagicMock:
+    """Create a mock Request with the given path."""
+    request = MagicMock()
+    request.url.path = path
+    request.method = method
+    request.headers = {}  # no auth header
+    return request
+
+
+class TestInvitationPathBypass:
+
+    @pytest.mark.asyncio
+    async def test_invite_lookup_is_public(self):
+        """GET /auth/invitations/{token} should bypass auth."""
+        request = make_request("/auth/invitations/abc123token")
+        call_next = AsyncMock(return_value=MagicMock())
+
+        response = await auth_middleware(request, call_next)
+
+        call_next.assert_called_once_with(request)
+
+    @pytest.mark.asyncio
+    async def test_nested_path_under_invitations_requires_auth(self):
+        """Paths like /auth/invitations/{token}/accept must NOT bypass auth."""
+        request = make_request("/auth/invitations/abc123/accept")
+        call_next = AsyncMock(return_value=MagicMock())
+
+        response = await auth_middleware(request, call_next)
+
+        # Should NOT have called through — should return 401 (no auth header)
+        call_next.assert_not_called()
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_deep_nested_path_requires_auth(self):
+        """Paths like /auth/invitations/x/y/z must NOT bypass auth."""
+        request = make_request("/auth/invitations/token/some/deep/path")
+        call_next = AsyncMock(return_value=MagicMock())
+
+        response = await auth_middleware(request, call_next)
+
+        call_next.assert_not_called()
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invitations_list_requires_auth(self):
+        """GET /auth/invitations/ (trailing slash, no token) must NOT bypass auth."""
+        request = make_request("/auth/invitations/")
+        call_next = AsyncMock(return_value=MagicMock())
+
+        response = await auth_middleware(request, call_next)
+
+        # This is a bare prefix with no token — should require auth
+        # (the actual invite lookup needs a token segment)
+        call_next.assert_not_called()
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_known_public_paths_still_work(self):
+        """Existing public paths should continue to bypass auth."""
+        call_next = AsyncMock(return_value=MagicMock())
+
+        for path in ["/auth/login", "/auth/register", "/health", "/auth/refresh"]:
+            request = make_request(path)
+            await auth_middleware(request, call_next)
+
+        assert call_next.call_count == 4


### PR DESCRIPTION
## Summary
- Auth middleware used `startswith("/auth/invitations/")` to skip JWT validation, allowing **any** path under that prefix to bypass authentication
- Replaced with exact pattern matching: only `/auth/invitations/{token}` (single path segment after prefix) bypasses auth
- Nested paths like `/auth/invitations/x/accept` or `/auth/invitations/` (bare prefix) now correctly require authentication

## Test plan
- [x] Added `test_invitation_auth_bypass.py` with 5 tests covering:
  - Valid invite lookup (`/auth/invitations/abc123`) bypasses auth
  - Nested path (`/auth/invitations/abc123/accept`) requires auth
  - Deep nested path (`/auth/invitations/x/y/z`) requires auth
  - Bare prefix (`/auth/invitations/`) requires auth
  - Existing public paths still work
- [x] 3 tests verified RED before fix, GREEN after
- [x] All 26 existing auth tests still pass
- [x] Tests pass in Docker container

Closes #63