### PR TITLE
Log errors in SkyPilot terminate instead of silently swallowing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,7 @@ jobs:
             package/src/inferia/services/data/tests/test_filename_sanitization.py \
             package/src/inferia/services/api_gateway/tests/test_totp_setup_security.py \
             package/src/inferia/services/api_gateway/tests/test_rate_limiter_bucket_race.py \
+            package/src/inferia/services/orchestration/test/test_skypilot_terminate.py \
             -p no:twisted -p no:trio -p no:tornasync \
             --junitxml=junit/test-results.xml \
             --cov=package/src/inferia \

--- a/package/src/inferia/services/orchestration/provisioning/skypilot.py
+++ b/package/src/inferia/services/orchestration/provisioning/skypilot.py
@@ -64,6 +64,6 @@ class SkyPilotProvisioner(Provisioner):
             import sky
             logger.info("Terminating SkyPilot cluster", extra={"cluster": cluster_id})
             sky.down(cluster_name=cluster_id)
-        except Exception:
+        except Exception as e:
             # best-effort termination
-            pass
+            logger.error(f"Failed to terminate SkyPilot cluster {cluster_id}: {e}", extra={"cluster": cluster_id})

--- a/package/src/inferia/services/orchestration/test/test_skypilot_terminate.py
+++ b/package/src/inferia/services/orchestration/test/test_skypilot_terminate.py
@@ -1,0 +1,56 @@
+"""Tests for SkyPilotProvisioner.terminate() error logging."""
+
+import logging
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture()
+def _container_env(monkeypatch):
+    """Pretend we are inside a container so the module-level guard passes."""
+    monkeypatch.setenv("INFERIA_ENV", "container")
+
+
+@pytest.fixture()
+def _fake_sky(monkeypatch):
+    """Inject a fake ``sky`` module so the real package is not required."""
+    fake = MagicMock()
+    monkeypatch.setitem(__import__("sys").modules, "sky", fake)
+    return fake
+
+
+@pytest.mark.usefixtures("_container_env", "_fake_sky")
+class TestTerminateLogging:
+    """SkyPilotProvisioner.terminate() must log errors instead of swallowing them."""
+
+    @pytest.mark.asyncio
+    async def test_terminate_logs_error_on_failure(self, _fake_sky, caplog):
+        _fake_sky.down.side_effect = RuntimeError("cloud API timeout")
+
+        # Import after env is set so the module-level guard passes.
+        from inferia.services.orchestration.provisioning.skypilot import (
+            SkyPilotProvisioner,
+        )
+
+        provisioner = SkyPilotProvisioner()
+
+        with caplog.at_level(logging.ERROR):
+            await provisioner.terminate("test-cluster-001")
+
+        assert any(
+            "Failed to terminate SkyPilot cluster test-cluster-001" in r.message
+            for r in caplog.records
+        ), "Expected an ERROR log about the failed termination"
+
+    @pytest.mark.asyncio
+    async def test_terminate_does_not_reraise(self, _fake_sky):
+        _fake_sky.down.side_effect = RuntimeError("cloud API timeout")
+
+        from inferia.services.orchestration.provisioning.skypilot import (
+            SkyPilotProvisioner,
+        )
+
+        provisioner = SkyPilotProvisioner()
+
+        # Must not raise — termination is best-effort.
+        await provisioner.terminate("test-cluster-002")


### PR DESCRIPTION
## Summary
- `terminate()` had bare `except Exception: pass` — failed terminations were invisible, orphaning cloud instances
- Now logs at ERROR level with cluster ID while keeping best-effort (no re-raise)

## Test plan
- [x] 2 tests: error logged on failure, exception not re-raised
- [x] Added to CI

Closes #64