### PR TITLE
Fix env var collision between dashboard and backend service URLs

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -46,10 +46,12 @@ services:
     env_file: .env
     environment:
       - SERVICE_TYPE=unified
-      - API_GATEWAY_URL=${API_GATEWAY_URL:-}
-      - INFERENCE_URL=${INFERENCE_URL:-}
-      - WEB_SOCKET_URL=${WEB_SOCKET_URL:-}
-      - SIDECAR_URL=${SIDECAR_URL:-}
+      # Dashboard frontend URLs (DASHBOARD_ prefix avoids colliding with
+      # backend service URL env vars like INFERENCE_URL used by Pydantic config)
+      - DASHBOARD_API_GATEWAY_URL=${API_GATEWAY_URL:-}
+      - DASHBOARD_INFERENCE_URL=${INFERENCE_URL:-}
+      - DASHBOARD_WEB_SOCKET_URL=${WEB_SOCKET_URL:-}
+      - DASHBOARD_SIDECAR_URL=${SIDECAR_URL:-}
       - LOGSTASH_HOST=${LOGSTASH_HOST:-}
       - LOGSTASH_PORT=${LOGSTASH_PORT:-5959}
       - FORWARDED_ALLOW_IPS=${FORWARDED_ALLOW_IPS:-}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,10 +48,12 @@ services:
       - POSTGRES_DSN=postgresql://inferia:inferia@inferia-postgres:5432/inferia
       - REDIS_URL=redis://inferia-redis:6379/0
       - SERVICE_TYPE=unified
-      - API_GATEWAY_URL=${API_GATEWAY_URL:-}
-      - INFERENCE_URL=${INFERENCE_URL:-}
-      - WEB_SOCKET_URL=${WEB_SOCKET_URL:-}
-      - SIDECAR_URL=${SIDECAR_URL:-}
+      # Dashboard frontend URLs (DASHBOARD_ prefix avoids colliding with
+      # backend service URL env vars like INFERENCE_URL used by Pydantic config)
+      - DASHBOARD_API_GATEWAY_URL=${API_GATEWAY_URL:-}
+      - DASHBOARD_INFERENCE_URL=${INFERENCE_URL:-}
+      - DASHBOARD_WEB_SOCKET_URL=${WEB_SOCKET_URL:-}
+      - DASHBOARD_SIDECAR_URL=${SIDECAR_URL:-}
       - LOGSTASH_HOST=${LOGSTASH_HOST:-}
       - LOGSTASH_PORT=${LOGSTASH_PORT:-5959}
       - FORWARDED_ALLOW_IPS=${FORWARDED_ALLOW_IPS:-}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,15 +4,18 @@ set -e
 # Generate runtime config for the dashboard from env vars.
 # This allows the pre-built image to work with any endpoint URLs
 # specified at container run time instead of build time.
+# Dashboard runtime config uses DASHBOARD_* prefixed env vars to avoid
+# colliding with backend service URL env vars (e.g. INFERENCE_URL).
+# Falls back to the unprefixed names for backward compatibility.
 DASHBOARD_DIR=$(python -c "import inferia, os; print(os.path.join(inferia.__path__[0], 'dashboard'))" 2>/dev/null || true)
 if [ -d "$DASHBOARD_DIR" ]; then
   python3 -c "
 import json, os
 config = {
-    'API_GATEWAY_URL': os.environ.get('API_GATEWAY_URL', ''),
-    'INFERENCE_URL': os.environ.get('INFERENCE_URL', ''),
-    'WEB_SOCKET_URL': os.environ.get('WEB_SOCKET_URL', ''),
-    'SIDECAR_URL': os.environ.get('SIDECAR_URL', ''),
+    'API_GATEWAY_URL': os.environ.get('DASHBOARD_API_GATEWAY_URL', '') or os.environ.get('API_GATEWAY_URL', ''),
+    'INFERENCE_URL': os.environ.get('DASHBOARD_INFERENCE_URL', '') or os.environ.get('INFERENCE_URL', ''),
+    'WEB_SOCKET_URL': os.environ.get('DASHBOARD_WEB_SOCKET_URL', '') or os.environ.get('WEB_SOCKET_URL', ''),
+    'SIDECAR_URL': os.environ.get('DASHBOARD_SIDECAR_URL', '') or os.environ.get('SIDECAR_URL', ''),
 }
 print('window.__RUNTIME_CONFIG__ = ' + json.dumps(config) + ';')
 " > "$DASHBOARD_DIR/config.js"


### PR DESCRIPTION
## Summary
- Dashboard frontend config and API gateway backend Pydantic settings both consumed the same env vars (`INFERENCE_URL`, `API_GATEWAY_URL`, etc.), causing the backend to route internal service requests to external URLs instead of `localhost`
- Prefixed dashboard-specific env vars with `DASHBOARD_` in both `docker-compose.yml` files and updated `entrypoint.sh` to read the prefixed vars (with unprefixed fallback for backward compatibility)
- This fixes persistent "Proxy request failed: All connection attempts failed" errors in unified mode when `.env` sets external URLs for the dashboard

## Test plan
- [ ] Deploy with `docker compose up` using `.env` with `INFERENCE_URL` / `API_GATEWAY_URL` set to external URLs
- [ ] Verify API gateway proxy routes connect to internal services (no "All connection attempts failed")
- [ ] Verify dashboard `config.js` still picks up the correct external URLs
- [ ] Verify backward compatibility: deployment without `DASHBOARD_*` vars still works