### PR TITLE
Add PermissionGuard to settings/security route

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -193,7 +193,8 @@ const router = createBrowserRouter([
           },
           {
             path: "settings/security",
-            element: <Security />,
+            element: <PermissionGuard permission="user:update_security" />,
+            children: [{ index: true, element: <Security /> }],
           },
           {
             path: "compute",


### PR DESCRIPTION
## Summary
- `settings/security` was the only dashboard route within `RequireAuth` missing a `PermissionGuard`
- Any authenticated user could access it regardless of permissions
- Added `<PermissionGuard permission="user:update_security" />` matching the pattern of all sibling routes

## Test plan
- [x] TSX route config change — verified correct JSX structure
- [x] No existing frontend tests in the project

Closes #42