### PR TITLE
fix: bound insights queries, health-check fan-out, and log task GC

### DIFF
--- a/package/src/inferia/services/api_gateway/gateway/router.py
+++ b/package/src/inferia/services/api_gateway/gateway/router.py
@@ -271,8 +271,8 @@ async def list_models(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Check cache after authentication
-    cache_key = (skip, limit)
+    # Check cache after authentication (include org_id to avoid cross-org leaks)
+    cache_key = (key_record.org_id, skip, limit)
     if cache_key in models_cache:
         return models_cache[cache_key]
 
@@ -351,10 +351,16 @@ async def list_models(
 
         return None
 
-    # Run health checks in parallel
+    # Run health checks in parallel with bounded concurrency
+    _health_semaphore = asyncio.Semaphore(10)
+
+    async def _bounded_check(client, d):
+        async with _health_semaphore:
+            return await check_health(client, d)
+
     client = gateway_http_client.get_service_client()
     health_results = await asyncio.gather(
-        *(check_health(client, d) for d in all_deployments), return_exceptions=True
+        *(_bounded_check(client, d) for d in all_deployments), return_exceptions=True
     )
 
     deployments = [

--- a/package/src/inferia/services/api_gateway/management/insights.py
+++ b/package/src/inferia/services/api_gateway/management/insights.py
@@ -604,6 +604,7 @@ async def get_insights_filters(
         .where(*log_conditions)
         .distinct()
         .order_by(DBInferenceLog.model.asc())
+        .limit(500)
     )
     models_result = await db.execute(models_stmt)
     models = [row.model for row in models_result.all() if row.model]
@@ -619,6 +620,7 @@ async def get_insights_filters(
         .where(*ip_conditions)
         .distinct()
         .order_by(DBInferenceLog.ip_address.asc())
+        .limit(1000)
     )
     ip_addresses_result = await db.execute(ip_addresses_stmt)
     ip_addresses = [

--- a/package/src/inferia/services/inference/core/handlers/completion.py
+++ b/package/src/inferia/services/inference/core/handlers/completion.py
@@ -3,7 +3,10 @@
 import asyncio
 import logging
 import time
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
+
+# Prevent fire-and-forget log tasks from being GC'd before completion
+_background_log_tasks: Set[asyncio.Task] = set()
 
 from fastapi import BackgroundTasks, HTTPException
 from fastapi.responses import StreamingResponse
@@ -247,7 +250,7 @@ class CompletionHandler:
                 raise
             finally:
                 try:
-                    asyncio.create_task(
+                    task = asyncio.create_task(
                         RequestLogger.log(
                             deployment_id=deployment_id,
                             user_id=user_context_id,
@@ -266,6 +269,9 @@ class CompletionHandler:
                             is_streaming=True,
                         )
                     )
+                    # Hold a strong reference so the task isn't GC'd before completion
+                    _background_log_tasks.add(task)
+                    task.add_done_callback(_background_log_tasks.discard)
                 except RuntimeError:
                     logger.error(
                         "Failed to schedule streaming log task: no running event loop"


### PR DESCRIPTION
## Summary
- Insights `/filters`: adds LIMIT to DISTINCT model and IP address queries (500/1000)
- `/models` endpoint: adds semaphore(10) to cap concurrent health-check HTTP requests; keys cache on org_id
- Streaming log task: holds strong reference in `_background_log_tasks` set to prevent GC

Closes #84, closes #86, closes #101

## Test plan
- [x] Limits prevent timeout on large inference_logs tables
- [x] Health-check semaphore prevents connection exhaustion
- [x] Task set cleanup via `add_done_callback(discard)`