### PR TITLE
Remove duplicate is_development property in orchestration config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
             package/src/inferia/services/orchestration/test/adapter_test/test_adapter_error_handling.py \
             package/src/inferia/services/orchestration/test/test_grpc_abort_return.py \
             package/src/inferia/services/orchestration/test/spot/test_spot_reclaimer_filter.py \
+            package/src/inferia/services/orchestration/test/test_config_properties.py \
             package/src/inferia/services/api_gateway/tests/test_invitation_auth_bypass.py \
             package/src/inferia/tests/test_entrypoint_config_escaping.py \
             package/src/inferia/services/guardrail/tests/test_scan_error_sanitization.py \

--- a/package/src/inferia/services/orchestration/config.py
+++ b/package/src/inferia/services/orchestration/config.py
@@ -169,11 +169,6 @@ class Settings(BaseSettings):
         """Check if running in production environment."""
         return getattr(self, "environment", "development") == "production"
 
-    @property
-    def is_development(self) -> bool:
-        """Check if running in development environment."""
-        return getattr(self, "environment", "development") == "development"
-
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
     )

--- a/package/src/inferia/services/orchestration/test/test_config_properties.py
+++ b/package/src/inferia/services/orchestration/test/test_config_properties.py
@@ -1,0 +1,43 @@
+"""Tests for orchestration service config properties."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from inferia.services.orchestration.config import Settings
+
+# Resolve the config source file relative to this test file
+_CONFIG_FILE = Path(__file__).resolve().parent.parent / "config.py"
+
+
+def _make_settings(**overrides):
+    """Create Settings isolated from any .env file or environment variables."""
+    env = {
+        "ENVIRONMENT": overrides.get("environment", "development"),
+    }
+    with patch.dict(os.environ, env, clear=False):
+        return Settings(
+            _env_file=None,
+            **overrides,
+        )
+
+
+def test_is_development_returns_true_for_development_env():
+    """is_development should return True when environment is 'development'."""
+    s = _make_settings(environment="development")
+    assert s.is_development is True
+
+
+def test_is_development_returns_false_for_production_env():
+    """is_development should return False when environment is 'production'."""
+    s = _make_settings(environment="production")
+    assert s.is_development is False
+
+
+def test_is_development_defined_once():
+    """is_development property must be defined exactly once in Settings source."""
+    source = _CONFIG_FILE.read_text()
+    count = source.count("def is_development")
+    assert count == 1, (
+        f"Expected is_development to be defined once, but found {count} definitions"
+    )


### PR DESCRIPTION
## Summary
- `is_development` was defined twice in `Settings` class (lines 118 and 173)
- Python silently uses the last definition, dropping the first
- Removed the duplicate; kept the first definition

## Test plan
- [x] 3 tests: returns True/False correctly, defined exactly once in source
- [x] Added to CI workflow

Closes #68