### PR TITLE
fix: make SkyPilot optional and log service startup failures

### DIFF
--- a/package/src/inferia/cli.py
+++ b/package/src/inferia/cli.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import multiprocessing
+import traceback
 from inferia.startup_ui import StartupUI
 from dotenv import load_dotenv, find_dotenv
 from inferia.inferiadocs import (
@@ -44,10 +45,10 @@ def run_api_gateway_service(queue=None):
             )
         start_api()
     except Exception as e:
+        print(f"[FATAL] API Gateway Service failed to start: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         if queue:
             queue.put(ServiceFailed("API Gateway Service", error=str(e)))
-        else:
-            print(f"Error starting API Gateway Service: {e}")
 
 
 def run_guardrail_service(queue=None):
@@ -66,10 +67,10 @@ def run_guardrail_service(queue=None):
 
         start_api()
     except Exception as e:
+        print(f"[FATAL] Guardrail Service failed to start: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         if queue:
             queue.put(ServiceFailed("Guardrail Service", error=str(e)))
-        else:
-            print(f"Error starting Guardrail Service: {e}")
 
 
 def run_data_service(queue=None):
@@ -86,10 +87,10 @@ def run_data_service(queue=None):
 
         start_api()
     except Exception as e:
+        print(f"[FATAL] Data Service failed to start: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         if queue:
             queue.put(ServiceFailed("Data Service", error=str(e)))
-        else:
-            print(f"Error starting Data Service: {e}")
 
 
 def run_inference_service(queue=None):
@@ -106,10 +107,10 @@ def run_inference_service(queue=None):
             )
         start_api()
     except Exception as e:
+        print(f"[FATAL] Inference Service failed to start: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         if queue:
             queue.put(ServiceFailed("Inference Service", error=str(e)))
-        else:
-            print(f"Error starting Inference Service: {e}")
 
 
 def run_orchestration_service(queue=None):
@@ -126,10 +127,10 @@ def run_orchestration_service(queue=None):
             )
         start_api()
     except Exception as e:
+        print(f"[FATAL] Orchestration Service failed to start: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         if queue:
             queue.put(ServiceFailed("Orchestration Service", error=str(e)))
-        else:
-            print(f"Error starting Orchestration Service: {e}")
 
 
 def run_worker(queue=None):
@@ -151,10 +152,10 @@ def run_worker(queue=None):
             )
         asyncio.run(main())
     except Exception as e:
+        print(f"[FATAL] Orchestration Worker failed to start: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         if queue:
             queue.put(ServiceFailed("Orchestration Worker", error=str(e)))
-        else:
-            print(f"Error starting Orchestration Worker: {e}")
 
 
 def run_nosana_sidecar(queue=None, env: str = "production"):

--- a/package/src/inferia/services/orchestration/services/adapter_engine/registry.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/registry.py
@@ -1,27 +1,40 @@
-# from services.adapter_engine.adapters.aws.aws_adapter import AWSAdapter
+import importlib.util
+import logging
+
 from inferia.services.orchestration.services.adapter_engine.adapters.nosana.nosana_adapter import (
     NosanaAdapter,
 )
 from inferia.services.orchestration.services.adapter_engine.adapters.k8s.k8s_adapter import (
     KubernetesAdapter,
 )
-from inferia.services.orchestration.services.adapter_engine.adapters.skypilot.skypilot_adapter import (
-    SkyPilotAdapter,
-)
 from inferia.services.orchestration.services.adapter_engine.adapters.akash.akash_adapter import (
     AkashAdapter,
 )
 
+logger = logging.getLogger(__name__)
+
 ADAPTER_REGISTRY = {
-    "aws": SkyPilotAdapter,
-    "gcp": SkyPilotAdapter,
-    "azure": SkyPilotAdapter,
-    "lambda": SkyPilotAdapter,
-    "runpod": SkyPilotAdapter,
     "nosana": NosanaAdapter,
     "k8s": KubernetesAdapter,
     "akash": AkashAdapter,
 }
+
+_SKYPILOT_PROVIDERS = ("aws", "gcp", "azure", "lambda", "runpod")
+_skypilot_available = importlib.util.find_spec("sky") is not None
+
+# Register SkyPilot-based cloud adapters only when the 'sky' package is installed
+if _skypilot_available:
+    from inferia.services.orchestration.services.adapter_engine.adapters.skypilot.skypilot_adapter import (
+        SkyPilotAdapter,
+    )
+
+    for _provider in _SKYPILOT_PROVIDERS:
+        ADAPTER_REGISTRY[_provider] = SkyPilotAdapter
+else:
+    logger.warning(
+        "SkyPilot is not installed — cloud provider adapters (aws, gcp, azure, lambda, runpod) "
+        "are unavailable. Install with: pip install 'skypilot[gcp]'"
+    )
 
 
 def get_adapter(provider: str):
@@ -37,13 +50,18 @@ def get_adapter(provider: str):
     Raises:
         ValueError: If provider is not registered
     """
+    if not _skypilot_available and provider in _SKYPILOT_PROVIDERS:
+        raise ValueError(
+            f"Provider '{provider}' requires SkyPilot which is not installed. "
+            f"Install with: pip install 'skypilot[{provider}]'"
+        )
     adapter_cls = ADAPTER_REGISTRY.get(provider)
     if not adapter_cls:
         raise ValueError(
             f"No adapter registered for provider '{provider}'. "
             f"Available providers: {list(ADAPTER_REGISTRY.keys())}"
         )
-    if adapter_cls is SkyPilotAdapter:
+    if _skypilot_available and adapter_cls is SkyPilotAdapter:
         return adapter_cls(cloud=provider)
     return adapter_cls()
 


### PR DESCRIPTION
## Summary
- **SkyPilot import crash fix**: `registry.py` now conditionally imports SkyPilot adapter using `importlib.util.find_spec("sky")`. Cloud provider adapters (aws, gcp, azure, lambda, runpod) are only registered when SkyPilot is installed. Without it, the orchestration service starts normally with a warning instead of crashing.
- **Error swallowing fix**: All service runner functions in `cli.py` now print `[FATAL]` messages with full tracebacks to stderr when a service fails to start. Previously, errors in multiprocessing child processes were only sent to a queue that was never read, making crashes invisible in `docker logs`.

## Test plan
- [ ] Deploy via Docker Compose without SkyPilot installed — orchestration service should start, logs should show warning about unavailable cloud adapters
- [ ] Intentionally break a service import and verify the full traceback appears in `docker logs`
- [ ] Verify nosana/k8s/akash adapters still work without SkyPilot