### PR TITLE
Fix Nosana API key overwritten with masked placeholder on config save

### DIFF
--- a/apps/dashboard/src/pages/Settings/Providers/ProviderConfig.tsx
+++ b/apps/dashboard/src/pages/Settings/Providers/ProviderConfig.tsx
@@ -124,15 +124,10 @@ export default function ProviderConfigPage() {
             const keys = await ConfigService.listNosanaApiKeys();
             dispatch({ type: 'SET_FIELD', field: 'nosanaApiKeys', value: keys });
 
-            // Sync with main config to prevent stale data when saving main config
-            // Note: nosanaApiKeys doesn't have the full secret 'key', but the backend
-            // merge logic now handles masked values by preserving existing unmasked ones.
-            const apiKeyEntries = keys.map(k => ({
-                name: k.name,
-                key: "********", // Placeholder to let backend know we have this key
-                is_active: k.is_active
-            }));
-            dispatch({ type: 'UPDATE_CONFIG', path: ['depin', 'nosana', 'api_keys'], value: apiKeyEntries });
+            // Don't sync api_keys into the main config state — they are managed
+            // separately via addNosanaApiKey/deleteNosanaApiKey and should not be
+            // included when saving the provider config form, as the backend merge
+            // would overwrite real keys with placeholder values.
         } catch (e) {
             toast.error("Failed to load Nosana API keys");
         } finally {
@@ -190,7 +185,11 @@ export default function ProviderConfigPage() {
         e.preventDefault();
         dispatch({ type: 'SET_FIELD', field: 'saving', value: true });
         try {
-            await ConfigService.updateProviderConfig(config);
+            // Strip api_keys from nosana config — they are managed separately
+            // and would overwrite real keys with masked/stale values
+            const safeConfig = structuredClone(config);
+            delete (safeConfig.depin.nosana as any).api_keys;
+            await ConfigService.updateProviderConfig(safeConfig);
             toast.success("Configuration saved successfully");
             dispatch({ type: 'SET_FIELD', field: 'isConfigured', value: true });
             dispatch({ type: 'SET_FIELD', field: 'isEditing', value: false });

--- a/package/src/inferia/services/api_gateway/management/config_manager.py
+++ b/package/src/inferia/services/api_gateway/management/config_manager.py
@@ -148,14 +148,14 @@ class ConfigManager(BaseConfigManager):
                 # Merge dict contents to handle masked keys/values
                 for k, v in new_item.items():
                     # Handle specific secret keys: 'key' for nosana, 'value' for universal, 'mnemonic' for akash
-                    if (
-                        k in ["key", "value", "mnemonic"]
-                        and isinstance(v, str)
-                        and "..." in v
-                    ):
-                        existing_val = existing_item.get(k)
-                        if existing_val and v == self._mask_secret(existing_val):
-                            continue  # Skip updating this masked field
+                    if k in ["key", "value", "mnemonic"] and isinstance(v, str):
+                        # Skip any masked/placeholder value — preserve the real secret
+                        if v == "********" or "*" * 4 in v:
+                            continue
+                        if "..." in v:
+                            existing_val = existing_item.get(k)
+                            if existing_val and v == self._mask_secret(existing_val):
+                                continue
                     existing_item[k] = v
             else:
                 # It's a brand new item in this list


### PR DESCRIPTION
## Summary
- Dashboard synced `api_keys` into config state with `key: "********"` placeholder
- On save, this placeholder was sent to the backend merge logic
- `_merge_credential_lists` only detected `"..."` as masked — `"********"` passed through and **overwrote the real API key** in the DB
- Sidecar then sent `Authorization: Bearer ********` to Nosana → 401 Unauthorized

## Fix
- **Backend** (`config_manager.py`): `_merge_credential_lists` now also skips values containing `"****"`
- **Dashboard** (`ProviderConfig.tsx`): Strip `api_keys` from config before saving — they are managed separately via dedicated add/delete endpoints and should never be included in the bulk config save

## Test plan
- [x] Verified: `"********"` no longer overwrites real keys in merge
- [x] Verified: `"nos_...aZ5g"` mask format still preserved
- [x] Verified: Real key updates still applied
- [x] Dashboard builds successfully
- [x] All 131 API gateway tests pass