### PR TITLE
Wrap synchronous K8s API calls in run_in_executor to unblock event loop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,7 @@ jobs:
             package/src/inferia/services/api_gateway/tests/test_totp_setup_security.py \
             package/src/inferia/services/api_gateway/tests/test_rate_limiter_bucket_race.py \
             package/src/inferia/services/orchestration/test/test_skypilot_terminate.py \
+            package/src/inferia/services/orchestration/test/test_k8s_nonblocking.py \
             -p no:twisted -p no:trio -p no:tornasync \
             --junitxml=junit/test-results.xml \
             --cov=package/src/inferia \

--- a/package/src/inferia/services/orchestration/infra/k8s_llmd_client.py
+++ b/package/src/inferia/services/orchestration/infra/k8s_llmd_client.py
@@ -1,5 +1,12 @@
 from kubernetes import client, config
 from kubernetes.client.exceptions import ApiException
+import asyncio
+import functools
+
+
+async def _run_sync(func, *args, **kwargs):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, functools.partial(func, *args, **kwargs))
 
 
 class LLMdK8sClient:
@@ -12,7 +19,8 @@ class LLMdK8sClient:
         name = spec["metadata"]["name"]
 
         try:
-            return self.api.create_namespaced_custom_object(
+            return await _run_sync(
+                self.api.create_namespaced_custom_object,
                 group="llmd.ai",
                 version="v1",
                 namespace=self.namespace,
@@ -21,7 +29,8 @@ class LLMdK8sClient:
             )
         except ApiException as e:
             if e.status == 409:
-                return self.api.patch_namespaced_custom_object(
+                return await _run_sync(
+                    self.api.patch_namespaced_custom_object,
                     group="llmd.ai",
                     version="v1",
                     namespace=self.namespace,
@@ -32,7 +41,8 @@ class LLMdK8sClient:
             raise
 
     async def delete(self, name: str):
-        self.api.delete_namespaced_custom_object(
+        await _run_sync(
+            self.api.delete_namespaced_custom_object,
             group="llmd.ai",
             version="v1",
             namespace=self.namespace,
@@ -41,7 +51,8 @@ class LLMdK8sClient:
         )
 
     async def get_status(self, name: str):
-        obj = self.api.get_namespaced_custom_object(
+        obj = await _run_sync(
+            self.api.get_namespaced_custom_object,
             group="llmd.ai",
             version="v1",
             namespace=self.namespace,

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/k8s/k8s_adapter.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/k8s/k8s_adapter.py
@@ -6,9 +6,16 @@ from inferia.services.orchestration.services.adapter_engine.base import (
     ProviderCapabilities,
 )
 from typing import List, Dict, Optional
+import asyncio
+import functools
 import uuid
 import logging
 import time
+
+
+async def _run_sync(func, *args, **kwargs):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, functools.partial(func, *args, **kwargs))
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +67,7 @@ class KubernetesAdapter(ProviderAdapter):
         Discover available node capacity.
         """
         try:
-            nodes = self.core.list_node().items
+            nodes = (await _run_sync(self.core.list_node)).items
 
             resources = []
 
@@ -170,7 +177,7 @@ class KubernetesAdapter(ProviderAdapter):
             ),
         )
 
-        self.core.create_namespaced_pod(namespace=namespace, body=pod)
+        await _run_sync(self.core.create_namespaced_pod, namespace=namespace, body=pod)
 
         return {
             "provider": "k8s",
@@ -212,8 +219,9 @@ class KubernetesAdapter(ProviderAdapter):
 
         while True:
             try:
-                pod = self.core.read_namespaced_pod(
-                    name=provider_instance_id, namespace=namespace
+                pod = await _run_sync(
+                    self.core.read_namespaced_pod,
+                    name=provider_instance_id, namespace=namespace,
                 )
 
                 phase = pod.status.phase
@@ -260,16 +268,18 @@ class KubernetesAdapter(ProviderAdapter):
             # Default to "default" namespace if not found
             namespace = "default"
             try:
-                pods = self.core.list_pod_for_all_namespaces(
-                    field_selector=f"metadata.name={provider_instance_id}"
+                pods = await _run_sync(
+                    self.core.list_pod_for_all_namespaces,
+                    field_selector=f"metadata.name={provider_instance_id}",
                 )
                 if pods.items:
                     namespace = pods.items[0].metadata.namespace
             except Exception:
                 pass
 
-            self.core.delete_namespaced_pod(
-                name=provider_instance_id, namespace=namespace
+            await _run_sync(
+                self.core.delete_namespaced_pod,
+                name=provider_instance_id, namespace=namespace,
             )
         except Exception:
             logger.exception("Kubernetes deprovision error")
@@ -291,16 +301,18 @@ class KubernetesAdapter(ProviderAdapter):
             # Similar to deprovision, we need to find the namespace
             namespace = "default"
             try:
-                pods = self.core.list_pod_for_all_namespaces(
-                    field_selector=f"metadata.name={provider_instance_id}"
+                pods = await _run_sync(
+                    self.core.list_pod_for_all_namespaces,
+                    field_selector=f"metadata.name={provider_instance_id}",
                 )
                 if pods.items:
                     namespace = pods.items[0].metadata.namespace
             except Exception:
                 pass
 
-            logs = self.core.read_namespaced_pod_log(
-                name=provider_instance_id, namespace=namespace, tail_lines=100
+            logs = await _run_sync(
+                self.core.read_namespaced_pod_log,
+                name=provider_instance_id, namespace=namespace, tail_lines=100,
             )
             return {"logs": logs.split("\n")}
         except Exception as e:

--- a/package/src/inferia/services/orchestration/services/llmd_runtime/client.py
+++ b/package/src/inferia/services/orchestration/services/llmd_runtime/client.py
@@ -1,5 +1,12 @@
 from kubernetes import client, config
+import asyncio
+import functools
 import logging
+
+
+async def _run_sync(func, *args, **kwargs):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, functools.partial(func, *args, **kwargs))
 
 logger = logging.getLogger("llmd-client")
 
@@ -14,7 +21,8 @@ class LLMdK8sClient:
         name = spec["metadata"]["name"]
 
         try:
-            self.api.create_namespaced_custom_object(
+            await _run_sync(
+                self.api.create_namespaced_custom_object,
                 group="llmd.ai",
                 version="v1",
                 namespace=self.namespace,
@@ -24,7 +32,8 @@ class LLMdK8sClient:
             logger.info("llm-d CRD created: %s", name)
         except client.exceptions.ApiException as e:
             if e.status == 409:
-                self.api.replace_namespaced_custom_object(
+                await _run_sync(
+                    self.api.replace_namespaced_custom_object,
                     group="llmd.ai",
                     version="v1",
                     namespace=self.namespace,
@@ -36,8 +45,9 @@ class LLMdK8sClient:
             else:
                 raise
 
-    def get(self, name: str):
-        return self.api.get_namespaced_custom_object(
+    async def get(self, name: str):
+        return await _run_sync(
+            self.api.get_namespaced_custom_object,
             group="llmd.ai",
             version="v1",
             namespace=self.namespace,

--- a/package/src/inferia/services/orchestration/test/test_k8s_nonblocking.py
+++ b/package/src/inferia/services/orchestration/test/test_k8s_nonblocking.py
@@ -1,0 +1,133 @@
+"""
+Verify that all Kubernetes API calls in async methods are wrapped
+with _run_sync (run_in_executor) so they never block the event loop.
+"""
+
+import ast
+import inspect
+import textwrap
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_source(module):
+    """Import a module by name and return its dedented source."""
+    mod = __import__(module, fromlist=["_"])
+    return textwrap.dedent(inspect.getsource(mod))
+
+
+def _async_methods_with_blocking_calls(source: str, blocked_prefixes: list[str]):
+    """
+    Parse *source* and return a list of (method_name, [offending_call, ...])
+    for every ``async def`` that contains a direct call to any of the
+    *blocked_prefixes* (e.g. ``self.core``, ``self.api``) **outside** of a
+    ``_run_sync(...)`` wrapper.
+    """
+    tree = ast.parse(source)
+    violations = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.AsyncFunctionDef,)):
+            continue
+
+        bad_calls: list[str] = []
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+
+            # Check if this call is _run_sync(...) — skip its children
+            func = child.func
+            if isinstance(func, ast.Name) and func.id == "_run_sync":
+                continue
+            if isinstance(func, ast.Attribute) and func.attr == "_run_sync":
+                continue
+
+            # Build the dotted name of the callee
+            callee = _dotted(child.func)
+            if callee and any(callee.startswith(p) for p in blocked_prefixes):
+                # Make sure it is NOT the first arg of an enclosing _run_sync
+                if not _is_arg_of_run_sync(child, source):
+                    bad_calls.append(callee)
+
+        if bad_calls:
+            violations.append((node.name, bad_calls))
+
+    return violations
+
+
+def _dotted(node) -> str | None:
+    """Reconstruct a dotted name from an AST node (``a.b.c``)."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _is_arg_of_run_sync(call_node: ast.Call, source: str) -> bool:
+    """
+    Return True if *call_node*'s function reference appears as the first
+    positional argument of a ``_run_sync(...)`` call.  We do this by
+    re-walking from the module root and checking enclosing Call nodes.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_run_sync = (isinstance(func, ast.Name) and func.id == "_run_sync") or (
+            isinstance(func, ast.Attribute) and func.attr == "_run_sync"
+        )
+        if not is_run_sync:
+            continue
+        # The blocked method reference is passed as the first positional arg
+        # (not called directly), so there should be no Call node wrapping it
+        # inside _run_sync — the Call is _run_sync itself.
+        # We just need to verify our detected call_node IS _run_sync's Call.
+        # Since AST nodes are unique objects we cannot match by identity after
+        # a re-parse, so we match by line + col.
+        if node.lineno == call_node.lineno and node.col_offset == call_node.col_offset:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+MODULES_AND_PREFIXES = [
+    (
+        "inferia.services.orchestration.services.adapter_engine.adapters.k8s.k8s_adapter",
+        ["self.core"],
+    ),
+    (
+        "inferia.services.orchestration.services.llmd_runtime.client",
+        ["self.api"],
+    ),
+    (
+        "inferia.services.orchestration.infra.k8s_llmd_client",
+        ["self.api"],
+    ),
+]
+
+
+@pytest.mark.parametrize("module,prefixes", MODULES_AND_PREFIXES)
+def test_no_blocking_k8s_calls_in_async_methods(module, prefixes):
+    """Every self.core.* / self.api.* call in an async def must go through _run_sync."""
+    source = _get_source(module)
+    violations = _async_methods_with_blocking_calls(source, prefixes)
+    if violations:
+        report = "\n".join(
+            f"  {method}: {', '.join(calls)}" for method, calls in violations
+        )
+        pytest.fail(
+            f"Blocking K8s calls found in async methods of {module}:\n{report}"
+        )


### PR DESCRIPTION
## Summary
- All K8s client calls were synchronous inside async methods, blocking the event loop
- Added `_run_sync` helper using `loop.run_in_executor(None, ...)` to each file
- Wrapped all 14 blocking calls across 3 files

## Test plan
- [x] AST-based test verifying no direct K8s API calls exist outside `_run_sync`
- [x] All tests pass locally on Python 3.12.9

Closes #39