### PR TITLE
Fix rate limiter reading user_id from header instead of JWT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
             package/src/inferia/services/data/tests/test_prompt_templates.py \
             package/src/inferia/services/api_gateway/tests/test_config_security.py \
             package/src/inferia/services/api_gateway/tests/test_rate_limit_bypass.py \
+            package/src/inferia/services/api_gateway/tests/test_rate_limiter_user_source.py \
             package/src/inferia/tests/test_cli_init_sql_injection.py \
             package/src/inferia/services/api_gateway/tests/test_internal_auth_bypass.py \
             package/src/inferia/services/orchestration/test/test_grpc_auth_interceptor.py \

--- a/package/src/inferia/services/api_gateway/gateway/rate_limiter.py
+++ b/package/src/inferia/services/api_gateway/gateway/rate_limiter.py
@@ -173,8 +173,9 @@ class RateLimiter:
         if not settings.rate_limit_enabled:
             return
 
-        # Use user_id as key if available, otherwise use IP address
-        user_id = getattr(request.state, "user_id", None)
+        # Use user_id from authenticated JWT context, not from headers
+        user = getattr(request.state, "user", None)
+        user_id = user.user_id if user else None
         if user_id:
             key = f"user:{user_id}"
         else:

--- a/package/src/inferia/services/api_gateway/tests/test_rate_limiter_user_source.py
+++ b/package/src/inferia/services/api_gateway/tests/test_rate_limiter_user_source.py
@@ -1,0 +1,122 @@
+"""
+Tests for rate limiter user identification source.
+
+Verifies that the gateway rate limiter reads user_id from the authenticated
+JWT context (request.state.user.user_id) rather than the client-controlled
+request.state.user_id header value.
+
+Closes #41
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def make_rate_limiter():
+    """Create a RateLimiter instance with mocked limiter backend."""
+    with patch("inferia.services.api_gateway.gateway.rate_limiter.settings") as mock_settings:
+        mock_settings.rate_limit_enabled = True
+        mock_settings.rate_limit_requests_per_minute = 100
+        mock_settings.rate_limit_burst_size = 50
+        mock_settings.use_redis_rate_limit = False
+
+        from inferia.services.api_gateway.gateway.rate_limiter import RateLimiter
+
+        rl = RateLimiter()
+        rl.limiter = MagicMock()
+        rl.limiter.is_allowed = AsyncMock(
+            return_value=(True, {"limit": 100, "remaining": 99, "reset": 0})
+        )
+        yield rl
+
+
+def _make_request(user=None, user_id=None, client_host="192.168.1.1"):
+    """Build a mock Request with optional user context and user_id header value."""
+    request = MagicMock()
+    request.client = MagicMock()
+    request.client.host = client_host
+
+    state = MagicMock(spec=[])
+    if user is not None:
+        state.user = user
+    if user_id is not None:
+        state.user_id = user_id
+
+    # Make getattr work correctly on the mock state
+    original_attrs = {}
+    if user is not None:
+        original_attrs["user"] = user
+    if user_id is not None:
+        original_attrs["user_id"] = user_id
+
+    def side_effect(attr, default=None):
+        return original_attrs.get(attr, default)
+
+    # We need getattr to work on request.state, so we use a real object
+    class FakeState:
+        pass
+
+    fake_state = FakeState()
+    if user is not None:
+        fake_state.user = user
+    if user_id is not None:
+        fake_state.user_id = user_id
+
+    request.state = fake_state
+    return request
+
+
+class TestRateLimiterUsesAuthenticatedUser:
+    """Verify rate limiter derives user_id from JWT-authenticated context."""
+
+    @pytest.mark.asyncio
+    async def test_uses_user_from_jwt_context(self, make_rate_limiter):
+        """Rate limiter must use request.state.user.user_id (JWT) as the key."""
+        rl = make_rate_limiter
+
+        user_ctx = MagicMock()
+        user_ctx.user_id = "jwt-authenticated-user-42"
+
+        request = _make_request(user=user_ctx)
+        await rl.check_rate_limit(request)
+
+        rl.limiter.is_allowed.assert_awaited_once()
+        key_used = rl.limiter.is_allowed.call_args[0][0]
+        assert key_used == "user:jwt-authenticated-user-42", (
+            f"Expected key 'user:jwt-authenticated-user-42', got '{key_used}'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_spoofed_user_id_header_ignored_when_no_user(self, make_rate_limiter):
+        """
+        When request.state.user is not set, a spoofed request.state.user_id
+        must be ignored and IP-based limiting must be used instead.
+        """
+        rl = make_rate_limiter
+
+        # Attacker sets user_id on request.state (from X-User-ID header)
+        # but has no authenticated user context
+        request = _make_request(user=None, user_id="spoofed-admin-id", client_host="10.0.0.99")
+        await rl.check_rate_limit(request)
+
+        rl.limiter.is_allowed.assert_awaited_once()
+        key_used = rl.limiter.is_allowed.call_args[0][0]
+        assert key_used == "ip:10.0.0.99", (
+            f"Expected IP-based key 'ip:10.0.0.99', got '{key_used}'. "
+            "Rate limiter is reading user_id from header instead of JWT!"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ip_based_limiting_when_no_user_authenticated(self, make_rate_limiter):
+        """When no user is authenticated at all, IP-based limiting must be used."""
+        rl = make_rate_limiter
+
+        request = _make_request(user=None, user_id=None, client_host="203.0.113.50")
+        await rl.check_rate_limit(request)
+
+        rl.limiter.is_allowed.assert_awaited_once()
+        key_used = rl.limiter.is_allowed.call_args[0][0]
+        assert key_used == "ip:203.0.113.50", (
+            f"Expected IP-based key 'ip:203.0.113.50', got '{key_used}'"
+        )


### PR DESCRIPTION
## Summary
- Rate limiter used `request.state.user_id` (from client-controlled `X-User-ID` header) instead of `request.state.user.user_id` (from authenticated JWT)
- Attackers could rate-limit victims by spoofing their user_id in the header
- Now reads from the authenticated `UserContext` object set by auth middleware

## Test plan
- [x] 3 tests: JWT user_id used when authenticated, spoofed header ignored, IP fallback when unauthenticated
- [x] Tests verified RED before fix, GREEN after

Closes #41