### PR TITLE
Replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
             package/src/inferia/services/api_gateway/tests/test_invitation_auth_bypass.py \
             package/src/inferia/tests/test_entrypoint_config_escaping.py \
             package/src/inferia/services/guardrail/tests/test_scan_error_sanitization.py \
+            package/src/inferia/services/guardrail/tests/test_asyncio_loop_usage.py \
             package/src/inferia/services/data/tests/test_error_sanitization.py \
             package/src/inferia/services/data/tests/test_router_error_sanitization.py \
             package/src/inferia/services/data/tests/test_filename_sanitization.py \

--- a/package/src/inferia/services/guardrail/pii_service.py
+++ b/package/src/inferia/services/guardrail/pii_service.py
@@ -80,7 +80,7 @@ class PIIService:
             ]
 
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             # scan_prompt signature: (scanners: list, prompt: str) -> (sanitized_prompt, results_valid, results_score)
             sanitized_text, results_valid, results_score = await loop.run_in_executor(
                 None, scan_prompt, [scanner], text

--- a/package/src/inferia/services/guardrail/providers/llama_guard_provider.py
+++ b/package/src/inferia/services/guardrail/providers/llama_guard_provider.py
@@ -96,7 +96,7 @@ class LlamaGuardProvider(GuardrailProvider):
         messages = [{"role": "user", "content": text}]
 
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             chat_completion = await loop.run_in_executor(
                 None,
                 lambda: self.groq_client.chat.completions.create(
@@ -164,7 +164,7 @@ class LlamaGuardProvider(GuardrailProvider):
         ]
 
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             chat_completion = await loop.run_in_executor(
                 None,
                 lambda: self.groq_client.chat.completions.create(

--- a/package/src/inferia/services/guardrail/tests/test_asyncio_loop_usage.py
+++ b/package/src/inferia/services/guardrail/tests/test_asyncio_loop_usage.py
@@ -1,0 +1,59 @@
+"""
+Verify that guardrail modules use asyncio.get_running_loop() instead of the
+deprecated asyncio.get_event_loop(), which raises RuntimeError on Python 3.12+
+when no running loop exists.
+
+Closes #49
+"""
+
+import ast
+import pathlib
+
+# Resolve paths relative to this test file so the correct worktree source is
+# read regardless of which copy of the package is installed.
+_GUARDRAIL_DIR = pathlib.Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _contains_get_event_loop(source: str) -> list[int]:
+    """Return line numbers where ``asyncio.get_event_loop()`` is called."""
+    hits: list[int] = []
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match: asyncio.get_event_loop()
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "get_event_loop"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "asyncio"
+        ):
+            hits.append(node.lineno)
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestNoDeprecatedGetEventLoop:
+    """Ensure no source file uses asyncio.get_event_loop()."""
+
+    def test_pii_service_uses_get_running_loop(self):
+        source = (_GUARDRAIL_DIR / "pii_service.py").read_text()
+        lines = _contains_get_event_loop(source)
+        assert lines == [], (
+            f"pii_service.py still calls asyncio.get_event_loop() on line(s) {lines}"
+        )
+
+    def test_llama_guard_provider_uses_get_running_loop(self):
+        source = (_GUARDRAIL_DIR / "providers" / "llama_guard_provider.py").read_text()
+        lines = _contains_get_event_loop(source)
+        assert lines == [], (
+            f"llama_guard_provider.py still calls asyncio.get_event_loop() on line(s) {lines}"
+        )


### PR DESCRIPTION
## Summary
- 3 call sites in guardrail service used `asyncio.get_event_loop()` which raises `RuntimeError` on Python 3.12
- Replaced with `asyncio.get_running_loop()` — all sites are inside async methods with a guaranteed running loop

## Test plan
- [x] AST-based test verifying no `get_event_loop()` calls remain in either file
- [x] All 23 guardrail tests pass

Closes #49