### PR TITLE
fix: Redis pipeline in rate limiter, shared pool, event bus connection pool

### DIFF
--- a/package/src/inferia/services/api_gateway/gateway/rate_limiter.py
+++ b/package/src/inferia/services/api_gateway/gateway/rate_limiter.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Tuple
 from fastapi import HTTPException, status, Request
 from datetime import datetime
 import asyncio
+from cachetools import TTLCache
 
 from inferia.services.api_gateway.config import settings
 
@@ -61,7 +62,7 @@ class InMemoryRateLimiter:
     """In-memory rate limiter using token bucket algorithm."""
 
     def __init__(self):
-        self.buckets: Dict[str, TokenBucket] = {}
+        self.buckets: TTLCache = TTLCache(maxsize=10000, ttl=120)
         self.requests_per_minute = settings.rate_limit_requests_per_minute
         self.burst_size = settings.rate_limit_burst_size
 
@@ -100,39 +101,40 @@ class RedisRateLimiter:
         if not REDIS_AVAILABLE:
             raise ImportError("redis package is required for RedisRateLimiter")
 
-        self.redis_client = redis.from_url(settings.redis_url, decode_responses=True)
+        from inferia.services.api_gateway.gateway.redis_pool import get_redis_client
+        self.redis_client = get_redis_client()
         self.requests_per_minute = settings.rate_limit_requests_per_minute
         self.window_seconds = 60
 
     async def is_allowed(self, key: str) -> Tuple[bool, Dict[str, Any]]:
         """
         Check if request is allowed using sliding window algorithm.
+        Uses a Redis pipeline to batch all commands in a single round-trip.
         Returns (is_allowed, metadata)
         """
         now = time.time()
         window_start = now - self.window_seconds
-
-        # Redis key for rate limiting
         redis_key = f"rate_limit:{key}"
 
-        # Remove old entries
-        await self.redis_client.zremrangebyscore(redis_key, 0, window_start)
+        # Single pipeline: clean old entries, add new, count, set expiry
+        async with self.redis_client.pipeline(transaction=True) as pipe:
+            pipe.zremrangebyscore(redis_key, 0, window_start)
+            pipe.zadd(redis_key, {str(now): now})
+            pipe.zcard(redis_key)
+            pipe.expire(redis_key, self.window_seconds * 2)
+            results = await pipe.execute()
 
-        # Count requests in current window
-        current_count = await self.redis_client.zcard(redis_key)
+        # results: [removed_count, added_count, current_count, expire_ok]
+        current_count = results[2]
+        allowed = current_count <= self.requests_per_minute
 
-        # Check if allowed
-        allowed = current_count < self.requests_per_minute
-
-        if allowed:
-            # Add new request timestamp
-            await self.redis_client.zadd(redis_key, {str(now): now})
-            # Set expiry on key
-            await self.redis_client.expire(redis_key, self.window_seconds * 2)
+        if not allowed:
+            # Over limit — remove the optimistic add
+            await self.redis_client.zrem(redis_key, str(now))
 
         metadata = {
             "limit": self.requests_per_minute,
-            "remaining": max(0, self.requests_per_minute - current_count - 1),
+            "remaining": max(0, self.requests_per_minute - current_count),
             "reset": int(now + self.window_seconds),
         }
 
@@ -143,6 +145,7 @@ class RedisRateLimiter:
 
 
 import logging
+import os
 
 logger = logging.getLogger("rate_limiter")
 
@@ -164,6 +167,16 @@ class RateLimiter:
         else:
             self.limiter = InMemoryRateLimiter()
             self.backend = "in-memory"
+
+        if self.backend == "in-memory":
+            workers = int(os.getenv("WEB_CONCURRENCY", "1"))
+            if workers > 1:
+                logger.warning(
+                    "In-memory rate limiter is active with %d workers. "
+                    "Rate limits will NOT be enforced across workers. "
+                    "Set use_redis_rate_limit=true or WEB_CONCURRENCY=1.",
+                    workers,
+                )
 
     async def check_rate_limit(self, request: Request) -> None:
         """

--- a/package/src/inferia/services/api_gateway/gateway/redis_pool.py
+++ b/package/src/inferia/services/api_gateway/gateway/redis_pool.py
@@ -1,0 +1,43 @@
+"""
+Shared async Redis connection pool for the API gateway.
+
+All gateway components (rate limiter, policy engine, health checks)
+should use ``get_redis_pool()`` instead of creating independent clients.
+"""
+
+import logging
+from typing import Optional
+
+import redis.asyncio as redis
+
+from inferia.services.api_gateway.config import settings
+
+logger = logging.getLogger(__name__)
+
+_pool: Optional[redis.ConnectionPool] = None
+
+
+def get_redis_pool() -> redis.ConnectionPool:
+    """Return the shared async Redis connection pool (lazy-init, singleton)."""
+    global _pool
+    if _pool is None:
+        _pool = redis.ConnectionPool.from_url(
+            settings.redis_url,
+            decode_responses=True,
+            max_connections=int(getattr(settings, "redis_max_connections", 20)),
+        )
+        logger.info("Shared Redis connection pool created (max_connections=%d)", _pool.max_connections)
+    return _pool
+
+
+def get_redis_client() -> redis.Redis:
+    """Return a Redis client backed by the shared pool."""
+    return redis.Redis(connection_pool=get_redis_pool())
+
+
+async def close_redis_pool() -> None:
+    """Shutdown the shared pool (call from lifespan shutdown)."""
+    global _pool
+    if _pool is not None:
+        await _pool.disconnect()
+        _pool = None

--- a/package/src/inferia/services/orchestration/infra/redis_event_bus.py
+++ b/package/src/inferia/services/orchestration/infra/redis_event_bus.py
@@ -11,13 +11,15 @@ log = logging.getLogger(__name__)
 
 class RedisEventBus:
     def __init__(self):
-        self.redis = redis.Redis(
+        pool = redis.ConnectionPool(
             host=os.getenv("REDIS_HOST", "localhost"),
-            decode_responses=True,
             port=int(os.getenv("REDIS_PORT") or 6379),
             username=os.getenv("REDIS_USERNAME", "default"),
             password=os.getenv("REDIS_PASSWORD", ""),
+            decode_responses=True,
+            max_connections=int(os.getenv("REDIS_EVENT_BUS_POOL_SIZE", "20")),
         )
+        self.redis = redis.Redis(connection_pool=pool)
 
     async def close(self):
         """Close the Redis connection."""


### PR DESCRIPTION
## Summary
- RedisRateLimiter: replaces 4 sequential Redis calls with a single pipeline (1 round-trip)
- New shared `redis_pool.py` module for API gateway — all components reuse one connection pool
- RedisEventBus: uses explicit `ConnectionPool(max_connections=20)` instead of single-connection default

Closes #87, closes #89, closes #98

## Test plan
- [x] Pipeline logic tested via existing rate limiter tests
- [x] No regressions in 307-test suite