### PR TITLE
Fix ChromaDB collection scoping bypass when org_id is null

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
             package/src/inferia/services/orchestration/test/test_traffic_router.py \
             package/src/inferia/services/orchestration/test/adapter_test/test_command_injection.py \
             package/src/inferia/services/orchestration/test/model_deployment/test_start_deployment_controller.py \
+            package/src/inferia/services/data/tests/test_collection_scoping.py \
             package/src/inferia/services/data/tests/test_prompt_templates.py \
             package/src/inferia/services/api_gateway/tests/test_config_security.py \
             package/src/inferia/services/api_gateway/tests/test_rate_limit_bypass.py \

--- a/package/src/inferia/services/data/app.py
+++ b/package/src/inferia/services/data/app.py
@@ -78,7 +78,7 @@ app.middleware("http")(internal_auth_middleware)
 class RetrieveRequest(BaseModel):
     collection_name: str
     query: str
-    org_id: Optional[str] = None
+    org_id: str = "default"
     n_results: int = 3
 
 
@@ -87,7 +87,7 @@ class IngestRequest(BaseModel):
     documents: List[str]
     metadatas: List[Dict[str, Any]]
     ids: List[str]
-    org_id: Optional[str] = None
+    org_id: str = "default"
 
 
 from inferia.common.schemas.prompt import PromptProcessRequest

--- a/package/src/inferia/services/data/engine.py
+++ b/package/src/inferia/services/data/engine.py
@@ -71,9 +71,9 @@ class DataEngine:
             self.client = None
 
     def _get_scoped_name(self, collection_name: str, org_id: Optional[str]) -> str:
-        """Scope collection name by Org ID. If no org_id, assumes global/admin or legacy."""
+        """Scope collection name by Org ID."""
         if not org_id:
-            return collection_name  # Default or Legacy
+            raise ValueError("org_id is required for collection scoping")
         return f"org_{org_id}_{collection_name}"
 
     def _get_unscoped_name(self, scoped_name: str) -> str:

--- a/package/src/inferia/services/data/tests/test_collection_scoping.py
+++ b/package/src/inferia/services/data/tests/test_collection_scoping.py
@@ -1,0 +1,44 @@
+"""Tests for ChromaDB collection scoping by org_id.
+
+Ensures _get_scoped_name enforces tenant isolation by requiring a valid org_id
+and never falling back to an unscoped collection name.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from inferia.services.data.engine import DataEngine
+
+
+@pytest.fixture
+def engine():
+    """Create a DataEngine instance with a mocked ChromaDB client."""
+    eng = DataEngine()
+    eng.client = MagicMock()
+    return eng
+
+
+class TestGetScopedName:
+    """Tests for DataEngine._get_scoped_name tenant isolation."""
+
+    def test_raises_valueerror_when_org_id_is_none(self, engine):
+        """org_id=None must raise ValueError, not fall back to unscoped name."""
+        with pytest.raises(ValueError, match="org_id is required"):
+            engine._get_scoped_name("my_collection", org_id=None)
+
+    def test_raises_valueerror_when_org_id_is_empty_string(self, engine):
+        """org_id='' must raise ValueError, not fall back to unscoped name."""
+        with pytest.raises(ValueError, match="org_id is required"):
+            engine._get_scoped_name("my_collection", org_id="")
+
+    def test_valid_org_id_returns_scoped_name(self, engine):
+        """A valid org_id must produce a scoped collection name."""
+        result = engine._get_scoped_name("my_collection", org_id="abc123")
+        assert result == "org_abc123_my_collection"
+
+    def test_scoped_name_format(self, engine):
+        """Verify the exact format: org_{org_id}_{collection_name}."""
+        org_id = "tenant-42"
+        collection = "documents"
+        result = engine._get_scoped_name(collection, org_id=org_id)
+        assert result == f"org_{org_id}_{collection}"

--- a/package/src/inferia/services/data/tests/test_engine_error_handling.py
+++ b/package/src/inferia/services/data/tests/test_engine_error_handling.py
@@ -38,5 +38,6 @@ class TestDataEngineErrors:
             documents=["doc"],
             metadatas=[{}],
             ids=["id1"],
+            org_id="default",
         )
         assert result is False


### PR DESCRIPTION
## Summary
- `_get_scoped_name` in `data/engine.py` fell back to unscoped collection name when `org_id` was None/empty, allowing cross-tenant data access
- Now raises `ValueError` for empty `org_id` instead of silently removing tenant isolation
- Changed `RetrieveRequest` and `IngestRequest` models to use `org_id: str = "default"` instead of `Optional[str] = None`

## Test plan
- [x] Added `test_collection_scoping.py` with 4 tests: ValueError on None, ValueError on empty string, valid org_id works, correct format verified
- [x] Tests confirmed RED before fix (no ValueError raised), GREEN after
- [x] Updated existing `test_engine_error_handling.py` to pass `org_id="default"` for compatibility
- [x] New test file added to CI workflow

Closes #61