### PR TITLE
Wire circuit breaker to upstream call and stream paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
             package/src/inferia/common/tests/test_rate_limit.py \
             package/src/inferia/common/tests/test_errors.py \
             package/src/inferia/common/tests/test_circuit_breaker.py \
+            package/src/inferia/services/inference/tests/test_circuit_breaker_wiring.py \
             package/src/inferia/common/tests/test_exception_handlers.py \
             package/src/inferia/common/tests/test_http_client.py \
             package/src/inferia/services/api_gateway/tests/test_auth_security.py \

--- a/package/src/inferia/services/inference/core/service.py
+++ b/package/src/inferia/services/inference/core/service.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException
 from inferia.services.inference.client import api_gateway_client
 from inferia.services.inference.config import settings
+from inferia.common.circuit_breaker import circuit_breaker_registry
 from typing import Dict, Any, List, AsyncGenerator
 import logging
 import httpx
@@ -257,6 +258,17 @@ class GatewayService:
             yield b'data: {"error": "Invalid upstream configuration"}\n\n'
             return
 
+        breaker = circuit_breaker_registry.get_or_create(
+            f"upstream:{concurrency_key}",
+            failure_threshold=5,
+            recovery_timeout=30.0,
+            expected_exception=(httpx.HTTPStatusError, httpx.RequestError),
+        )
+
+        if not await breaker._can_execute():
+            yield b'data: {"error": "Upstream temporarily unavailable (circuit breaker open)"}\n\n'
+            return
+
         max_bytes = settings.upstream_max_response_bytes
         client = http_client.get_client()
         try:
@@ -273,9 +285,11 @@ class GatewayService:
                             return
                         yield chunk
         except httpx.HTTPStatusError as e:
+            await breaker._record_failure()
             logger.error(f"Upstream Error {e.response.status_code}: {e.response.text}")
             yield b'data: {"error": "Upstream provider returned an error"}\n\n'
         except Exception as e:
+            await breaker._record_failure()
             logger.error(f"Streaming Exception: {e}")
             yield b'data: {"error": "Streaming connection failed"}\n\n'
 
@@ -308,6 +322,19 @@ class GatewayService:
         transformed_payload = adapter.transform_request(payload)
         max_bytes = settings.upstream_max_response_bytes
 
+        breaker = circuit_breaker_registry.get_or_create(
+            f"upstream:{concurrency_key}",
+            failure_threshold=5,
+            recovery_timeout=30.0,
+            expected_exception=(httpx.HTTPStatusError, httpx.RequestError),
+        )
+
+        if not await breaker._can_execute():
+            raise HTTPException(
+                status_code=503,
+                detail="Upstream temporarily unavailable (circuit breaker open)",
+            )
+
         client = http_client.get_client()
         try:
             async with upstream_concurrency_limiter.limit(concurrency_key):
@@ -329,16 +356,19 @@ class GatewayService:
                 raw_response = resp.json()
 
                 # Transform response back to OpenAI format
+                await breaker._record_success()
                 return adapter.transform_response(raw_response)
         except HTTPException:
             raise
         except httpx.HTTPStatusError as e:
+            await breaker._record_failure()
             logger.error(f"Provider error {e.response.status_code}: {e.response.text}")
             raise HTTPException(
                 status_code=e.response.status_code,
                 detail="Upstream provider returned an error",
             )
         except Exception as e:
+            await breaker._record_failure()
             logger.error(f"Provider request failed: {e}")
             raise HTTPException(
                 status_code=502, detail="Upstream provider is unavailable"

--- a/package/src/inferia/services/inference/tests/conftest.py
+++ b/package/src/inferia/services/inference/tests/conftest.py
@@ -1,1 +1,13 @@
 """Shared test configuration for inference service tests."""
+
+import pytest
+
+from inferia.common.circuit_breaker import circuit_breaker_registry
+
+
+@pytest.fixture(autouse=True)
+def _clear_circuit_breakers():
+    """Reset global circuit breaker state between tests."""
+    circuit_breaker_registry._breakers.clear()
+    yield
+    circuit_breaker_registry._breakers.clear()

--- a/package/src/inferia/services/inference/tests/test_circuit_breaker_wiring.py
+++ b/package/src/inferia/services/inference/tests/test_circuit_breaker_wiring.py
@@ -1,0 +1,264 @@
+"""Tests for circuit breaker wiring into upstream call/stream paths."""
+
+import time
+import pytest
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from fastapi import HTTPException
+
+from inferia.common.circuit_breaker import circuit_breaker_registry
+
+
+@asynccontextmanager
+async def noop_limit(key):
+    yield
+
+
+def make_mock_adapter():
+    adapter = MagicMock()
+    adapter.get_chat_path.return_value = "/v1/chat/completions"
+    adapter.transform_request.side_effect = lambda x: x
+    adapter.transform_response.side_effect = lambda x: x
+    return adapter
+
+
+def make_failing_client(status_code=500):
+    """Create a mock client whose .post() raises HTTPStatusError."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.text = "Internal Server Error"
+    mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Error", request=MagicMock(), response=mock_resp
+    )
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    return mock_client
+
+
+def make_successful_client(response_body=None):
+    """Create a mock client whose .post() returns a valid response."""
+    if response_body is None:
+        response_body = {"choices": [{"message": {"content": "ok"}}]}
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {}
+    mock_resp.content = b'{"choices":[]}'
+    mock_resp.json.return_value = response_body
+    mock_resp.raise_for_status = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+    return mock_client
+
+
+def _patch_service(mock_client):
+    """Return stacked patches for call_upstream dependencies."""
+    return (
+        patch(
+            "inferia.services.inference.core.service.get_adapter",
+            return_value=make_mock_adapter(),
+        ),
+        patch("inferia.services.inference.core.service.http_client"),
+        patch("inferia.services.inference.core.service.upstream_concurrency_limiter"),
+        patch("inferia.services.inference.core.service.settings"),
+        mock_client,
+    )
+
+
+class TestCircuitBreakerWiring:
+    """Verify circuit breaker is wired into call_upstream."""
+
+    @pytest.mark.asyncio
+    async def test_call_upstream_opens_circuit_after_failures(self):
+        """After 5 consecutive upstream failures, the 6th call raises 503 (circuit open)."""
+        from inferia.services.inference.core.service import GatewayService
+
+        concurrency_key = "deploy-fail-test"
+
+        with patch(
+            "inferia.services.inference.core.service.get_adapter",
+            return_value=make_mock_adapter(),
+        ), patch(
+            "inferia.services.inference.core.service.http_client"
+        ) as mock_hc, patch(
+            "inferia.services.inference.core.service.upstream_concurrency_limiter"
+        ) as mock_limiter, patch(
+            "inferia.services.inference.core.service.settings"
+        ) as mock_settings:
+            mock_hc.get_client.return_value = make_failing_client()
+            mock_limiter.limit = noop_limit
+            mock_settings.upstream_allowed_internal_hosts = ""
+            mock_settings.upstream_max_response_bytes = 52_428_800
+
+            # Trigger 5 failures to open the circuit
+            for _ in range(5):
+                with pytest.raises(HTTPException) as exc:
+                    await GatewayService.call_upstream(
+                        "https://api.example.com",
+                        {"model": "test"},
+                        {},
+                        concurrency_key=concurrency_key,
+                    )
+                # These should be upstream errors (500), not circuit breaker
+                assert exc.value.status_code == 500
+
+            # 6th call should be blocked by the circuit breaker (503)
+            with pytest.raises(HTTPException) as exc:
+                await GatewayService.call_upstream(
+                    "https://api.example.com",
+                    {"model": "test"},
+                    {},
+                    concurrency_key=concurrency_key,
+                )
+            assert exc.value.status_code == 503
+            assert "circuit breaker" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_call_upstream_circuit_recovers_after_timeout(self):
+        """After recovery timeout, a successful call closes the circuit."""
+        from inferia.services.inference.core.service import GatewayService
+
+        concurrency_key = "deploy-recover-test"
+
+        with patch(
+            "inferia.services.inference.core.service.get_adapter",
+            return_value=make_mock_adapter(),
+        ), patch(
+            "inferia.services.inference.core.service.http_client"
+        ) as mock_hc, patch(
+            "inferia.services.inference.core.service.upstream_concurrency_limiter"
+        ) as mock_limiter, patch(
+            "inferia.services.inference.core.service.settings"
+        ) as mock_settings:
+            mock_hc.get_client.return_value = make_failing_client()
+            mock_limiter.limit = noop_limit
+            mock_settings.upstream_allowed_internal_hosts = ""
+            mock_settings.upstream_max_response_bytes = 52_428_800
+
+            # Trigger 5 failures to open the circuit
+            for _ in range(5):
+                with pytest.raises(HTTPException):
+                    await GatewayService.call_upstream(
+                        "https://api.example.com",
+                        {"model": "test"},
+                        {},
+                        concurrency_key=concurrency_key,
+                    )
+
+            # Simulate recovery timeout by backdating last_failure_time
+            breaker = circuit_breaker_registry.get(f"upstream:{concurrency_key}")
+            assert breaker is not None
+            breaker._last_failure_time = time.time() - 60  # Well past recovery_timeout
+
+            # Now switch to a successful client
+            mock_hc.get_client.return_value = make_successful_client()
+
+            # This call should succeed (half-open -> closed)
+            result = await GatewayService.call_upstream(
+                "https://api.example.com",
+                {"model": "test"},
+                {},
+                concurrency_key=concurrency_key,
+            )
+            assert result is not None
+
+            # Circuit should now be closed
+            from inferia.common.circuit_breaker import CircuitState
+
+            assert breaker.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_call_upstream_success_does_not_open_circuit(self):
+        """Successful calls keep the circuit closed."""
+        from inferia.services.inference.core.service import GatewayService
+
+        concurrency_key = "deploy-success-test"
+
+        with patch(
+            "inferia.services.inference.core.service.get_adapter",
+            return_value=make_mock_adapter(),
+        ), patch(
+            "inferia.services.inference.core.service.http_client"
+        ) as mock_hc, patch(
+            "inferia.services.inference.core.service.upstream_concurrency_limiter"
+        ) as mock_limiter, patch(
+            "inferia.services.inference.core.service.settings"
+        ) as mock_settings:
+            mock_hc.get_client.return_value = make_successful_client()
+            mock_limiter.limit = noop_limit
+            mock_settings.upstream_allowed_internal_hosts = ""
+            mock_settings.upstream_max_response_bytes = 52_428_800
+
+            for _ in range(10):
+                result = await GatewayService.call_upstream(
+                    "https://api.example.com",
+                    {"model": "test"},
+                    {},
+                    concurrency_key=concurrency_key,
+                )
+                assert result is not None
+
+            # Circuit should remain closed
+            breaker = circuit_breaker_registry.get(f"upstream:{concurrency_key}")
+            from inferia.common.circuit_breaker import CircuitState
+
+            assert breaker.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_stream_upstream_records_failure_on_http_error(self):
+        """stream_upstream records circuit breaker failure on HTTPStatusError."""
+        from inferia.services.inference.core.service import GatewayService
+
+        concurrency_key = "deploy-stream-fail"
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Error", request=MagicMock(), response=MagicMock(status_code=500, text="err")
+        )
+
+        @asynccontextmanager
+        async def mock_stream(*args, **kwargs):
+            yield mock_response
+
+        mock_client = MagicMock()
+        mock_client.stream = mock_stream
+
+        with patch(
+            "inferia.services.inference.core.service.get_adapter",
+            return_value=make_mock_adapter(),
+        ), patch(
+            "inferia.services.inference.core.service.http_client"
+        ) as mock_hc, patch(
+            "inferia.services.inference.core.service.upstream_concurrency_limiter"
+        ) as mock_limiter, patch(
+            "inferia.services.inference.core.service.settings"
+        ) as mock_settings:
+            mock_hc.get_client.return_value = mock_client
+            mock_limiter.limit = noop_limit
+            mock_settings.upstream_allowed_internal_hosts = ""
+            mock_settings.upstream_max_response_bytes = 52_428_800
+
+            # Trigger 5 streaming failures
+            for _ in range(5):
+                chunks = []
+                async for chunk in GatewayService.stream_upstream(
+                    "https://api.example.com",
+                    {"model": "test"},
+                    {},
+                    concurrency_key=concurrency_key,
+                ):
+                    chunks.append(chunk)
+
+            # 6th call should be blocked by circuit breaker
+            chunks = []
+            async for chunk in GatewayService.stream_upstream(
+                "https://api.example.com",
+                {"model": "test"},
+                {},
+                concurrency_key=concurrency_key,
+            ):
+                chunks.append(chunk)
+
+            assert len(chunks) == 1
+            assert b"circuit breaker" in chunks[0].lower()


### PR DESCRIPTION
## Summary
- The existing `CircuitBreaker` in `common/` was implemented but never used
- Now wired to `call_upstream` and `stream_upstream` in `service.py`
- Per-deployment breaker (keyed by `concurrency_key`): opens after 5 failures, recovers after 30s
- Returns 503 when circuit is open instead of waiting for upstream timeout

## Test plan
- [x] 4 tests: circuit opens after failures, recovers after timeout, success keeps closed, streaming failures counted
- [x] All inference tests pass

Closes #55