### PR TITLE
Replace print() with logger.error() for usage tracking failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,7 @@ jobs:
             package/src/inferia/services/api_gateway/tests/test_inference_routing.py \
             package/src/inferia/services/inference/tests/test_routing_logic.py \
             package/src/inferia/services/inference/tests/test_rate_limiter_workers.py \
+            package/src/inferia/services/inference/tests/test_usage_tracking_logging.py \
             package/src/inferia/services/orchestration/test/adapter_test/test_adapter_error_handling.py \
             package/src/inferia/services/orchestration/test/test_grpc_abort_return.py \
             package/src/inferia/services/orchestration/test/spot/test_spot_reclaimer_filter.py \

--- a/package/src/inferia/services/inference/client.py
+++ b/package/src/inferia/services/inference/client.py
@@ -128,7 +128,7 @@ class ApiGatewayClient:
                 headers=self._get_headers(),
             )
         except Exception as e:
-            print(f"Failed to track usage: {e}")
+            logger.error(f"Failed to track usage: {e}")
 
     async def log_inference(
         self,

--- a/package/src/inferia/services/inference/tests/test_usage_tracking_logging.py
+++ b/package/src/inferia/services/inference/tests/test_usage_tracking_logging.py
@@ -1,0 +1,61 @@
+"""Tests that usage-tracking errors are routed through the logger, not print()."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+@pytest.fixture
+def mock_settings():
+    """Provide minimal settings so ApiGatewayClient can be instantiated."""
+    with patch("inferia.services.inference.client.settings") as s:
+        s.api_gateway_url = "http://localhost:8000"
+        s.api_gateway_internal_key = "test-key"
+        s.request_timeout = 5
+        s.context_cache_maxsize = 10
+        s.context_cache_ttl = 30
+        s.quota_check_cache_ttl_seconds = 1.0
+        s.quota_check_cache_maxsize = 100
+        yield s
+
+
+@pytest.fixture
+def gateway_client(mock_settings):
+    from inferia.services.inference.client import ApiGatewayClient
+
+    return ApiGatewayClient()
+
+
+@pytest.mark.asyncio
+async def test_track_usage_logs_error_on_failure(gateway_client):
+    """track_usage must call logger.error (not print) when the HTTP call fails."""
+    fake_client = AsyncMock()
+    fake_client.post = AsyncMock(side_effect=RuntimeError("connection refused"))
+    fake_client.is_closed = False
+    gateway_client._client = fake_client
+
+    with patch("inferia.services.inference.client.logger") as mock_logger:
+        await gateway_client.track_usage(
+            user_id="user-1",
+            model="gpt-4",
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+        )
+        mock_logger.error.assert_called_once()
+        args = mock_logger.error.call_args[0][0]
+        assert "Failed to track usage" in args
+
+
+@pytest.mark.asyncio
+async def test_track_usage_does_not_print_on_failure(gateway_client):
+    """track_usage must NOT use print() for error reporting."""
+    fake_client = AsyncMock()
+    fake_client.post = AsyncMock(side_effect=RuntimeError("connection refused"))
+    fake_client.is_closed = False
+    gateway_client._client = fake_client
+
+    with patch("builtins.print") as mock_print:
+        await gateway_client.track_usage(
+            user_id="user-1",
+            model="gpt-4",
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+        )
+        mock_print.assert_not_called()


### PR DESCRIPTION
## Summary
- Usage tracking error handler used bare `print()`, bypassing JSON structured logging
- Replaced with `logger.error()` so errors appear in Logstash with request IDs

## Test plan
- [x] 2 tests: logger.error called on failure, print not called
- [x] All 60 inference tests pass

Closes #69