### PR TITLE
Use actual EC2 instance type resources instead of hardcoded placeholders

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,7 @@ jobs:
             package/src/inferia/services/orchestration/test/adapter_test/test_adapter_error_handling.py \
             package/src/inferia/services/orchestration/test/test_grpc_abort_return.py \
             package/src/inferia/services/orchestration/test/spot/test_spot_reclaimer_filter.py \
+            package/src/inferia/services/orchestration/test/test_aws_instance_resources.py \
             package/src/inferia/services/orchestration/test/test_config_properties.py \
             package/src/inferia/services/api_gateway/tests/test_invitation_auth_bypass.py \
             package/src/inferia/tests/test_entrypoint_config_escaping.py \

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/adapter.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/adapter.py
@@ -10,6 +10,27 @@ from inferia.services.orchestration.v1 import (
 
 GRPC_ADDR = "localhost:50051"
 
+AWS_INSTANCE_RESOURCES = {
+    "g4dn.xlarge": {"cpu": "4", "memory": "16Gi"},
+    "g4dn.2xlarge": {"cpu": "8", "memory": "32Gi"},
+    "g4dn.4xlarge": {"cpu": "16", "memory": "64Gi"},
+    "g4dn.8xlarge": {"cpu": "32", "memory": "128Gi"},
+    "g4dn.12xlarge": {"cpu": "48", "memory": "192Gi"},
+    "g4dn.16xlarge": {"cpu": "64", "memory": "256Gi"},
+    "g5.xlarge": {"cpu": "4", "memory": "16Gi"},
+    "g5.2xlarge": {"cpu": "8", "memory": "32Gi"},
+    "g5.4xlarge": {"cpu": "16", "memory": "64Gi"},
+    "g5.8xlarge": {"cpu": "32", "memory": "64Gi"},
+    "g5.12xlarge": {"cpu": "48", "memory": "192Gi"},
+    "g5.16xlarge": {"cpu": "64", "memory": "256Gi"},
+    "g5.48xlarge": {"cpu": "192", "memory": "768Gi"},
+    "p3.2xlarge": {"cpu": "8", "memory": "61Gi"},
+    "p3.8xlarge": {"cpu": "32", "memory": "244Gi"},
+    "p3.16xlarge": {"cpu": "64", "memory": "488Gi"},
+    "p4d.24xlarge": {"cpu": "96", "memory": "1152Gi"},
+    "p5.48xlarge": {"cpu": "192", "memory": "2048Gi"},
+}
+
 
 class AWSAdapter(ProviderAdapter):
     def __init__(self, region: str):
@@ -72,10 +93,10 @@ class AWSAdapter(ProviderAdapter):
                             pool_id="aws-default-pool",
                             node_name=node["node_id"],
                             node_type=node["instance_type"],
-                            allocatable={
-                                "cpu": "4",  # Placeholder
-                                "memory": "16Gi",  # Placeholder
-                            },
+                            allocatable=AWS_INSTANCE_RESOURCES.get(
+                                node["instance_type"],
+                                {"cpu": "4", "memory": "16Gi"},
+                            ),
                         )
                     )
                 except grpc.aio.AioRpcError as e:

--- a/package/src/inferia/services/orchestration/test/test_aws_instance_resources.py
+++ b/package/src/inferia/services/orchestration/test/test_aws_instance_resources.py
@@ -1,0 +1,74 @@
+"""Tests for AWS instance type resource lookup."""
+
+import ast
+import os
+import pytest
+
+# Parse AWS_INSTANCE_RESOURCES directly from source to avoid importing
+# boto3/grpc which are not available in the test environment.
+_adapter_path = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "services",
+    "adapter_engine",
+    "adapters",
+    "aws",
+    "adapter.py",
+)
+with open(_adapter_path) as _f:
+    _tree = ast.parse(_f.read())
+
+AWS_INSTANCE_RESOURCES = None
+for _node in ast.iter_child_nodes(_tree):
+    if isinstance(_node, ast.Assign):
+        for target in _node.targets:
+            if isinstance(target, ast.Name) and target.id == "AWS_INSTANCE_RESOURCES":
+                AWS_INSTANCE_RESOURCES = ast.literal_eval(_node.value)
+
+assert AWS_INSTANCE_RESOURCES is not None, "Could not find AWS_INSTANCE_RESOURCES in adapter.py"
+
+DEFAULT_RESOURCES = {"cpu": "4", "memory": "16Gi"}
+
+
+class TestAWSInstanceResources:
+    """Verify the static lookup returns correct specs for known types
+    and falls back gracefully for unknown types."""
+
+    @pytest.mark.parametrize(
+        "instance_type, expected_cpu, expected_memory",
+        [
+            ("g4dn.xlarge", "4", "16Gi"),
+            ("g4dn.2xlarge", "8", "32Gi"),
+            ("g4dn.4xlarge", "16", "64Gi"),
+            ("g4dn.8xlarge", "32", "128Gi"),
+            ("g4dn.12xlarge", "48", "192Gi"),
+            ("g4dn.16xlarge", "64", "256Gi"),
+            ("g5.xlarge", "4", "16Gi"),
+            ("g5.2xlarge", "8", "32Gi"),
+            ("g5.4xlarge", "16", "64Gi"),
+            ("g5.8xlarge", "32", "64Gi"),
+            ("g5.12xlarge", "48", "192Gi"),
+            ("g5.16xlarge", "64", "256Gi"),
+            ("g5.48xlarge", "192", "768Gi"),
+            ("p3.2xlarge", "8", "61Gi"),
+            ("p3.8xlarge", "32", "244Gi"),
+            ("p3.16xlarge", "64", "488Gi"),
+            ("p4d.24xlarge", "96", "1152Gi"),
+            ("p5.48xlarge", "192", "2048Gi"),
+        ],
+    )
+    def test_known_instance_type(self, instance_type, expected_cpu, expected_memory):
+        resources = AWS_INSTANCE_RESOURCES.get(instance_type, DEFAULT_RESOURCES)
+        assert resources["cpu"] == expected_cpu
+        assert resources["memory"] == expected_memory
+
+    def test_unknown_instance_type_returns_default(self):
+        resources = AWS_INSTANCE_RESOURCES.get("t3.micro", DEFAULT_RESOURCES)
+        assert resources == DEFAULT_RESOURCES
+
+    def test_empty_string_returns_default(self):
+        resources = AWS_INSTANCE_RESOURCES.get("", DEFAULT_RESOURCES)
+        assert resources == DEFAULT_RESOURCES
+
+    def test_lookup_dict_is_not_empty(self):
+        assert len(AWS_INSTANCE_RESOURCES) >= 18


### PR DESCRIPTION
## Summary
- Every AWS node was registered with hardcoded 4 vCPU / 16 GiB regardless of instance type
- Added static lookup for 18 common GPU instance types (g4dn, g5, p3, p4d, p5)
- Unknown types fall back to previous defaults

## Test plan
- [x] 21 tests: all 18 known types, unknown fallback, empty string, dict size
- [x] Added to CI

Closes #48