### PR TITLE
Fix login crash: add missing org_id column to audit_logs

### DIFF
--- a/package/src/inferia/infra/schema/global_schema.sql
+++ b/package/src/inferia/infra/schema/global_schema.sql
@@ -583,12 +583,14 @@ CREATE TABLE audit_logs (
     resource_id VARCHAR, 
     details JSON, 
     ip_address VARCHAR, 
-    status VARCHAR NOT NULL, 
-    PRIMARY KEY (id), 
+    status VARCHAR NOT NULL,
+    org_id VARCHAR,
+    PRIMARY KEY (id),
     FOREIGN KEY(user_id) REFERENCES users (id)
 );
 CREATE INDEX ix_audit_logs_user_id ON audit_logs (user_id);
 CREATE INDEX ix_audit_logs_action ON audit_logs (action);
+CREATE INDEX ix_audit_logs_org_id ON audit_logs (org_id);
 
 CREATE TABLE system_settings (
     key VARCHAR NOT NULL, 

--- a/package/src/inferia/infra/schema/migrations/20260318_add_audit_logs_org_id.sql
+++ b/package/src/inferia/infra/schema/migrations/20260318_add_audit_logs_org_id.sql
@@ -1,0 +1,3 @@
+-- Add org_id column to audit_logs table for organization-scoped audit tracking
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS org_id VARCHAR;
+CREATE INDEX IF NOT EXISTS ix_audit_logs_org_id ON audit_logs (org_id);


### PR DESCRIPTION
## Summary

- The `AuditLog` ORM model references `org_id` but the column was missing from `global_schema.sql`, causing `UndefinedColumnError` on every login attempt (audit logging fires after authentication).
- Adds `org_id VARCHAR` + index to `audit_logs` in `global_schema.sql` (fresh installs).
- Adds migration `20260318_add_audit_logs_org_id.sql` for existing databases (uses the migration runner from #156).

## Test plan

- [x] All 130 API gateway tests pass
- [x] Deploy via `docker compose up` — verify login succeeds without `UndefinedColumnError`