### PR TITLE
fix: defer LLMGuard ML model loading to async startup handler

### DIFF
--- a/package/src/inferia/services/guardrail/app.py
+++ b/package/src/inferia/services/guardrail/app.py
@@ -33,6 +33,9 @@ async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown events."""
     logger.info(f"Starting {settings.app_name} v{settings.app_version}")
 
+    # Initialize guardrail providers (loads ML models in background thread)
+    await guardrail_engine.initialize()
+
     # Start polling config from Filtration Service
     from inferia.services.guardrail.config_manager import config_manager
 

--- a/package/src/inferia/services/guardrail/engine.py
+++ b/package/src/inferia/services/guardrail/engine.py
@@ -19,39 +19,55 @@ class GuardrailEngine:
     """
 
     def __init__(self):
-        """Initialize guardrail providers."""
+        """Register provider objects without loading heavy ML models."""
         self.settings = guardrail_settings
         self.providers: Dict[str, GuardrailProvider] = {}
 
         self._load_providers()
 
         logger.info(
-            f"Guardrail engine initialized with providers: {list(self.providers.keys())}"
+            f"Guardrail engine created with providers: {list(self.providers.keys())}"
         )
         logger.info(f"Default provider: {self.settings.default_guardrail_engine}")
 
     def _load_providers(self):
-        """Register available providers."""
-        # 1. LLM Guard (Local)
+        """Register available providers (lightweight — no model downloads)."""
+        # 1. LLM Guard (Local) — models loaded later via initialize()
         try:
             llm_guard = LLMGuardProvider()
             self.providers[llm_guard.name] = llm_guard
         except Exception as e:
-            logger.error(f"Failed to initialize LLMGuardProvider: {e}", exc_info=True)
+            logger.error(f"Failed to create LLMGuardProvider: {e}", exc_info=True)
 
         # 2. Llama Guard (Groq)
         try:
             llama_guard = LlamaGuardProvider()
             self.providers[llama_guard.name] = llama_guard
         except Exception as e:
-            logger.error(f"Failed to initialize LlamaGuardProvider: {e}", exc_info=True)
+            logger.error(f"Failed to create LlamaGuardProvider: {e}", exc_info=True)
 
         # 3. Lakera Guard (API)
         try:
             lakera_guard = LakeraProvider()
             self.providers[lakera_guard.name] = lakera_guard
         except Exception as e:
-            logger.error(f"Failed to initialize LakeraProvider: {e}", exc_info=True)
+            logger.error(f"Failed to create LakeraProvider: {e}", exc_info=True)
+
+    async def initialize(self):
+        """
+        Perform async initialization for providers that need it
+        (e.g. LLMGuardProvider loading ML models).
+        Call from the FastAPI lifespan handler.
+        """
+        for name, provider in self.providers.items():
+            init_fn = getattr(provider, "initialize", None)
+            if init_fn is not None:
+                try:
+                    await init_fn()
+                except Exception as e:
+                    logger.error(
+                        f"Failed to initialize provider {name}: {e}", exc_info=True
+                    )
 
     async def scan_input(
         self,

--- a/package/src/inferia/services/guardrail/providers/llm_guard_provider.py
+++ b/package/src/inferia/services/guardrail/providers/llm_guard_provider.py
@@ -24,20 +24,32 @@ logger = logging.getLogger(__name__)
 class LLMGuardProvider(GuardrailProvider):
     """
     Provider for 'llm-guard' (Local Standards).
+
+    Scanner initialization is deferred to ``initialize()`` so that
+    heavy HuggingFace model downloads do not block the Python import
+    or the event loop.  Call ``await initialize()`` from a FastAPI
+    lifespan handler.
     """
 
     def __init__(self):
         self.settings = guardrail_settings
         self.input_scanners = []
         self.output_scanners = []
+        self._ready = False
 
-        # Initialize scanners based on granular config
-        if True:  # Always attempt init, granular flags inside control
-            logger.info(
-                "[LLMGuardProvider] Initializing scanners based on granular config..."
-            )
-            self.input_scanners = self._init_input_scanners()
-            self.output_scanners = self._init_output_scanners()
+    async def initialize(self) -> None:
+        """Load ML models in a background thread to avoid blocking the event loop."""
+        logger.info(
+            "[LLMGuardProvider] Initializing scanners in background thread..."
+        )
+        self.input_scanners = await asyncio.to_thread(self._init_input_scanners)
+        self.output_scanners = await asyncio.to_thread(self._init_output_scanners)
+        self._ready = True
+        logger.info("[LLMGuardProvider] Scanners ready.")
+
+    @property
+    def ready(self) -> bool:
+        return self._ready
 
     @property
     def name(self) -> str:

--- a/package/src/inferia/services/guardrail/tests/test_deferred_init.py
+++ b/package/src/inferia/services/guardrail/tests/test_deferred_init.py
@@ -1,0 +1,170 @@
+"""Tests for deferred LLMGuard model loading (#78)."""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from inferia.services.guardrail.providers.llm_guard_provider import LLMGuardProvider
+from inferia.services.guardrail.engine import GuardrailEngine
+
+
+class TestLLMGuardProviderDeferredInit:
+    def test_init_does_not_load_models(self):
+        """__init__ should NOT call scanner initialization."""
+        with patch.object(
+            LLMGuardProvider, "_init_input_scanners"
+        ) as mock_input, patch.object(
+            LLMGuardProvider, "_init_output_scanners"
+        ) as mock_output:
+            provider = LLMGuardProvider()
+
+        mock_input.assert_not_called()
+        mock_output.assert_not_called()
+
+    def test_not_ready_after_init(self):
+        """Provider should not be ready until initialize() is called."""
+        provider = LLMGuardProvider()
+        assert provider.ready is False
+
+    def test_scanners_empty_after_init(self):
+        """Scanners should be empty lists after __init__."""
+        provider = LLMGuardProvider()
+        assert provider.input_scanners == []
+        assert provider.output_scanners == []
+
+    @pytest.mark.asyncio
+    async def test_initialize_loads_models_in_thread(self):
+        """initialize() should load models via asyncio.to_thread."""
+        provider = LLMGuardProvider()
+
+        fake_input = [MagicMock()]
+        fake_output = [MagicMock()]
+
+        with patch.object(
+            provider, "_init_input_scanners", return_value=fake_input
+        ), patch.object(
+            provider, "_init_output_scanners", return_value=fake_output
+        ), patch(
+            "inferia.services.guardrail.providers.llm_guard_provider.asyncio.to_thread",
+            new_callable=AsyncMock,
+        ) as mock_to_thread:
+            mock_to_thread.side_effect = [fake_input, fake_output]
+            await provider.initialize()
+
+        assert mock_to_thread.await_count == 2
+        assert provider.input_scanners == fake_input
+        assert provider.output_scanners == fake_output
+        assert provider.ready is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_sets_ready_true(self):
+        """After successful initialize(), ready should be True."""
+        provider = LLMGuardProvider()
+
+        with patch.object(provider, "_init_input_scanners", return_value=[]), \
+             patch.object(provider, "_init_output_scanners", return_value=[]), \
+             patch(
+                 "inferia.services.guardrail.providers.llm_guard_provider.asyncio.to_thread",
+                 new_callable=AsyncMock,
+                 side_effect=[[], []],
+             ):
+            await provider.initialize()
+
+        assert provider.ready is True
+
+    def test_name_property(self):
+        provider = LLMGuardProvider()
+        assert provider.name == "llm-guard"
+
+
+class TestGuardrailEngineAsyncInit:
+    def test_engine_init_creates_providers_without_model_loading(self):
+        """GuardrailEngine.__init__ should create providers but not load models."""
+        with patch(
+            "inferia.services.guardrail.engine.LLMGuardProvider"
+        ) as MockLLM, patch(
+            "inferia.services.guardrail.engine.LlamaGuardProvider"
+        ) as MockLlama, patch(
+            "inferia.services.guardrail.engine.LakeraProvider"
+        ) as MockLakera:
+            mock_llm = MagicMock()
+            mock_llm.name = "llm-guard"
+            MockLLM.return_value = mock_llm
+
+            mock_llama = MagicMock()
+            mock_llama.name = "llama-guard"
+            MockLlama.return_value = mock_llama
+
+            mock_lakera = MagicMock()
+            mock_lakera.name = "lakera-guard"
+            MockLakera.return_value = mock_lakera
+
+            engine = GuardrailEngine()
+
+        assert "llm-guard" in engine.providers
+        assert "llama-guard" in engine.providers
+        assert "lakera-guard" in engine.providers
+
+    @pytest.mark.asyncio
+    async def test_engine_initialize_calls_provider_initialize(self):
+        """engine.initialize() should call initialize() on providers that have it."""
+        with patch(
+            "inferia.services.guardrail.engine.LLMGuardProvider"
+        ) as MockLLM, patch(
+            "inferia.services.guardrail.engine.LlamaGuardProvider"
+        ) as MockLlama, patch(
+            "inferia.services.guardrail.engine.LakeraProvider"
+        ) as MockLakera:
+            mock_llm = MagicMock()
+            mock_llm.name = "llm-guard"
+            mock_llm.initialize = AsyncMock()
+            MockLLM.return_value = mock_llm
+
+            mock_llama = MagicMock()
+            mock_llama.name = "llama-guard"
+            mock_llama.initialize = AsyncMock()
+            MockLlama.return_value = mock_llama
+
+            mock_lakera = MagicMock()
+            mock_lakera.name = "lakera-guard"
+            # Lakera has no initialize method
+            del mock_lakera.initialize
+            MockLakera.return_value = mock_lakera
+
+            engine = GuardrailEngine()
+            await engine.initialize()
+
+        mock_llm.initialize.assert_awaited_once()
+        mock_llama.initialize.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_engine_initialize_handles_provider_failure(self):
+        """If a provider's initialize() fails, other providers should still init."""
+        with patch(
+            "inferia.services.guardrail.engine.LLMGuardProvider"
+        ) as MockLLM, patch(
+            "inferia.services.guardrail.engine.LlamaGuardProvider"
+        ) as MockLlama, patch(
+            "inferia.services.guardrail.engine.LakeraProvider"
+        ) as MockLakera:
+            mock_llm = MagicMock()
+            mock_llm.name = "llm-guard"
+            mock_llm.initialize = AsyncMock(side_effect=RuntimeError("model download failed"))
+            MockLLM.return_value = mock_llm
+
+            mock_llama = MagicMock()
+            mock_llama.name = "llama-guard"
+            mock_llama.initialize = AsyncMock()
+            MockLlama.return_value = mock_llama
+
+            mock_lakera = MagicMock()
+            mock_lakera.name = "lakera-guard"
+            del mock_lakera.initialize
+            MockLakera.return_value = mock_lakera
+
+            engine = GuardrailEngine()
+            # Should NOT raise
+            await engine.initialize()
+
+        # LLama should still have been initialized
+        mock_llama.initialize.assert_awaited_once()


### PR DESCRIPTION
## Summary
- `LLMGuardProvider.__init__` no longer loads HuggingFace models synchronously
- New `async initialize()` method loads scanners via `asyncio.to_thread` to avoid blocking the event loop
- `GuardrailEngine.initialize()` calls provider `initialize()` methods and is wired into FastAPI lifespan
- K8s liveness probes no longer killed by 30-120s blocking import

Closes #78

## Test plan
- [x] `test_deferred_init.py` — 9 tests: no model loading in __init__, ready flag, async init, engine init, failure isolation