### PR TITLE
Ensure deployment state always transitions from TERMINATING on cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
             package/src/inferia/services/data/tests/test_engine_error_handling.py \
             package/src/inferia/services/guardrail/tests/test_scan_endpoint_security.py \
             package/src/inferia/services/orchestration/test/model_deployment/test_worker_lifecycle.py \
+            package/src/inferia/services/orchestration/test/model_deployment/test_terminate_state_update.py \
             package/src/inferia/services/orchestration/test/adapter_test/test_injection_expanded.py \
             package/src/inferia/services/orchestration/test/adapter_test/test_sdl_injection.py \
             package/src/inferia/services/orchestration/test/compute_pools_nodes/test_pool_manager.py \

--- a/package/src/inferia/services/orchestration/services/model_deployment/worker.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/worker.py
@@ -553,108 +553,116 @@ class ModelDeploymentWorker:
         except Exception:
             pass
 
-        # ------------------------------------
-        # 1. STOP RUNTIME (External providers / vLLM / etc)
-        # ------------------------------------
-        # Use node_ids to find the exact running instances to stop
-        if d.get("node_ids"):
-            for node_id in d["node_ids"]:
-                node = await self.inventory.get_node_by_id(node_id)
-                if node:
-                    adapter = get_adapter(node["provider"])
-                    metadata = node.get("metadata", {})
-                    if isinstance(metadata, str):
-                        try:
-                            import json
+        cleanup_error = None
+        try:
+            # ------------------------------------
+            # 1. STOP RUNTIME (External providers / vLLM / etc)
+            # ------------------------------------
+            # Use node_ids to find the exact running instances to stop
+            if d.get("node_ids"):
+                for node_id in d["node_ids"]:
+                    node = await self.inventory.get_node_by_id(node_id)
+                    if node:
+                        adapter = get_adapter(node["provider"])
+                        metadata = node.get("metadata", {})
+                        if isinstance(metadata, str):
+                            try:
+                                import json
 
-                            metadata = json.loads(metadata)
-                        except Exception:
-                            metadata = {}
+                                metadata = json.loads(metadata)
+                            except Exception:
+                                metadata = {}
 
-                    # Check if this is a cluster-based deployment
-                    service_name = metadata.get("service_name") if metadata else None
+                        # Check if this is a cluster-based deployment
+                        service_name = metadata.get("service_name") if metadata else None
 
-                    if is_cluster_pool and service_name and cluster_id:
-                        # For cluster-based pools: stop the service but keep the cluster
-                        log.info(
-                            f"Stopping service {service_name} on cluster {cluster_id}"
-                        )
-                        try:
-                            await adapter.stop_service(
-                                cluster_id=cluster_id,
-                                service_name=service_name,
+                        if is_cluster_pool and service_name and cluster_id:
+                            # For cluster-based pools: stop the service but keep the cluster
+                            log.info(
+                                f"Stopping service {service_name} on cluster {cluster_id}"
+                            )
+                            try:
+                                await adapter.stop_service(
+                                    cluster_id=cluster_id,
+                                    service_name=service_name,
+                                    provider_credential_name=metadata.get(
+                                        "provider_credential_name"
+                                    ),
+                                )
+                                log.info(
+                                    f"Stopped service {service_name} on cluster {cluster_id}"
+                                )
+                            except Exception as e:
+                                log.warning(f"Failed to stop service {service_name}: {e}")
+                        else:
+                            # For job-based pools: deprovision the node
+                            log.info(f"Deprovisioning {node['provider']} node {node_id}")
+                            await adapter.deprovision_node(
+                                provider_instance_id=node["provider_instance_id"],
                                 provider_credential_name=metadata.get(
                                     "provider_credential_name"
                                 ),
                             )
-                            log.info(
-                                f"Stopped service {service_name} on cluster {cluster_id}"
-                            )
+
+            log.info(f"Stopped runtime for deployment {deployment_id}")
+
+            # ------------------------------------
+            # 2. RELEASE SCHEDULER ALLOCATIONS
+            # ------------------------------------
+            if d.get("allocation_ids"):
+                for alloc_id in d["allocation_ids"]:
+                    await self.scheduler.release(allocation_id=alloc_id)
+
+            log.info(f"Released scheduler allocations for deployment {deployment_id}")
+
+            # ------------------------------------
+            # 3. HANDLE INVENTORY
+            # ------------------------------------
+            node = None
+            if d.get("node_ids"):
+                for node_id in d["node_ids"]:
+                    node = await self.inventory.get_node_by_id(node_id)
+
+                    # Use adapter capabilities to determine if ephemeral
+                    is_ephemeral = False
+                    is_cluster = False
+                    if node:
+                        try:
+                            adapter = get_adapter(node["provider"])
+                            capabilities = adapter.get_capabilities()
+                            is_ephemeral = capabilities.is_ephemeral
+                            is_cluster = capabilities.supports_cluster_mode
                         except Exception as e:
-                            log.warning(f"Failed to stop service {service_name}: {e}")
+                            log.warning(
+                                f"Could not get capabilities for {node['provider']}: {e}"
+                            )
+                            # Fallback: check if provider is known to be ephemeral
+                            is_ephemeral = node.get("provider") in ["nosana", "akash"]
+
+                    # For cluster-based deployments: always recycle (cluster stays alive)
+                    # For ephemeral job-based: mark as terminated
+                    # For persistent: recycle
+                    if is_cluster:
+                        await self.inventory.recycle_node(node_id)
+                        log.info(
+                            f"Recycled cluster service node {node_id} (cluster remains alive)"
+                        )
+                    elif is_ephemeral:
+                        await self.inventory.mark_terminated(node_id)
+                        log.info(f"Terminated ephemeral node {node_id}")
                     else:
-                        # For job-based pools: deprovision the node
-                        log.info(f"Deprovisioning {node['provider']} node {node_id}")
-                        await adapter.deprovision_node(
-                            provider_instance_id=node["provider_instance_id"],
-                            provider_credential_name=metadata.get(
-                                "provider_credential_name"
-                            ),
-                        )
-
-        log.info(f"Stopped runtime for deployment {deployment_id}")
-
-        # ------------------------------------
-        # 2. RELEASE SCHEDULER ALLOCATIONS
-        # ------------------------------------
-        if d.get("allocation_ids"):
-            for alloc_id in d["allocation_ids"]:
-                await self.scheduler.release(allocation_id=alloc_id)
-
-        log.info(f"Released scheduler allocations for deployment {deployment_id}")
-
-        # ------------------------------------
-        # 3. HANDLE INVENTORY
-        # ------------------------------------
-        node = None
-        if d.get("node_ids"):
-            for node_id in d["node_ids"]:
-                node = await self.inventory.get_node_by_id(node_id)
-
-                # Use adapter capabilities to determine if ephemeral
-                is_ephemeral = False
-                is_cluster = False
-                if node:
-                    try:
-                        adapter = get_adapter(node["provider"])
-                        capabilities = adapter.get_capabilities()
-                        is_ephemeral = capabilities.is_ephemeral
-                        is_cluster = capabilities.supports_cluster_mode
-                    except Exception as e:
-                        log.warning(
-                            f"Could not get capabilities for {node['provider']}: {e}"
-                        )
-                        # Fallback: check if provider is known to be ephemeral
-                        is_ephemeral = node.get("provider") in ["nosana", "akash"]
-
-                # For cluster-based deployments: always recycle (cluster stays alive)
-                # For ephemeral job-based: mark as terminated
-                # For persistent: recycle
-                if is_cluster:
-                    await self.inventory.recycle_node(node_id)
-                    log.info(
-                        f"Recycled cluster service node {node_id} (cluster remains alive)"
-                    )
-                elif is_ephemeral:
-                    await self.inventory.mark_terminated(node_id)
-                    log.info(f"Terminated ephemeral node {node_id}")
-                else:
-                    await self.inventory.recycle_node(node_id)
-                    log.info(f"Recycled inventory node {node_id}")
-
-        # ------------------------------------
-        # 4. FINAL STATE
-        # ------------------------------------
-        await self.deployments.update_state(deployment_id, "STOPPED")
-
-        log.info(f"Deployment {deployment_id} stopped")
+                        await self.inventory.recycle_node(node_id)
+                        log.info(f"Recycled inventory node {node_id}")
+        except Exception as e:
+            cleanup_error = e
+            log.error(f"Cleanup failed for deployment {deployment_id}: {e}")
+        finally:
+            # ------------------------------------
+            # 4. FINAL STATE — always reached
+            # ------------------------------------
+            final_state = "STOPPED" if cleanup_error is None else "FAILED"
+            await self.deployments.update_state(deployment_id, final_state)
+            if cleanup_error:
+                log.error(f"Deployment {deployment_id} marked FAILED due to cleanup error: {cleanup_error}")
+            else:
+                log.info(f"Deployment {deployment_id} stopped")

--- a/package/src/inferia/services/orchestration/test/model_deployment/test_terminate_state_update.py
+++ b/package/src/inferia/services/orchestration/test/model_deployment/test_terminate_state_update.py
@@ -1,0 +1,123 @@
+"""Tests that handle_terminate_requested always transitions state from TERMINATING.
+
+Regression tests for GitHub issue #19: deployment stuck in TERMINATING state
+when cleanup steps raise exceptions.
+"""
+
+import pytest
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from inferia.services.orchestration.services.model_deployment.worker import (
+    ModelDeploymentWorker,
+)
+
+
+@pytest.fixture
+def worker():
+    """Create worker with mocked repos."""
+    return ModelDeploymentWorker(
+        deployment_repo=AsyncMock(),
+        model_registry_repo=AsyncMock(),
+        pool_repo=AsyncMock(),
+        placement_repo=AsyncMock(),
+        scheduler=AsyncMock(),
+        inventory_repo=AsyncMock(),
+        runtime_resolver=MagicMock(),
+        runtime_strategies={"vllm": AsyncMock()},
+    )
+
+
+def _make_deployment(dep_id, node_ids=None, alloc_ids=None):
+    """Build a minimal deployment dict in TERMINATING state."""
+    return {
+        "state": "TERMINATING",
+        "deployment_id": str(dep_id),
+        "pool_id": str(uuid4()),
+        "node_ids": node_ids or [],
+        "allocation_ids": alloc_ids or [],
+    }
+
+
+class TestTerminateStateUpdate:
+    """Ensure deployment always leaves TERMINATING state (issue #19)."""
+
+    @pytest.mark.asyncio
+    async def test_normal_termination_sets_stopped(self, worker):
+        """Clean termination with no errors sets state to STOPPED."""
+        dep_id = uuid4()
+        node_id = str(uuid4())
+        dep = _make_deployment(dep_id, node_ids=[node_id])
+        worker.deployments.get = AsyncMock(return_value=dep)
+        worker.pools.get = AsyncMock(return_value={"pool_type": "job"})
+
+        node_data = {
+            "provider": "nosana",
+            "provider_instance_id": "inst-1",
+            "metadata": {},
+        }
+        worker.inventory.get_node_by_id = AsyncMock(return_value=node_data)
+
+        mock_adapter = MagicMock()
+        mock_adapter.deprovision_node = AsyncMock()
+        mock_adapter.get_capabilities.return_value = MagicMock(
+            is_ephemeral=True, supports_cluster_mode=False
+        )
+
+        with patch(
+            "inferia.services.orchestration.services.model_deployment.worker.get_adapter",
+            return_value=mock_adapter,
+        ):
+            await worker.handle_terminate_requested(dep_id)
+
+        worker.deployments.update_state.assert_called_with(dep_id, "STOPPED")
+
+    @pytest.mark.asyncio
+    async def test_deprovision_failure_sets_failed(self, worker):
+        """If deprovision_node raises, state must transition to FAILED (not stay TERMINATING)."""
+        dep_id = uuid4()
+        node_id = str(uuid4())
+        dep = _make_deployment(dep_id, node_ids=[node_id])
+        worker.deployments.get = AsyncMock(return_value=dep)
+        worker.pools.get = AsyncMock(return_value={"pool_type": "job"})
+
+        node_data = {
+            "provider": "nosana",
+            "provider_instance_id": "inst-1",
+            "metadata": {},
+        }
+        worker.inventory.get_node_by_id = AsyncMock(return_value=node_data)
+
+        mock_adapter = MagicMock()
+        mock_adapter.deprovision_node = AsyncMock(
+            side_effect=RuntimeError("provider down")
+        )
+
+        with patch(
+            "inferia.services.orchestration.services.model_deployment.worker.get_adapter",
+            return_value=mock_adapter,
+        ):
+            await worker.handle_terminate_requested(dep_id)
+
+        worker.deployments.update_state.assert_called_with(dep_id, "FAILED")
+
+    @pytest.mark.asyncio
+    async def test_scheduler_release_failure_sets_failed(self, worker):
+        """If scheduler.release raises, state must transition to FAILED."""
+        dep_id = uuid4()
+        alloc_id = str(uuid4())
+        dep = _make_deployment(dep_id, alloc_ids=[alloc_id])
+        worker.deployments.get = AsyncMock(return_value=dep)
+        worker.pools.get = AsyncMock(return_value={"pool_type": "job"})
+
+        worker.scheduler.release = AsyncMock(
+            side_effect=RuntimeError("redis unavailable")
+        )
+
+        with patch(
+            "inferia.services.orchestration.services.model_deployment.worker.get_adapter",
+            return_value=MagicMock(),
+        ):
+            await worker.handle_terminate_requested(dep_id)
+
+        worker.deployments.update_state.assert_called_with(dep_id, "FAILED")


### PR DESCRIPTION
## Summary
- If any cleanup step in \`handle_terminate_requested\` raised, state stayed \`TERMINATING\` forever
- Wrapped cleanup in try/finally — sets STOPPED on success, FAILED on error
- State update always executes regardless of cleanup failures

## Test plan
- [x] 3 tests: normal → STOPPED, deprovision failure → FAILED, scheduler failure → FAILED
- [x] All 7 existing worker lifecycle tests pass

Closes #19