### PR TITLE
fix: resolve 19 test collection errors and 2 test failures

### DIFF
--- a/package/src/inferia/services/api_gateway/tests/test_guardrail_proceed.py
+++ b/package/src/inferia/services/api_gateway/tests/test_guardrail_proceed.py
@@ -1,8 +1,8 @@
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from guardrail.engine import GuardrailEngine
-from guardrail.models import GuardrailResult, Violation
+from inferia.services.guardrail.engine import GuardrailEngine
+from inferia.services.guardrail.models import GuardrailResult, Violation
 
 @pytest.mark.asyncio
 async def test_proceed_on_violation():

--- a/package/src/inferia/services/orchestration/infra/test_setup.py
+++ b/package/src/inferia/services/orchestration/infra/test_setup.py
@@ -1,0 +1,81 @@
+import uuid
+import json
+import grpc
+
+from inferia.services.orchestration.v1 import scheduler_pb2_grpc
+
+
+def uid():
+    return uuid.uuid4().hex[:8]
+
+
+async def scheduler_stub():
+    channel = grpc.aio.insecure_channel("localhost:50051")
+    return scheduler_pb2_grpc.SchedulerStub(channel)
+
+
+async def create_test_pool(db, provider="k8s"):
+    pool_name = f"test-pool-{uid()}"
+    pool_id = await db.fetchval(
+        """
+        INSERT INTO compute_pools (
+          pool_name,
+          owner_type,
+          owner_id,
+          provider,
+          scheduling_policy,
+          autoscaling_policy
+        )
+        VALUES (
+          $1,
+          'system',
+          'system',
+          $2,
+          '{"strategy":"best_fit"}',
+          $3
+        )
+        RETURNING id
+        """,
+        pool_name,
+        provider,
+        json.dumps({
+            "enabled": False,
+            "min_nodes": 0,
+            "max_nodes": 10,
+            "scale_up_threshold": 0.8,
+            "scale_down_threshold": 0.2,
+            "cooldown_seconds": 0,
+        }),
+    )
+    return pool_id
+
+
+async def create_ready_node(db, pool_id, vcpu=2, ram_gb=4, gpu=0, provider="k8s"):
+    node_id = await db.fetchval(
+        """
+        INSERT INTO compute_inventory (
+          pool_id,
+          provider,
+          provider_instance_id,
+          state,
+          gpu_total, gpu_allocated,
+          vcpu_total, vcpu_allocated,
+          ram_gb_total, ram_gb_allocated
+        )
+        VALUES (
+          $1, $2, $3,
+          'ready',
+          $4, 0,
+          $5, 0,
+          $6, 0
+        )
+        RETURNING id
+        """,
+        pool_id,
+        provider,
+        f"test-node-{uid()}",
+        gpu,
+        vcpu,
+        ram_gb,
+    )
+    return node_id

--- a/package/src/inferia/services/orchestration/provisioning/skypilot.py
+++ b/package/src/inferia/services/orchestration/provisioning/skypilot.py
@@ -6,13 +6,11 @@ from inferia.services.orchestration.provisioning.base import Provisioner
 logger = logging.getLogger(__name__)
 
 
-if os.getenv("INFERIA_ENV") != "container":
-    raise RuntimeError("SkyPilot provisioner must run in container")
-
-
 class SkyPilotProvisioner(Provisioner):
 
     async def provision(self, request) -> str:
+        if os.getenv("INFERIA_ENV") != "container":
+            raise RuntimeError("SkyPilot provisioner must run in container")
         try:
             import sky
         except ImportError as e:

--- a/package/src/inferia/services/orchestration/services/adapter_stub.py
+++ b/package/src/inferia/services/orchestration/services/adapter_stub.py
@@ -1,0 +1,28 @@
+class FakeAdapterStub:
+    """
+    In-memory adapter stub for testing autoscaler and other components
+    that call provision_node / deprovision_node.
+    """
+
+    def __init__(self):
+        self.provision_calls = []
+        self.deprovision_calls = []
+
+    async def provision_node(self, *, provider, provider_resource_id, pool_id, **kwargs):
+        self.provision_calls.append({
+            "provider": provider,
+            "provider_resource_id": provider_resource_id,
+            "pool_id": pool_id,
+            **kwargs,
+        })
+        return {
+            "provider": provider,
+            "provider_instance_id": f"fake-{pool_id}",
+        }
+
+    async def deprovision_node(self, *, provider, provider_instance_id, **kwargs):
+        self.deprovision_calls.append({
+            "provider": provider,
+            "provider_instance_id": provider_instance_id,
+            **kwargs,
+        })

--- a/package/src/inferia/services/orchestration/test/compute_pools_nodes/test_fake_adapter.py
+++ b/package/src/inferia/services/orchestration/test/compute_pools_nodes/test_fake_adapter.py
@@ -1,7 +1,7 @@
 import asyncio
 import grpc
 
-from inferia.services.orchestration.services.adapters.base.adapter import ProviderAdapter
+from inferia.services.orchestration.services.adapter_engine.adapters.base.adapter import ProviderAdapter
 from inferia.services.orchestration.v1 import compute_node_pb2, compute_node_pb2_grpc
 
 

--- a/package/src/inferia/services/orchestration/test/provisioning/test_skypilot_provisioner.py
+++ b/package/src/inferia/services/orchestration/test/provisioning/test_skypilot_provisioner.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import sys
 from unittest.mock import MagicMock
@@ -18,6 +19,7 @@ async def test_provision_success(mocker, caplog):
     # Inject fake sky module BEFORE provision() imports it
     mock_sky = MagicMock()
     mocker.patch.dict(sys.modules, {"sky": mock_sky})
+    mocker.patch.dict(os.environ, {"INFERIA_ENV": "container"})
 
     caplog.set_level("INFO")
 
@@ -33,6 +35,7 @@ async def test_provision_failure(mocker):
     mock_sky = MagicMock()
     mock_sky.launch.side_effect = Exception("SkyPilot internal error")
     mocker.patch.dict(sys.modules, {"sky": mock_sky})
+    mocker.patch.dict(os.environ, {"INFERIA_ENV": "container"})
 
     provisioner = SkyPilotProvisioner()
 

--- a/package/src/inferia/services/orchestration/test/test_aws_realtime_capacity.py
+++ b/package/src/inferia/services/orchestration/test/test_aws_realtime_capacity.py
@@ -1,6 +1,8 @@
-import boto3
-from collections import defaultdict
+import pytest
+boto3 = pytest.importorskip("boto3")
+tabulate_mod = pytest.importorskip("tabulate")
 from tabulate import tabulate
+from collections import defaultdict
 
 from aws_instance_specs import INSTANCE_SPECS
 from dotenv import load_dotenv

--- a/package/src/inferia/services/orchestration/test/test_grpc.py
+++ b/package/src/inferia/services/orchestration/test/test_grpc.py
@@ -6,7 +6,7 @@ from inferia.services.orchestration.v1 import compute_node_pb2, compute_node_pb2
 
 async def test():
     async with aio.insecure_channel("localhost:50051") as channel:
-        stub = compute_pool_pb2_grpc.ComputePoolServiceStub(channel)
+        stub = compute_pool_pb2_grpc.ComputePoolManagerStub(channel)
 
         pool = await stub.RegisterPool(
             compute_pool_pb2.RegisterPoolRequest(
@@ -22,4 +22,5 @@ async def test():
         print("All pools:", pools)
 
 
-asyncio.run(test())
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/package/src/inferia/tests/test_entrypoint_config_escaping.py
+++ b/package/src/inferia/tests/test_entrypoint_config_escaping.py
@@ -71,8 +71,8 @@ class TestEntrypointConfigEscaping:
     def test_normal_urls_work(self):
         """Normal URL values produce valid config."""
         js = generate_config_js({
-            "API_GATEWAY_URL": "https://api.example.com",
-            "INFERENCE_URL": "https://inference.example.com",
+            "DASHBOARD_API_GATEWAY_URL": "https://api.example.com",
+            "DASHBOARD_INFERENCE_URL": "https://inference.example.com",
         })
         assert "https://api.example.com" in js
         assert "https://inference.example.com" in js
@@ -80,7 +80,7 @@ class TestEntrypointConfigEscaping:
     def test_double_quotes_in_env_var_escaped(self):
         """Double quotes in env var must not break the JS string."""
         js = generate_config_js({
-            "API_GATEWAY_URL": 'https://evil.com", injected: "pwned',
+            "DASHBOARD_API_GATEWAY_URL": 'https://evil.com", injected: "pwned',
         })
         # The output must NOT contain an unescaped injection that creates
         # a separate JS property
@@ -89,7 +89,7 @@ class TestEntrypointConfigEscaping:
     def test_backslash_in_env_var_escaped(self):
         """Backslashes must not produce broken JS."""
         js = generate_config_js({
-            "API_GATEWAY_URL": "C:\\Users\\test\\path",
+            "DASHBOARD_API_GATEWAY_URL": "C:\\Users\\test\\path",
         })
         assert "window.__RUNTIME_CONFIG__" in js
 


### PR DESCRIPTION
## Summary
- **Fixed 19 pytest collection errors** — tests that couldn't even be imported due to wrong paths, missing modules, or module-level side effects
- **Fixed 2 test failures** — `test_skypilot_provisioner` (env check blocking import) and `test_entrypoint_config_escaping` (stale env var names after DASHBOARD_ prefix migration)
- **Result**: 553 passed, 1 skipped (boto3 not installed). Remaining 23 failures are orchestration integration tests that require a running PostgreSQL + gRPC server

### Changes
- Fix import paths: `guardrail.engine` → `inferia.services.guardrail.engine`, `services.adapters` → `services.adapter_engine.adapters`
- Fix gRPC stub name: `ComputePoolServiceStub` → `ComputePoolManagerStub`
- Create missing `infra/test_setup.py` (shared test utilities: `uid`, `scheduler_stub`, `create_test_pool`, `create_ready_node`)
- Create missing `services/adapter_stub.py` (`FakeAdapterStub` for autoscaler tests)
- Skip `test_aws_realtime_capacity` when `boto3` is not installed
- Move `skypilot.py` env check from module level to `provision()` method
- Update entrypoint escaping test to use `DASHBOARD_*` prefixed env vars

## Test plan
- [x] `make test` — 553 passed, 1 skipped, 0 collection errors