### PR TITLE
fix: release concurrency slot after connection established, not stream end

### DIFF
--- a/package/src/inferia/services/inference/core/service.py
+++ b/package/src/inferia/services/inference/core/service.py
@@ -291,18 +291,26 @@ class GatewayService:
         max_bytes = settings.upstream_max_response_bytes
         client = http_client.get_client()
         try:
+            # Acquire concurrency slot only for connection establishment,
+            # then release it so long-running streams don't cause
+            # head-of-line blocking for new requests.
             async with upstream_concurrency_limiter.limit(concurrency_key):
-                async with client.stream(
+                request = client.build_request(
                     "POST", full_url, json=transformed_payload, headers=headers
-                ) as response:
-                    response.raise_for_status()
-                    total_bytes = 0
-                    async for chunk in response.aiter_raw():
-                        total_bytes += len(chunk)
-                        if total_bytes > max_bytes:
-                            yield b'data: {"error": "Upstream response exceeded size limit"}\n\n'
-                            return
-                        yield chunk
+                )
+                response = await client.send(request, stream=True)
+                response.raise_for_status()
+            # Slot released — stream body without holding it
+            try:
+                total_bytes = 0
+                async for chunk in response.aiter_raw():
+                    total_bytes += len(chunk)
+                    if total_bytes > max_bytes:
+                        yield b'data: {"error": "Upstream response exceeded size limit"}\n\n'
+                        return
+                    yield chunk
+            finally:
+                await response.aclose()
         except httpx.HTTPStatusError as e:
             await breaker._record_failure()
             logger.error(f"Upstream Error {e.response.status_code}: {e.response.text}")

--- a/package/src/inferia/services/inference/tests/test_provider_error_sanitization.py
+++ b/package/src/inferia/services/inference/tests/test_provider_error_sanitization.py
@@ -119,10 +119,8 @@ class TestStreamUpstreamErrorSanitization:
         )
 
         mock_client = AsyncMock()
-        stream_cm = MagicMock()
-        stream_cm.__aenter__ = AsyncMock(side_effect=error)
-        stream_cm.__aexit__ = AsyncMock(return_value=False)
-        mock_client.stream = MagicMock(return_value=stream_cm)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(side_effect=error)
 
         limiter_cm = MagicMock()
         limiter_cm.__aenter__ = AsyncMock(return_value=None)
@@ -152,12 +150,10 @@ class TestStreamUpstreamErrorSanitization:
     async def test_streaming_exception_does_not_expose_details(self):
         """Streaming connection errors must return generic message."""
         mock_client = AsyncMock()
-        stream_cm = MagicMock()
-        stream_cm.__aenter__ = AsyncMock(
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(
             side_effect=ConnectionError("DNS resolution failed for gpu-node-3.internal")
         )
-        stream_cm.__aexit__ = AsyncMock(return_value=False)
-        mock_client.stream = MagicMock(return_value=stream_cm)
 
         limiter_cm = MagicMock()
         limiter_cm.__aenter__ = AsyncMock(return_value=None)

--- a/package/src/inferia/services/inference/tests/test_upstream_security.py
+++ b/package/src/inferia/services/inference/tests/test_upstream_security.py
@@ -267,13 +267,11 @@ class TestCallUpstreamSecurity:
         mock_response.aiter_raw = MagicMock(
             return_value=self._async_iter([b"x" * 500, b"x" * 500, b"x" * 500])
         )
-
-        @asynccontextmanager
-        async def mock_stream(*args, **kwargs):
-            yield mock_response
+        mock_response.aclose = AsyncMock()
 
         mock_client = MagicMock()
-        mock_client.stream = mock_stream
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(return_value=mock_response)
 
         with patch(
             "inferia.services.inference.core.service.settings"


### PR DESCRIPTION
## Summary
- Refactors `stream_upstream` to use `client.build_request()` + `client.send(stream=True)` instead of `client.stream()` context manager
- Concurrency slot is released after the upstream connection is established and first response received
- Stream body is read outside the concurrency limiter scope, preventing head-of-line blocking
- Updates existing test mocks to match the new streaming pattern

Closes #75

## Test plan
- [x] Existing streaming security tests updated and passing (error sanitization, oversized response)
- [x] No regressions in 307-test suite