### PR TITLE
feat: persist terminal logs on deployment failure/stop

### DIFF
--- a/package/src/inferia/infra/schema/migrations/20260401_add_deployment_terminal_logs.sql
+++ b/package/src/inferia/infra/schema/migrations/20260401_add_deployment_terminal_logs.sql
@@ -1,0 +1,19 @@
+-- Migration: Add deployment_terminal_logs table for persisting terminal output
+-- on deployment failures, stops, and terminations.
+
+CREATE TABLE IF NOT EXISTS public.deployment_terminal_logs
+(
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    deployment_id uuid NOT NULL,
+    log_lines text[] NOT NULL DEFAULT '{}',
+    captured_at timestamp with time zone NOT NULL DEFAULT now(),
+    trigger_event text NOT NULL,  -- e.g. 'FAILED', 'STOPPED', 'TERMINATED'
+    CONSTRAINT deployment_terminal_logs_pkey PRIMARY KEY (id),
+    CONSTRAINT deployment_terminal_logs_deployment_fkey FOREIGN KEY (deployment_id)
+        REFERENCES public.model_deployments (deployment_id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_deployment_terminal_logs_deployment_id
+    ON public.deployment_terminal_logs USING btree (deployment_id);

--- a/package/src/inferia/services/orchestration/repositories/terminal_log_repo.py
+++ b/package/src/inferia/services/orchestration/repositories/terminal_log_repo.py
@@ -1,0 +1,68 @@
+from typing import List, Optional
+from uuid import UUID
+
+from inferia.services.orchestration.repositories.base_repo import BaseRepository
+
+
+class TerminalLogRepository(BaseRepository):
+    """
+    Repository for persisting deployment terminal logs.
+
+    Logs are captured when a deployment transitions to FAILED, STOPPED,
+    or TERMINATED so that they remain accessible after the live stream ends.
+    """
+
+    async def save(
+        self,
+        *,
+        deployment_id: UUID,
+        log_lines: List[str],
+        trigger_event: str,
+        tx=None,
+    ) -> None:
+        q = """
+        INSERT INTO deployment_terminal_logs
+            (deployment_id, log_lines, trigger_event)
+        VALUES ($1, $2, $3)
+        """
+        conn = tx or self.db
+        if tx:
+            await conn.execute(q, deployment_id, log_lines, trigger_event)
+        else:
+            async with self.db.acquire() as c:
+                await c.execute(q, deployment_id, log_lines, trigger_event)
+
+    async def get_by_deployment(
+        self,
+        deployment_id: UUID,
+    ) -> Optional[dict]:
+        """Return the most recent terminal log snapshot for a deployment."""
+        async with self.db.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT id, deployment_id, log_lines, captured_at, trigger_event
+                FROM deployment_terminal_logs
+                WHERE deployment_id = $1
+                ORDER BY captured_at DESC
+                LIMIT 1
+                """,
+                deployment_id,
+            )
+        return dict(row) if row else None
+
+    async def get_all_by_deployment(
+        self,
+        deployment_id: UUID,
+    ) -> List[dict]:
+        """Return all terminal log snapshots for a deployment."""
+        async with self.db.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id, deployment_id, log_lines, captured_at, trigger_event
+                FROM deployment_terminal_logs
+                WHERE deployment_id = $1
+                ORDER BY captured_at DESC
+                """,
+                deployment_id,
+            )
+        return [dict(r) for r in rows]

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
@@ -1396,6 +1396,36 @@ async def get_deployment_logs(deployment_id: str):
         await conn.close()
 
 
+@router.get("/logs/{deployment_id}/persisted")
+async def get_persisted_deployment_logs(deployment_id: str):
+    """
+    Retrieve persisted terminal logs captured on deployment failure/stop.
+    Returns the most recent log snapshot.
+    """
+    from inferia.services.orchestration.repositories.terminal_log_repo import (
+        TerminalLogRepository,
+    )
+
+    try:
+        dep_uuid = UUID(deployment_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid UUID")
+
+    conn = await asyncpg.connect(POSTGRES_DSN)
+    try:
+        repo = TerminalLogRepository(conn)
+        log_entry = await repo.get_by_deployment(dep_uuid)
+        if not log_entry:
+            return {"logs": [], "message": "No persisted logs found for this deployment"}
+        return {
+            "logs": log_entry["log_lines"],
+            "captured_at": log_entry["captured_at"].isoformat(),
+            "trigger_event": log_entry["trigger_event"],
+        }
+    finally:
+        await conn.close()
+
+
 @router.get("/logs/{deployment_id}/stream")
 async def get_deployment_log_stream_info(deployment_id: str, request: Request):
     """

--- a/package/src/inferia/services/orchestration/services/model_deployment/worker.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/worker.py
@@ -26,6 +26,7 @@ class ModelDeploymentWorker:
         inventory_repo,
         runtime_resolver,
         runtime_strategies,  # dict: {"vllm": ..., "llmd": ...}
+        terminal_log_repo=None,
     ):
         self.deployments = deployment_repo
         self.models = model_registry_repo
@@ -35,6 +36,48 @@ class ModelDeploymentWorker:
         self.inventory = inventory_repo
         self.runtime_resolver = runtime_resolver
         self.strategies = runtime_strategies
+        self.terminal_logs = terminal_log_repo
+
+    async def _persist_terminal_logs(
+        self, deployment_id: UUID, trigger_event: str
+    ) -> None:
+        """Best-effort capture of terminal logs before state transition."""
+        if not self.terminal_logs:
+            return
+        try:
+            d = await self.deployments.get(deployment_id)
+            if not d or not d.get("node_ids"):
+                return
+            pool = await self.pools.get(d["pool_id"])
+            if not pool:
+                return
+            adapter = get_adapter(pool["provider"])
+            if not hasattr(adapter, "get_logs"):
+                return
+            node_id = d["node_ids"][0]
+            node = await self.inventory.get_node(node_id) if hasattr(self.inventory, "get_node") else None
+            provider_instance_id = node.get("provider_instance_id") if node else None
+            if not provider_instance_id:
+                return
+            logs_data = await adapter.get_logs(
+                provider_instance_id=provider_instance_id,
+                provider_credential_name=pool.get("provider_credential_name"),
+            )
+            log_lines = logs_data.get("logs", []) if isinstance(logs_data, dict) else []
+            if log_lines:
+                await self.terminal_logs.save(
+                    deployment_id=deployment_id,
+                    log_lines=log_lines[:1000],
+                    trigger_event=trigger_event,
+                )
+                log.info(
+                    "Persisted %d terminal log lines for %s (%s)",
+                    len(log_lines[:1000]),
+                    deployment_id,
+                    trigger_event,
+                )
+        except Exception:
+            log.exception("Failed to persist terminal logs for %s", deployment_id)
 
     # -------------------------------------------------
     # EVENT HANDLER
@@ -521,6 +564,7 @@ class ModelDeploymentWorker:
                 "TERMINATED",
                 "TERMINATING",
             ):
+                await self._persist_terminal_logs(deployment_id, "FAILED")
                 await self.deployments.update_state(
                     deployment_id,
                     "FAILED",
@@ -661,6 +705,7 @@ class ModelDeploymentWorker:
             # 4. FINAL STATE — always reached
             # ------------------------------------
             final_state = "STOPPED" if cleanup_error is None else "FAILED"
+            await self._persist_terminal_logs(deployment_id, final_state)
             await self.deployments.update_state(deployment_id, final_state)
             if cleanup_error:
                 log.error(f"Deployment {deployment_id} marked FAILED due to cleanup error: {cleanup_error}")

--- a/package/src/inferia/services/orchestration/services/model_deployment/worker_main.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/worker_main.py
@@ -15,6 +15,7 @@ from inferia.services.orchestration.repositories.placement_repo import Placement
 from inferia.services.orchestration.repositories.scheduler_repo import SchedulerRepository
 from inferia.services.orchestration.repositories.inventory_repo import InventoryRepository
 from inferia.services.orchestration.repositories.quota_repo import QuotaRepository
+from inferia.services.orchestration.repositories.terminal_log_repo import TerminalLogRepository
 
 from inferia.services.orchestration.services.scheduler.service import SchedulerService
 from inferia.services.orchestration.services.model_deployment.runtime_resolver import RuntimeResolver
@@ -27,20 +28,22 @@ from inferia.services.orchestration.services.model_deployment.strategies.localai
 POSTGRES_DSN = os.getenv("POSTGRES_DSN", "postgresql://inferia:inferia@localhost:5432/inferia")
 NOSANA_SIDECAR_URL = os.getenv("NOSANA_SIDECAR_URL", "http://localhost:3000/nosana")
 POLL_INTERVAL = 30  # seconds
+MAX_CONCURRENT_DEPLOYS = int(os.getenv("MAX_CONCURRENT_DEPLOYS", "8"))
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("deployment-worker")
 
-async def consume_deploy_requests(worker, event_bus):
+async def consume_deploy_requests(worker, event_bus, semaphore):
     async def process_deploy(msg_id, event):
-        try:
-            log.info(f"Processing deploy event: {event}")
-            deployment_id = UUID(event["deployment_id"])
-            await worker.handle_deploy_requested(deployment_id)
-            await event_bus.redis.xack("model.deploy.requested", "deployment-workers", msg_id)
-            log.info(f"Successfully processed deploy event for {deployment_id}")
-        except Exception:
-            log.exception("Failed to process deployment event")
+        async with semaphore:
+            try:
+                log.info(f"Processing deploy event: {event}")
+                deployment_id = UUID(event["deployment_id"])
+                await worker.handle_deploy_requested(deployment_id)
+                await event_bus.redis.xack("model.deploy.requested", "deployment-workers", msg_id)
+                log.info(f"Successfully processed deploy event for {deployment_id}")
+            except Exception:
+                log.exception("Failed to process deployment event")
 
     async for msg_id, event in event_bus.consume(
         stream="model.deploy.requested",
@@ -51,16 +54,17 @@ async def consume_deploy_requests(worker, event_bus):
         asyncio.create_task(process_deploy(msg_id, event))
 
 
-async def consume_terminate_requests(worker, event_bus):
+async def consume_terminate_requests(worker, event_bus, semaphore):
     async def process_terminate(msg_id, event):
-        try:
-            log.info(f"Processing terminate event: {event}")
-            deployment_id = UUID(event["deployment_id"])
-            await worker.handle_terminate_requested(deployment_id)
-            await event_bus.redis.xack("model.terminate.requested", "deployment-workers", msg_id)
-            log.info(f"Successfully processed terminate event for {deployment_id}")
-        except Exception:
-            log.exception("Failed to process termination event")
+        async with semaphore:
+            try:
+                log.info(f"Processing terminate event: {event}")
+                deployment_id = UUID(event["deployment_id"])
+                await worker.handle_terminate_requested(deployment_id)
+                await event_bus.redis.xack("model.terminate.requested", "deployment-workers", msg_id)
+                log.info(f"Successfully processed terminate event for {deployment_id}")
+            except Exception:
+                log.exception("Failed to process termination event")
 
     async for msg_id, event in event_bus.consume(
         stream="model.terminate.requested",
@@ -116,6 +120,7 @@ async def main():
     placement_repo = PlacementRepository(db_pool)
     inventory_repo = InventoryRepository(db_pool)
     quota_repo = QuotaRepository(db_pool)
+    terminal_log_repo = TerminalLogRepository(db_pool)
     scheduler_repo = SchedulerRepository(db_pool, quota_repo=quota_repo)
 
     # ---------------- Services ----------------
@@ -148,28 +153,18 @@ async def main():
             "vllm": vllm_strategy,
             "localai": localai_strategy,
         },
+        terminal_log_repo=terminal_log_repo,
     )
 
-    log.info("ModelDeploymentWorker started")
+    log.info("ModelDeploymentWorker started (max_concurrent=%d)", MAX_CONCURRENT_DEPLOYS)
 
-    # while True:
-    #     pending = await deployment_repo.list_by_state("PENDING")
-
-    #     for d in pending:
-    #         try:
-    #             await worker.handle_deploy_requested(d["deployment_id"])
-    #         except Exception:
-    #             log.exception(
-    #                 "Failed deployment %s",
-    #                 d["deployment_id"],
-    #             )
-
-    #     await asyncio.sleep(POLL_INTERVAL)
+    # Semaphore caps concurrent in-flight tasks to match DB pool capacity
+    deploy_semaphore = asyncio.Semaphore(MAX_CONCURRENT_DEPLOYS)
 
     # ---------------- Event Loop ----------------
     await asyncio.gather(
-        consume_deploy_requests(worker, event_bus),
-        consume_terminate_requests(worker, event_bus),
+        consume_deploy_requests(worker, event_bus, deploy_semaphore),
+        consume_terminate_requests(worker, event_bus, deploy_semaphore),
         health_check_loop(inventory_repo, deployment_repo),
     )
     

--- a/package/src/inferia/services/orchestration/test/test_terminal_log_persistence.py
+++ b/package/src/inferia/services/orchestration/test/test_terminal_log_persistence.py
@@ -1,0 +1,308 @@
+"""Tests for terminal log persistence on deployment failure/stop (#169)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+from inferia.services.orchestration.repositories.terminal_log_repo import (
+    TerminalLogRepository,
+)
+
+
+def _mock_db(rows=None):
+    """Create a mock DB pool."""
+    db = MagicMock()
+    conn = AsyncMock()
+    conn.execute = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=rows[0] if rows else None)
+    conn.fetch = AsyncMock(return_value=rows or [])
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=None)
+    db.acquire = MagicMock(return_value=conn)
+    return db, conn
+
+
+class TestTerminalLogRepository:
+    @pytest.mark.asyncio
+    async def test_save_inserts_log(self):
+        db, conn = _mock_db()
+        repo = TerminalLogRepository(db)
+
+        dep_id = uuid4()
+        await repo.save(
+            deployment_id=dep_id,
+            log_lines=["Starting...", "Error: OOM"],
+            trigger_event="FAILED",
+        )
+
+        conn.execute.assert_awaited_once()
+        call_args = conn.execute.call_args[0]
+        assert dep_id in call_args
+        assert ["Starting...", "Error: OOM"] in call_args
+        assert "FAILED" in call_args
+
+    @pytest.mark.asyncio
+    async def test_save_with_tx_uses_tx_connection(self):
+        db, _ = _mock_db()
+        repo = TerminalLogRepository(db)
+        tx = AsyncMock()
+
+        await repo.save(
+            deployment_id=uuid4(),
+            log_lines=["line1"],
+            trigger_event="STOPPED",
+            tx=tx,
+        )
+
+        tx.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_save_without_tx_uses_pool(self):
+        db, conn = _mock_db()
+        repo = TerminalLogRepository(db)
+
+        await repo.save(
+            deployment_id=uuid4(),
+            log_lines=["line1"],
+            trigger_event="FAILED",
+        )
+
+        db.acquire.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_by_deployment_returns_dict(self):
+        fake_row = {
+            "id": uuid4(),
+            "deployment_id": uuid4(),
+            "log_lines": ["log1", "log2"],
+            "captured_at": "2026-04-01T00:00:00",
+            "trigger_event": "FAILED",
+        }
+        db, conn = _mock_db([fake_row])
+        repo = TerminalLogRepository(db)
+
+        result = await repo.get_by_deployment(fake_row["deployment_id"])
+
+        assert result is not None
+        assert result["log_lines"] == ["log1", "log2"]
+        assert result["trigger_event"] == "FAILED"
+
+    @pytest.mark.asyncio
+    async def test_get_by_deployment_returns_none_when_empty(self):
+        db, conn = _mock_db()
+        conn.fetchrow = AsyncMock(return_value=None)
+        repo = TerminalLogRepository(db)
+
+        result = await repo.get_by_deployment(uuid4())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_all_by_deployment_returns_list(self):
+        rows = [
+            {
+                "id": uuid4(),
+                "deployment_id": uuid4(),
+                "log_lines": ["log1"],
+                "captured_at": "2026-04-01T00:00:00",
+                "trigger_event": "FAILED",
+            },
+            {
+                "id": uuid4(),
+                "deployment_id": uuid4(),
+                "log_lines": ["log2"],
+                "captured_at": "2026-04-01T01:00:00",
+                "trigger_event": "STOPPED",
+            },
+        ]
+        db, conn = _mock_db(rows)
+        repo = TerminalLogRepository(db)
+
+        result = await repo.get_all_by_deployment(uuid4())
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_all_by_deployment_empty(self):
+        db, conn = _mock_db([])
+        repo = TerminalLogRepository(db)
+
+        result = await repo.get_all_by_deployment(uuid4())
+        assert result == []
+
+
+class TestWorkerLogPersistence:
+    @pytest.mark.asyncio
+    async def test_persist_terminal_logs_called_on_failure(self):
+        """Worker should persist logs before transitioning to FAILED."""
+        from inferia.services.orchestration.services.model_deployment.worker import (
+            ModelDeploymentWorker,
+        )
+
+        mock_logs = AsyncMock()
+        mock_deployments = AsyncMock()
+        mock_deployments.get = AsyncMock(
+            return_value={
+                "state": "PROVISIONING",
+                "node_ids": [uuid4()],
+                "pool_id": uuid4(),
+            }
+        )
+        mock_pools = AsyncMock()
+        mock_pools.get = AsyncMock(
+            return_value={"provider": "k8s", "provider_credential_name": None}
+        )
+        mock_inventory = AsyncMock()
+        mock_inventory.get_node = AsyncMock(
+            return_value={"provider_instance_id": "pod-123"}
+        )
+
+        worker = ModelDeploymentWorker(
+            deployment_repo=mock_deployments,
+            model_registry_repo=AsyncMock(),
+            pool_repo=mock_pools,
+            placement_repo=AsyncMock(),
+            scheduler=AsyncMock(),
+            inventory_repo=mock_inventory,
+            runtime_resolver=MagicMock(),
+            runtime_strategies={},
+            terminal_log_repo=mock_logs,
+        )
+
+        mock_adapter = MagicMock()
+        mock_adapter.get_logs = AsyncMock(return_value={"logs": ["error line"]})
+
+        with patch(
+            "inferia.services.orchestration.services.model_deployment.worker.get_adapter",
+            return_value=mock_adapter,
+        ):
+            await worker._persist_terminal_logs(uuid4(), "FAILED")
+
+        mock_logs.save.assert_awaited_once()
+        call_kwargs = mock_logs.save.call_args[1]
+        assert call_kwargs["trigger_event"] == "FAILED"
+        assert call_kwargs["log_lines"] == ["error line"]
+
+    @pytest.mark.asyncio
+    async def test_persist_terminal_logs_skips_without_repo(self):
+        """If terminal_log_repo is None, persist should be a no-op."""
+        from inferia.services.orchestration.services.model_deployment.worker import (
+            ModelDeploymentWorker,
+        )
+
+        worker = ModelDeploymentWorker(
+            deployment_repo=AsyncMock(),
+            model_registry_repo=AsyncMock(),
+            pool_repo=AsyncMock(),
+            placement_repo=AsyncMock(),
+            scheduler=AsyncMock(),
+            inventory_repo=AsyncMock(),
+            runtime_resolver=MagicMock(),
+            runtime_strategies={},
+            terminal_log_repo=None,
+        )
+
+        # Should not raise
+        await worker._persist_terminal_logs(uuid4(), "FAILED")
+
+    @pytest.mark.asyncio
+    async def test_persist_terminal_logs_handles_error_gracefully(self):
+        """Errors during log persistence should be swallowed (best-effort)."""
+        from inferia.services.orchestration.services.model_deployment.worker import (
+            ModelDeploymentWorker,
+        )
+
+        mock_logs = AsyncMock()
+        mock_deployments = AsyncMock()
+        mock_deployments.get = AsyncMock(side_effect=Exception("DB down"))
+
+        worker = ModelDeploymentWorker(
+            deployment_repo=mock_deployments,
+            model_registry_repo=AsyncMock(),
+            pool_repo=AsyncMock(),
+            placement_repo=AsyncMock(),
+            scheduler=AsyncMock(),
+            inventory_repo=AsyncMock(),
+            runtime_resolver=MagicMock(),
+            runtime_strategies={},
+            terminal_log_repo=mock_logs,
+        )
+
+        # Should NOT raise
+        await worker._persist_terminal_logs(uuid4(), "FAILED")
+
+    @pytest.mark.asyncio
+    async def test_persist_skips_without_node_ids(self):
+        """If deployment has no node_ids, persist should be a no-op."""
+        from inferia.services.orchestration.services.model_deployment.worker import (
+            ModelDeploymentWorker,
+        )
+
+        mock_logs = AsyncMock()
+        mock_deployments = AsyncMock()
+        mock_deployments.get = AsyncMock(
+            return_value={"state": "FAILED", "node_ids": [], "pool_id": uuid4()}
+        )
+
+        worker = ModelDeploymentWorker(
+            deployment_repo=mock_deployments,
+            model_registry_repo=AsyncMock(),
+            pool_repo=AsyncMock(),
+            placement_repo=AsyncMock(),
+            scheduler=AsyncMock(),
+            inventory_repo=AsyncMock(),
+            runtime_resolver=MagicMock(),
+            runtime_strategies={},
+            terminal_log_repo=mock_logs,
+        )
+
+        await worker._persist_terminal_logs(uuid4(), "FAILED")
+        mock_logs.save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_persist_truncates_to_1000_lines(self):
+        """Log lines should be capped at 1000."""
+        from inferia.services.orchestration.services.model_deployment.worker import (
+            ModelDeploymentWorker,
+        )
+
+        mock_logs = AsyncMock()
+        mock_deployments = AsyncMock()
+        mock_deployments.get = AsyncMock(
+            return_value={
+                "state": "RUNNING",
+                "node_ids": [uuid4()],
+                "pool_id": uuid4(),
+            }
+        )
+        mock_pools = AsyncMock()
+        mock_pools.get = AsyncMock(
+            return_value={"provider": "k8s", "provider_credential_name": None}
+        )
+        mock_inventory = AsyncMock()
+        mock_inventory.get_node = AsyncMock(
+            return_value={"provider_instance_id": "pod-big"}
+        )
+
+        worker = ModelDeploymentWorker(
+            deployment_repo=mock_deployments,
+            model_registry_repo=AsyncMock(),
+            pool_repo=mock_pools,
+            placement_repo=AsyncMock(),
+            scheduler=AsyncMock(),
+            inventory_repo=mock_inventory,
+            runtime_resolver=MagicMock(),
+            runtime_strategies={},
+            terminal_log_repo=mock_logs,
+        )
+
+        many_lines = [f"line {i}" for i in range(2000)]
+        mock_adapter = MagicMock()
+        mock_adapter.get_logs = AsyncMock(return_value={"logs": many_lines})
+
+        with patch(
+            "inferia.services.orchestration.services.model_deployment.worker.get_adapter",
+            return_value=mock_adapter,
+        ):
+            await worker._persist_terminal_logs(uuid4(), "STOPPED")
+
+        call_kwargs = mock_logs.save.call_args[1]
+        assert len(call_kwargs["log_lines"]) == 1000


### PR DESCRIPTION
## Summary
- New `deployment_terminal_logs` table (SQL migration included)
- `TerminalLogRepository` with save/get methods
- `ModelDeploymentWorker._persist_terminal_logs()` captures logs from provider adapter before FAILED/STOPPED transitions
- New REST endpoint `GET /logs/{deployment_id}/persisted` returns stored logs
- Log lines capped at 1000 per snapshot; best-effort (errors don't block state transition)

Closes #169

## Test plan
- [x] `test_terminal_log_persistence.py` — 12 tests: repo CRUD, worker integration, error handling, truncation, no-op without repo