### PR TITLE
fix: hold outbox transaction open through publish cycle

### DIFF
--- a/package/src/inferia/services/orchestration/repositories/outbox_repo.py
+++ b/package/src/inferia/services/orchestration/repositories/outbox_repo.py
@@ -1,10 +1,10 @@
 # app/repositories/outbox_repo.py
 
 import json
-from typing import List
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, List, Tuple
 from uuid import UUID
 
-# from datetime import datetime
 from inferia.services.orchestration.repositories.base_repo import BaseRepository
 
 
@@ -59,21 +59,29 @@ class OutboxRepository(BaseRepository):
         )
 
     # -------------------------------------------------
-    # READ (used by outbox worker)
+    # READ + PROCESS (used by outbox worker)
     # -------------------------------------------------
-    async def fetch_pending(
+    @asynccontextmanager
+    async def fetch_and_lock(
         self,
         *,
         limit: int = 100,
-    ) -> List[dict]:
+    ) -> AsyncGenerator[Tuple[List[dict], "object"], None]:
         """
-        Fetch pending events for publishing.
+        Fetch pending events inside a held transaction.
 
-        Uses FOR UPDATE SKIP LOCKED inside an explicit transaction so that
-        row-level locks are held until the transaction commits, preventing
-        concurrent workers from picking the same events.
+        Yields (events, conn) — the transaction stays open so that
+        FOR UPDATE SKIP LOCKED locks are held until the caller finishes
+        marking events as published/failed and the context manager exits.
+
+        Usage::
+
+            async with repo.fetch_and_lock(limit=50) as (events, conn):
+                for event in events:
+                    await publish(event)
+                    await repo.mark_published_on(conn, event_id=event["id"])
+            # transaction commits here, locks released
         """
-
         async with self.db.acquire() as conn:
             async with conn.transaction():
                 rows = await conn.fetch(
@@ -91,21 +99,78 @@ class OutboxRepository(BaseRepository):
                     """,
                     limit,
                 )
+                yield [dict(r) for r in rows], conn
 
+    async def fetch_pending(
+        self,
+        *,
+        limit: int = 100,
+    ) -> List[dict]:
+        """
+        Fetch pending events (legacy convenience method).
+
+        WARNING: locks are released when this returns. Prefer
+        fetch_and_lock() for the publish loop.
+        """
+        async with self.db.acquire() as conn:
+            async with conn.transaction():
+                rows = await conn.fetch(
+                    """
+                    SELECT id,
+                           aggregate_type,
+                           aggregate_id,
+                           event_type,
+                           payload
+                    FROM outbox_events
+                    WHERE status = 'PENDING'
+                    ORDER BY created_at ASC
+                    LIMIT $1
+                    FOR UPDATE SKIP LOCKED
+                    """,
+                    limit,
+                )
         return [dict(r) for r in rows]
 
     # -------------------------------------------------
-    # MARK PUBLISHED
+    # MARK helpers (connection-bound for use inside fetch_and_lock)
+    # -------------------------------------------------
+    @staticmethod
+    async def mark_published_on(conn, *, event_id: UUID) -> None:
+        """Mark event as published using the given connection (same txn)."""
+        await conn.execute(
+            """
+            UPDATE outbox_events
+            SET status = 'PUBLISHED',
+                published_at = now()
+            WHERE id = $1
+            """,
+            event_id,
+        )
+
+    @staticmethod
+    async def mark_failed_on(conn, *, event_id: UUID, error: str) -> None:
+        """Mark event as failed using the given connection (same txn)."""
+        error_str = str(error)[:1024] if error else ""
+        await conn.execute(
+            """
+            UPDATE outbox_events
+            SET status = 'FAILED',
+                error = $2,
+                updated_at = now()
+            WHERE id = $1
+            """,
+            event_id,
+            error_str,
+        )
+
+    # -------------------------------------------------
+    # MARK PUBLISHED (pool-level, legacy)
     # -------------------------------------------------
     async def mark_published(
         self,
         *,
         event_id: UUID,
     ) -> None:
-        """
-        Mark event as successfully published.
-        """
-
         await self.db.execute(
             """
             UPDATE outbox_events
@@ -125,11 +190,7 @@ class OutboxRepository(BaseRepository):
         event_id: UUID,
         error: str,
     ) -> None:
-        """
-        Mark event as failed but retryable.
-        """
         error_str = str(error)[:1024] if error else ""
-
         await self.db.execute(
             """
             UPDATE outbox_events
@@ -151,11 +212,7 @@ class OutboxRepository(BaseRepository):
         event_id: UUID,
         error: str,
     ) -> None:
-        """
-        Mark event as dead (manual intervention required).
-        """
         error_str = str(error)[:1024] if error else ""
-
         await self.db.execute(
             """
             UPDATE outbox_events

--- a/package/src/inferia/services/orchestration/services/eventing/outbox_publisher.py
+++ b/package/src/inferia/services/orchestration/services/eventing/outbox_publisher.py
@@ -10,51 +10,32 @@ async def outbox_publisher_loop(db, event_bus, *, batch_size=50, interval=0.5):
     """
     Reliable outbox publisher.
     Must run as a background task in the orchestration service.
+
+    Uses fetch_and_lock so that FOR UPDATE SKIP LOCKED row locks are
+    held for the entire publish cycle, preventing duplicate delivery.
     """
     repo = OutboxRepository(db)
     logger.info("Outbox publisher started")
 
     while True:
         try:
-            # explicit transaction handling is done inside fetch_pending via DB pool if needed,
-            # but here we pass the pool directly. OutboxRepository usually takes a pool or connection.
-            # Checking base_repo.py, it takes 'db'.
-            # fetch_pending uses self.db.fetch, so passing pool is fine.
-            
-            # Additional transaction is needed for atomic mark_published if we were doing complex things,
-            # but fetch_pending uses FOR UPDATE SKIP LOCKED, so we should commit promptly.
-            # However, the repo methods are designed to be called; fetch_pending returns dicts.
-            
-            # We need a strategy: fetch pending, publish each, mark as published.
-            # Ideally we mark published AFTER successful publish.
-            
-            async with db.acquire() as conn:
-                # We use a repo instance bound to the connection for this batch
-                # wait, OutboxRepository takes 'db' in init. 
-                # If we pass pool, it uses pool. If we pass conn, it uses conn.
-                repo_conn = OutboxRepository(conn)
-                
-                # Fetch pending (locks rows)
-                events = await repo_conn.fetch_pending(limit=batch_size)
-                
+            async with repo.fetch_and_lock(limit=batch_size) as (events, conn):
                 for event in events:
                     try:
                         await event_bus.publish(
                             event["event_type"],
                             event["payload"],
                         )
-                        await repo_conn.mark_published(event_id=event["id"])
+                        await OutboxRepository.mark_published_on(
+                            conn, event_id=event["id"]
+                        )
                     except Exception as e:
-                        logger.error(f"Failed to publish event {event['id']}: {e}")
-                        # Optionally mark failed or retry later. 
-                        # For now, we just log and it will be picked up again if we didn't update status,
-                        # OR we should mark it failed/retryable if we want to avoid head-of-line blocking.
-                        # The original code didn't handle failure updates, just caught exception loop-wide.
-                        # We will skip marking published so it retries, but we should be careful about poison pills.
-                        pass
+                        logger.error("Failed to publish event %s: %s", event["id"], e)
+                        await OutboxRepository.mark_failed_on(
+                            conn, event_id=event["id"], error=str(e)
+                        )
 
         except Exception as e:
-            # Never crash the process
             logger.exception("Outbox publisher failure: %s", e)
 
         await asyncio.sleep(interval)

--- a/package/src/inferia/services/orchestration/test/test_outbox_transaction.py
+++ b/package/src/inferia/services/orchestration/test/test_outbox_transaction.py
@@ -116,3 +116,74 @@ class TestOutboxFetchPendingTransaction:
         assert isinstance(result, list)
         assert len(result) == 1
         assert result[0]["id"] == 1
+
+
+class TestFetchAndLock:
+    """Verify fetch_and_lock keeps the transaction open through mark_published."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_and_lock_yields_connection(self):
+        """fetch_and_lock should yield (events, conn) inside a transaction."""
+        pool, mock_conn, tx_ctx = _make_mock_pool()
+        repo = OutboxRepository(pool)
+
+        async with repo.fetch_and_lock(limit=10) as (events, conn):
+            assert conn is mock_conn
+
+    @pytest.mark.asyncio
+    async def test_transaction_open_inside_context(self):
+        """Transaction must remain open while inside the context manager."""
+        pool, mock_conn, tx_ctx = _make_mock_pool()
+        repo = OutboxRepository(pool)
+
+        async with repo.fetch_and_lock(limit=10) as (events, conn):
+            # tx_ctx entered but not exited yet
+            assert tx_ctx.entered
+            assert not tx_ctx.exited
+
+        # Now it should have exited
+        assert tx_ctx.exited
+
+    @pytest.mark.asyncio
+    async def test_mark_published_on_uses_given_connection(self):
+        """mark_published_on must execute on the provided connection."""
+        from uuid import uuid4
+
+        conn = AsyncMock()
+        event_id = uuid4()
+
+        await OutboxRepository.mark_published_on(conn, event_id=event_id)
+
+        conn.execute.assert_awaited_once()
+        call_args = conn.execute.call_args[0]
+        assert event_id in call_args
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_on_truncates_error(self):
+        """Error messages should be truncated to 1024 chars."""
+        from uuid import uuid4
+
+        conn = AsyncMock()
+        long_error = "x" * 2000
+
+        await OutboxRepository.mark_failed_on(
+            conn, event_id=uuid4(), error=long_error
+        )
+
+        call_args = conn.execute.call_args[0]
+        error_arg = call_args[2]
+        assert len(error_arg) <= 1024
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_on_handles_none_error(self):
+        """None error should become empty string."""
+        from uuid import uuid4
+
+        conn = AsyncMock()
+        await OutboxRepository.mark_failed_on(
+            conn, event_id=uuid4(), error=None
+        )
+
+        call_args = conn.execute.call_args[0]
+        error_arg = call_args[2]
+        assert error_arg == ""


### PR DESCRIPTION
## Summary
- Adds `fetch_and_lock()` context manager that yields `(events, conn)` inside a held transaction
- `mark_published_on(conn)` and `mark_failed_on(conn)` static methods operate on the same connection
- Outbox publisher now uses `fetch_and_lock` so `FOR UPDATE SKIP LOCKED` locks are held until publish completes
- Prevents duplicate event delivery by concurrent workers

Closes #76

## Test plan
- [x] `test_outbox_transaction.py` — 10 tests: transaction scope, lock holding, connection-bound marks, error truncation