### PR TITLE
Fix JS injection via unescaped env vars in entrypoint config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
             package/src/inferia/services/orchestration/test/test_grpc_abort_return.py \
             package/src/inferia/services/orchestration/test/spot/test_spot_reclaimer_filter.py \
             package/src/inferia/services/api_gateway/tests/test_invitation_auth_bypass.py \
+            package/src/inferia/tests/test_entrypoint_config_escaping.py \
             package/src/inferia/services/guardrail/tests/test_scan_error_sanitization.py \
             package/src/inferia/services/data/tests/test_error_sanitization.py \
             package/src/inferia/services/data/tests/test_router_error_sanitization.py \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,14 +6,16 @@ set -e
 # specified at container run time instead of build time.
 DASHBOARD_DIR=$(python -c "import inferia, os; print(os.path.join(inferia.__path__[0], 'dashboard'))" 2>/dev/null || true)
 if [ -d "$DASHBOARD_DIR" ]; then
-  cat > "$DASHBOARD_DIR/config.js" <<EOF
-window.__RUNTIME_CONFIG__ = {
-  API_GATEWAY_URL: "${API_GATEWAY_URL:-}",
-  INFERENCE_URL: "${INFERENCE_URL:-}",
-  WEB_SOCKET_URL: "${WEB_SOCKET_URL:-}",
-  SIDECAR_URL: "${SIDECAR_URL:-}",
-};
-EOF
+  python3 -c "
+import json, os
+config = {
+    'API_GATEWAY_URL': os.environ.get('API_GATEWAY_URL', ''),
+    'INFERENCE_URL': os.environ.get('INFERENCE_URL', ''),
+    'WEB_SOCKET_URL': os.environ.get('WEB_SOCKET_URL', ''),
+    'SIDECAR_URL': os.environ.get('SIDECAR_URL', ''),
+}
+print('window.__RUNTIME_CONFIG__ = ' + json.dumps(config) + ';')
+" > "$DASHBOARD_DIR/config.js"
 fi
 
 # SERVICE_TYPE can be: filtration, inference, orchestration, unified

--- a/package/src/inferia/tests/test_entrypoint_config_escaping.py
+++ b/package/src/inferia/tests/test_entrypoint_config_escaping.py
@@ -1,0 +1,99 @@
+"""Tests for entrypoint.sh config.js generation escaping (issue #59).
+
+Env vars containing quotes, backslashes, or JS-breaking characters
+must be properly escaped when written into config.js.
+
+These tests run the actual entrypoint.sh config generation block
+via subprocess to verify real behavior.
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+import pytest
+
+
+# Path from package/src/inferia/tests/ -> repo root docker/entrypoint.sh
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+ENTRYPOINT_PATH = os.path.join(REPO_ROOT, "docker", "entrypoint.sh")
+
+
+def generate_config_js(env_vars: dict) -> str:
+    """
+    Run the config.js generation section of entrypoint.sh in a subprocess
+    with the given env vars, writing to a temp file.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outpath = os.path.join(tmpdir, "config.js")
+
+        # Read the entrypoint and extract only the config generation block
+        with open(ENTRYPOINT_PATH) as f:
+            content = f.read()
+
+        # Build a script that sets DASHBOARD_DIR to our temp dir and
+        # sources just the config generation part of the entrypoint
+        script = f'''
+set -e
+export DASHBOARD_DIR="{tmpdir}"
+'''
+        # Find and extract the config generation block (between "if [ -d" and "fi")
+        lines = content.split("\n")
+        in_block = False
+        for line in lines:
+            if 'if [ -d "$DASHBOARD_DIR" ]' in line:
+                in_block = True
+                script += line + "\n"
+                continue
+            if in_block:
+                script += line + "\n"
+                if line.strip() == "fi":
+                    break
+
+        env = {**os.environ, **env_vars}
+        result = subprocess.run(
+            ["bash", "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            pytest.fail(f"Script failed: {result.stderr}")
+
+        with open(outpath) as f:
+            return f.read()
+
+
+class TestEntrypointConfigEscaping:
+
+    def test_normal_urls_work(self):
+        """Normal URL values produce valid config."""
+        js = generate_config_js({
+            "API_GATEWAY_URL": "https://api.example.com",
+            "INFERENCE_URL": "https://inference.example.com",
+        })
+        assert "https://api.example.com" in js
+        assert "https://inference.example.com" in js
+
+    def test_double_quotes_in_env_var_escaped(self):
+        """Double quotes in env var must not break the JS string."""
+        js = generate_config_js({
+            "API_GATEWAY_URL": 'https://evil.com", injected: "pwned',
+        })
+        # The output must NOT contain an unescaped injection that creates
+        # a separate JS property
+        assert 'injected: "pwned"' not in js
+
+    def test_backslash_in_env_var_escaped(self):
+        """Backslashes must not produce broken JS."""
+        js = generate_config_js({
+            "API_GATEWAY_URL": "C:\\Users\\test\\path",
+        })
+        assert "window.__RUNTIME_CONFIG__" in js
+
+    def test_empty_values_work(self):
+        """Empty/unset env vars produce valid config."""
+        js = generate_config_js({})
+        assert "window.__RUNTIME_CONFIG__" in js


### PR DESCRIPTION
## Summary
- Docker entrypoint generated `config.js` using shell heredoc with unquoted `${VAR}` interpolation
- Env vars containing double-quotes could inject arbitrary JS properties (e.g., `API_GATEWAY_URL='", evil: "pwned'`)
- Replaced with `python3 json.dumps()` which properly escapes all special characters

## Test plan
- [x] Added `test_entrypoint_config_escaping.py` with 4 tests:
  - Normal URLs produce valid config
  - Double-quote injection attempt is properly escaped (was RED, now GREEN)
  - Backslashes are handled correctly
  - Empty/unset values work
- [x] Test runs the actual entrypoint.sh config block via subprocess
- [x] New test file added to CI workflow

Closes #59