### PR TITLE
Validate 2FA QR code is data URI before rendering

### DIFF
--- a/apps/dashboard/src/pages/Auth/Setup2FA.tsx
+++ b/apps/dashboard/src/pages/Auth/Setup2FA.tsx
@@ -170,7 +170,11 @@ export default function Setup2FA() {
                 <div className="space-y-5">
                   <div className="flex flex-col items-center gap-4 rounded-2xl border border-border/70 bg-muted/20 p-5">
                     <div className="rounded-xl border border-border/60 bg-white p-4 shadow-sm">
-                      <img src={setupData.qr_code} alt="2FA QR Code" className="h-48 w-48" />
+                      {setupData.qr_code.startsWith("data:image/") ? (
+                        <img src={setupData.qr_code} alt="2FA QR Code" className="h-48 w-48" />
+                      ) : (
+                        <p className="text-sm text-destructive">Invalid QR code data</p>
+                      )}
                     </div>
                     <div className="w-full space-y-1 text-center">
                       <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Secret Key</p>

--- a/apps/dashboard/src/pages/Settings/Security.tsx
+++ b/apps/dashboard/src/pages/Settings/Security.tsx
@@ -178,7 +178,11 @@ export default function Security() {
             {setupData && (
               <div className="flex flex-col items-center gap-4 py-2">
                 <div className="bg-white p-2 rounded-lg border">
-                  <img src={setupData.qr_code} alt="2FA QR Code" className="w-48 h-48" />
+                  {setupData.qr_code.startsWith("data:image/") ? (
+                    <img src={setupData.qr_code} alt="2FA QR Code" className="w-48 h-48" />
+                  ) : (
+                    <p className="text-sm text-destructive">Invalid QR code data</p>
+                  )}
                 </div>
                 <div className="text-xs text-muted-foreground text-center">
                   <p className="mb-1">Cannot scan the QR code?</p>


### PR DESCRIPTION
## Summary
- Both 2FA setup pages rendered `<img src={setupData.qr_code}>` without validating the value is a `data:image/` URI
- Could allow external URL injection in the img src attribute
- Added runtime check in both `Setup2FA.tsx` and `Security.tsx`

## Test plan
- [x] Minimal rendering guard — shows "Invalid QR code data" error if value doesn't start with `data:image/`
- [x] No existing frontend tests; change is a simple conditional render

Closes #58