### PR TITLE
Fix audit endpoint falling back to static dev-internal-key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
           pytest \
             package/src/inferia/services/api_gateway/tests/test_rbac.py \
             package/src/inferia/services/api_gateway/tests/test_audit.py \
+            package/src/inferia/services/api_gateway/tests/test_audit_key_security.py \
             package/src/inferia/services/api_gateway/tests/test_gateway.py \
             package/src/inferia/services/api_gateway/tests/test_integration.py \
             package/src/inferia/services/api_gateway/tests/test_management_insights.py \

--- a/package/src/inferia/services/api_gateway/audit/router.py
+++ b/package/src/inferia/services/api_gateway/audit/router.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Depends, Query, HTTPException, status, Security
 from fastapi.security import APIKeyHeader
-import os
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List, Optional
 from datetime import datetime
 
 from inferia.services.api_gateway.db.database import get_db
 from inferia.services.api_gateway.audit.service import audit_service
+from inferia.services.api_gateway.config import settings
 from inferia.services.api_gateway.models import (
     AuditLogResponse,
     AuditLogFilter,
@@ -56,7 +56,12 @@ async def create_internal_log(
     """
     Manually create an audit log (Internal Only).
     """
-    expected_key = os.getenv("INTERNAL_API_KEY", "dev-internal-key")
+    expected_key = settings.internal_api_key
+    if not expected_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Internal API key not configured"
+        )
     if api_key != expected_key:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/package/src/inferia/services/api_gateway/tests/test_audit.py
+++ b/package/src/inferia/services/api_gateway/tests/test_audit.py
@@ -4,7 +4,9 @@ import pytest
 from unittest.mock import patch, AsyncMock
 from datetime import datetime
 import uuid
-import os
+
+
+VALID_INTERNAL_KEY = "a" * 32  # 32-char key that satisfies min_length
 
 
 @pytest.mark.asyncio
@@ -23,11 +25,15 @@ async def test_audit_flow_admin(client, admin_token):
         "status": "success",
     }
 
-    internal_key = os.getenv("INTERNAL_API_KEY", "dev-internal-key")
-
-    with patch(
-        "inferia.services.api_gateway.audit.router.audit_service"
-    ) as mock_service:
+    with (
+        patch(
+            "inferia.services.api_gateway.audit.router.settings"
+        ) as mock_settings,
+        patch(
+            "inferia.services.api_gateway.audit.router.audit_service"
+        ) as mock_service,
+    ):
+        mock_settings.internal_api_key = VALID_INTERNAL_KEY
         mock_service.log_event = AsyncMock(return_value=mock_log)
         mock_service.get_logs = AsyncMock(return_value=[mock_log])
 
@@ -44,7 +50,7 @@ async def test_audit_flow_admin(client, admin_token):
 
         create_response = await client.post(
             "/audit/internal/log",
-            headers={"X-Internal-API-Key": internal_key},
+            headers={"X-Internal-API-Key": VALID_INTERNAL_KEY},
             json=log_data,
         )
         assert create_response.status_code == 200

--- a/package/src/inferia/services/api_gateway/tests/test_audit_key_security.py
+++ b/package/src/inferia/services/api_gateway/tests/test_audit_key_security.py
@@ -1,0 +1,105 @@
+"""Security tests for audit internal endpoint API key handling."""
+
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+from datetime import datetime
+import uuid
+
+
+VALID_INTERNAL_KEY = "a" * 32  # 32-char key that satisfies min_length
+
+LOG_DATA = {
+    "user_id": "test_user_123",
+    "action": "test_action",
+    "resource_type": "model",
+    "resource_id": "gpt-4",
+    "details": {"foo": "bar"},
+    "ip_address": "127.0.0.1",
+    "status": "success",
+}
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_internal_key_not_configured(client):
+    """Endpoint must return 503 when settings.internal_api_key is None."""
+    with patch(
+        "inferia.services.api_gateway.audit.router.settings"
+    ) as mock_settings:
+        mock_settings.internal_api_key = None
+
+        response = await client.post(
+            "/audit/internal/log",
+            headers={"X-Internal-API-Key": "any-key-value-here"},
+            json=LOG_DATA,
+        )
+        assert response.status_code == 503, (
+            f"Expected 503 when internal_api_key is None, got {response.status_code}"
+        )
+        assert "not configured" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_rejects_wrong_key(client):
+    """Endpoint must return 403 when the provided key does not match."""
+    with patch(
+        "inferia.services.api_gateway.audit.router.settings"
+    ) as mock_settings:
+        mock_settings.internal_api_key = VALID_INTERNAL_KEY
+
+        response = await client.post(
+            "/audit/internal/log",
+            headers={"X-Internal-API-Key": "wrong-key"},
+            json=LOG_DATA,
+        )
+        assert response.status_code == 403, (
+            f"Expected 403 for wrong key, got {response.status_code}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_dev_internal_key(client):
+    """The static 'dev-internal-key' must NOT be accepted."""
+    with patch(
+        "inferia.services.api_gateway.audit.router.settings"
+    ) as mock_settings:
+        mock_settings.internal_api_key = VALID_INTERNAL_KEY
+
+        response = await client.post(
+            "/audit/internal/log",
+            headers={"X-Internal-API-Key": "dev-internal-key"},
+            json=LOG_DATA,
+        )
+        assert response.status_code == 403, (
+            f"Expected 403 for dev-internal-key, got {response.status_code}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_accepts_valid_key(client):
+    """Endpoint must accept the correct key and return 200."""
+    mock_id = str(uuid.uuid4())
+    mock_log = {
+        "id": mock_id,
+        "timestamp": datetime.now().isoformat(),
+        **LOG_DATA,
+    }
+
+    with (
+        patch(
+            "inferia.services.api_gateway.audit.router.settings"
+        ) as mock_settings,
+        patch(
+            "inferia.services.api_gateway.audit.router.audit_service"
+        ) as mock_service,
+    ):
+        mock_settings.internal_api_key = VALID_INTERNAL_KEY
+        mock_service.log_event = AsyncMock(return_value=mock_log)
+
+        response = await client.post(
+            "/audit/internal/log",
+            headers={"X-Internal-API-Key": VALID_INTERNAL_KEY},
+            json=LOG_DATA,
+        )
+        assert response.status_code == 200, (
+            f"Expected 200 for valid key, got {response.status_code}"
+        )


### PR DESCRIPTION
## Summary
- `/audit/internal/log` used `os.getenv("INTERNAL_API_KEY", "dev-internal-key")` which falls back to a publicly known static key
- Combined with being in `public_paths` (skips JWT), this created an unauthenticated write path to audit logs
- Replaced with `settings.internal_api_key` which defaults to `None` (reject with 503) instead of a known static key
- Removed unused `import os`

## Test plan
- [x] Added `test_audit_key_security.py` with 4 tests: unconfigured key (503), wrong key (403), static "dev-internal-key" rejected (403), valid key accepted
- [x] Fixed existing `test_audit.py` to use patched settings instead of the broken `os.getenv` pattern
- [x] New test file added to CI workflow

Closes #45