### PR TITLE
Remove [SYSTEM:] warning injection from guardrail prompt text

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
             package/src/inferia/services/api_gateway/tests/test_invitation_auth_bypass.py \
             package/src/inferia/tests/test_entrypoint_config_escaping.py \
             package/src/inferia/services/guardrail/tests/test_scan_error_sanitization.py \
+            package/src/inferia/services/guardrail/tests/test_proceed_on_violation.py \
             package/src/inferia/services/data/tests/test_error_sanitization.py \
             package/src/inferia/services/data/tests/test_router_error_sanitization.py \
             package/src/inferia/services/data/tests/test_filename_sanitization.py \

--- a/package/src/inferia/services/guardrail/engine.py
+++ b/package/src/inferia/services/guardrail/engine.py
@@ -139,15 +139,8 @@ class GuardrailEngine:
                     f"Guardrail violation detected but 'proceed_on_violation' is active. User: {user_id}"
                 )
 
-                violations_desc = ", ".join(
-                    [f"{v.violation_type} ({v.score:.2f})" for v in result.violations]
-                )
-                warning_suffix = f"\n\n[SYSTEM: Guardrail Violation Detected: {violations_desc}. User Configured to Proceed.]"
-
                 result.is_valid = True
-                current_text = result.sanitized_text or text
-                result.sanitized_text = current_text + warning_suffix
-                result.actions_taken.append("proceed_on_violation_warning")
+                result.actions_taken.append("proceed_on_violation")
 
             return result
 

--- a/package/src/inferia/services/guardrail/tests/test_engine_orchestration.py
+++ b/package/src/inferia/services/guardrail/tests/test_engine_orchestration.py
@@ -102,4 +102,4 @@ class TestGuardrailEngineOrchestration:
             )
             # Despite violation, is_valid is overridden to True
             assert result.is_valid is True
-            assert "proceed_on_violation_warning" in result.actions_taken
+            assert "proceed_on_violation" in result.actions_taken

--- a/package/src/inferia/services/guardrail/tests/test_proceed_on_violation.py
+++ b/package/src/inferia/services/guardrail/tests/test_proceed_on_violation.py
@@ -1,0 +1,172 @@
+"""Tests for proceed_on_violation — verify no prompt injection into sanitized text."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from inferia.services.guardrail.models import GuardrailResult, Violation, ViolationType
+
+
+class TestProceedOnViolationNoInjection:
+    """Verify proceed_on_violation does not inject [SYSTEM:] text into the prompt."""
+
+    @pytest.mark.asyncio
+    async def test_sanitized_text_has_no_system_tag(self):
+        """When proceed_on_violation=True, sanitized_text must not contain [SYSTEM:."""
+        mock_provider = AsyncMock()
+        mock_provider.name = "mock-guard"
+        mock_provider.scan_input.return_value = GuardrailResult(
+            is_valid=False,
+            sanitized_text="user input here",
+            violations=[
+                Violation(
+                    scanner="test",
+                    violation_type=ViolationType.TOXICITY,
+                    score=0.95,
+                    details="toxic content detected",
+                )
+            ],
+        )
+
+        with patch(
+            "inferia.services.guardrail.engine.LLMGuardProvider",
+            side_effect=Exception("skip"),
+        ), patch(
+            "inferia.services.guardrail.engine.LlamaGuardProvider",
+            side_effect=Exception("skip"),
+        ), patch(
+            "inferia.services.guardrail.engine.LakeraProvider",
+            side_effect=Exception("skip"),
+        ):
+            from inferia.services.guardrail.engine import GuardrailEngine
+
+            engine = GuardrailEngine()
+            engine.providers["mock-guard"] = mock_provider
+            engine.settings.default_guardrail_engine = "mock-guard"
+
+            result = await engine.scan_input(
+                "user input here", config={"proceed_on_violation": True}
+            )
+
+            assert "[SYSTEM:" not in (result.sanitized_text or "")
+
+    @pytest.mark.asyncio
+    async def test_is_valid_set_to_true(self):
+        """When proceed_on_violation=True, result.is_valid must be True."""
+        mock_provider = AsyncMock()
+        mock_provider.name = "mock-guard"
+        mock_provider.scan_input.return_value = GuardrailResult(
+            is_valid=False,
+            sanitized_text="test prompt",
+            violations=[
+                Violation(
+                    scanner="test",
+                    violation_type=ViolationType.PROMPT_INJECTION,
+                    score=0.85,
+                    details="injection attempt",
+                )
+            ],
+        )
+
+        with patch(
+            "inferia.services.guardrail.engine.LLMGuardProvider",
+            side_effect=Exception("skip"),
+        ), patch(
+            "inferia.services.guardrail.engine.LlamaGuardProvider",
+            side_effect=Exception("skip"),
+        ), patch(
+            "inferia.services.guardrail.engine.LakeraProvider",
+            side_effect=Exception("skip"),
+        ):
+            from inferia.services.guardrail.engine import GuardrailEngine
+
+            engine = GuardrailEngine()
+            engine.providers["mock-guard"] = mock_provider
+            engine.settings.default_guardrail_engine = "mock-guard"
+
+            result = await engine.scan_input(
+                "test prompt", config={"proceed_on_violation": True}
+            )
+
+            assert result.is_valid is True
+
+    @pytest.mark.asyncio
+    async def test_proceed_on_violation_in_actions_taken(self):
+        """When proceed_on_violation=True, 'proceed_on_violation' must be in actions_taken."""
+        mock_provider = AsyncMock()
+        mock_provider.name = "mock-guard"
+        mock_provider.scan_input.return_value = GuardrailResult(
+            is_valid=False,
+            sanitized_text="test prompt",
+            violations=[
+                Violation(
+                    scanner="test",
+                    violation_type=ViolationType.TOXICITY,
+                    score=0.9,
+                    details="toxic",
+                )
+            ],
+        )
+
+        with patch(
+            "inferia.services.guardrail.engine.LLMGuardProvider",
+            side_effect=Exception("skip"),
+        ), patch(
+            "inferia.services.guardrail.engine.LlamaGuardProvider",
+            side_effect=Exception("skip"),
+        ), patch(
+            "inferia.services.guardrail.engine.LakeraProvider",
+            side_effect=Exception("skip"),
+        ):
+            from inferia.services.guardrail.engine import GuardrailEngine
+
+            engine = GuardrailEngine()
+            engine.providers["mock-guard"] = mock_provider
+            engine.settings.default_guardrail_engine = "mock-guard"
+
+            result = await engine.scan_input(
+                "test prompt", config={"proceed_on_violation": True}
+            )
+
+            assert "proceed_on_violation" in result.actions_taken
+
+    @pytest.mark.asyncio
+    async def test_violations_still_recorded(self):
+        """When proceed_on_violation=True, violations must still be in result.violations."""
+        mock_provider = AsyncMock()
+        mock_provider.name = "mock-guard"
+        mock_provider.scan_input.return_value = GuardrailResult(
+            is_valid=False,
+            sanitized_text="test prompt",
+            violations=[
+                Violation(
+                    scanner="test",
+                    violation_type=ViolationType.TOXICITY,
+                    score=0.9,
+                    details="toxic content",
+                )
+            ],
+        )
+
+        with patch(
+            "inferia.services.guardrail.engine.LLMGuardProvider",
+            side_effect=Exception("skip"),
+        ), patch(
+            "inferia.services.guardrail.engine.LlamaGuardProvider",
+            side_effect=Exception("skip"),
+        ), patch(
+            "inferia.services.guardrail.engine.LakeraProvider",
+            side_effect=Exception("skip"),
+        ):
+            from inferia.services.guardrail.engine import GuardrailEngine
+
+            engine = GuardrailEngine()
+            engine.providers["mock-guard"] = mock_provider
+            engine.settings.default_guardrail_engine = "mock-guard"
+
+            result = await engine.scan_input(
+                "test prompt", config={"proceed_on_violation": True}
+            )
+
+            assert len(result.violations) == 1
+            assert result.violations[0].violation_type == ViolationType.TOXICITY
+            assert result.violations[0].score == 0.9


### PR DESCRIPTION
## Summary
- When `proceed_on_violation=True`, the engine appended `[SYSTEM: Guardrail Violation Detected: ...]` directly into the sanitized text that becomes the LLM prompt
- An LLM could interpret this as a system directive — self-inflicted prompt injection
- Violations now flagged only in metadata (`actions_taken`) — the sanitized text stays clean

## Test plan
- [x] 4 new tests: no `[SYSTEM:` in text, `is_valid=True`, action recorded, violations preserved
- [x] Updated existing `test_engine_orchestration.py` for renamed action
- [x] All 25 guardrail tests pass

Closes #66