### PR TITLE
Add expected_type parameter to JWT decode_token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
             package/src/inferia/common/tests/test_exception_handlers.py \
             package/src/inferia/common/tests/test_http_client.py \
             package/src/inferia/services/api_gateway/tests/test_auth_security.py \
+            package/src/inferia/services/api_gateway/tests/test_jwt_token_type.py \
             package/src/inferia/services/api_gateway/tests/test_encryption.py \
             package/src/inferia/services/api_gateway/tests/test_db_security.py \
             package/src/inferia/services/guardrail/tests/test_engine_error_handling.py \

--- a/package/src/inferia/services/api_gateway/rbac/auth.py
+++ b/package/src/inferia/services/api_gateway/rbac/auth.py
@@ -76,7 +76,7 @@ class AuthService:
         encoded_jwt = jwt.encode(payload, self.secret_key, algorithm=self.algorithm)
         return encoded_jwt
     
-    def decode_token(self, token: str) -> TokenPayload:
+    def decode_token(self, token: str, expected_type: Optional[str] = None) -> TokenPayload:
         """Decode and validate JWT token."""
         try:
             payload = jwt.decode(token, self.secret_key, algorithms=[self.algorithm])
@@ -88,11 +88,17 @@ class AuthService:
                 roles=payload.get("roles", []),
                 org_id=payload.get("org_id"),
             )
+            if expected_type and token_payload.type != expected_type:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=f"Invalid token type: expected {expected_type}",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
             return token_payload
         except JWTError as e:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=f"Invalid token: {str(e)}",
+                detail="Invalid token",
                 headers={"WWW-Authenticate": "Bearer"},
             )
     
@@ -226,13 +232,7 @@ class AuthService:
         Security: role and org access are resolved from live DB membership,
         not trusted directly from JWT role claims.
         """
-        token_payload = self.decode_token(token)
-        
-        if token_payload.type != "access":
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token type",
-            )
+        token_payload = self.decode_token(token, expected_type="access")
         
         result = await db.execute(select(DBUser).where(DBUser.id == token_payload.sub))
         user = result.scalars().first()
@@ -277,9 +277,7 @@ class AuthService:
     async def refresh_access_token(self, refresh_token: str, db: AsyncSession) -> AuthToken:
         """Refresh access token using refresh token."""
         try:
-            payload = self.decode_token(refresh_token)
-            if payload.type != "refresh":
-                 raise HTTPException(status_code=401, detail="Invalid token type")
+            payload = self.decode_token(refresh_token, expected_type="refresh")
             
             user_id = payload.sub
             org_id = getattr(payload, "org_id", None)

--- a/package/src/inferia/services/api_gateway/tests/test_jwt_token_type.py
+++ b/package/src/inferia/services/api_gateway/tests/test_jwt_token_type.py
@@ -1,0 +1,75 @@
+"""Tests for decode_token expected_type enforcement (issue #52)."""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+from jose import jwt
+from fastapi import HTTPException
+
+from inferia.services.api_gateway.rbac.auth import AuthService
+from inferia.services.api_gateway.db.models import User as DBUser
+
+
+@pytest.fixture
+def auth():
+    """AuthService with deterministic config."""
+    svc = AuthService.__new__(AuthService)
+    svc.secret_key = "test-secret-key-for-unit-tests-only"
+    svc.algorithm = "HS256"
+    svc.access_token_expire_minutes = 30
+    svc.refresh_token_expire_days = 7
+    return svc
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock(spec=DBUser)
+    user.id = "user-001"
+    user.email = "test@inferia.com"
+    user.default_org_id = "org-001"
+    return user
+
+
+class TestDecodeTokenExpectedType:
+    """decode_token should enforce token type when expected_type is provided."""
+
+    def test_rejects_refresh_token_when_access_expected(self, auth, mock_user):
+        """A refresh token must be rejected when expected_type='access'."""
+        refresh_token = auth.create_refresh_token(mock_user, org_id="org-001")
+        with pytest.raises(HTTPException) as exc_info:
+            auth.decode_token(refresh_token, expected_type="access")
+        assert exc_info.value.status_code == 401
+        assert "expected access" in exc_info.value.detail.lower()
+
+    def test_rejects_access_token_when_refresh_expected(self, auth, mock_user):
+        """An access token must be rejected when expected_type='refresh'."""
+        access_token = auth.create_access_token(mock_user, org_id="org-001", role="member")
+        with pytest.raises(HTTPException) as exc_info:
+            auth.decode_token(access_token, expected_type="refresh")
+        assert exc_info.value.status_code == 401
+        assert "expected refresh" in exc_info.value.detail.lower()
+
+    def test_accepts_any_type_without_expected_type(self, auth, mock_user):
+        """Without expected_type, decode_token accepts both access and refresh tokens."""
+        access_token = auth.create_access_token(mock_user, org_id="org-001", role="admin")
+        refresh_token = auth.create_refresh_token(mock_user, org_id="org-001")
+
+        access_payload = auth.decode_token(access_token)
+        assert access_payload.type == "access"
+
+        refresh_payload = auth.decode_token(refresh_token)
+        assert refresh_payload.type == "refresh"
+
+    def test_accepts_matching_expected_type_access(self, auth, mock_user):
+        """Access token passes when expected_type='access'."""
+        access_token = auth.create_access_token(mock_user, org_id="org-001", role="admin")
+        payload = auth.decode_token(access_token, expected_type="access")
+        assert payload.type == "access"
+        assert payload.sub == "user-001"
+
+    def test_accepts_matching_expected_type_refresh(self, auth, mock_user):
+        """Refresh token passes when expected_type='refresh'."""
+        refresh_token = auth.create_refresh_token(mock_user, org_id="org-001")
+        payload = auth.decode_token(refresh_token, expected_type="refresh")
+        assert payload.type == "refresh"
+        assert payload.sub == "user-001"


### PR DESCRIPTION
## Summary
- `decode_token` accepted any token type — callers had to manually check after decoding
- Added optional `expected_type` parameter for defense-in-depth type enforcement inside the function
- Updated `get_current_user` and `refresh_access_token` to use the new parameter
- Also sanitized the JWT error detail to avoid exposing internal error info

## Test plan
- [x] 5 tests: refresh rejected as access, access rejected as refresh, backward compat without type, matching types accepted
- [x] All 11 existing auth security tests still pass

Closes #52