### PR TITLE
fix: add size limits to /ingest and truncate oversized log payloads

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -87,6 +87,12 @@ HEALTH_CHECK_TIMEOUT=5
 # Interval between health checks (seconds)
 HEALTH_CHECK_INTERVAL=30
 
+# --- Data Service / Ingest Limits ---
+# Maximum number of documents per /ingest request
+MAX_INGEST_DOCUMENTS=500
+# Maximum size of a single document in bytes (default: 1MB)
+MAX_DOCUMENT_SIZE_BYTES=1000000
+
 # --- Feature Flags ---
 ENABLE_2FA=true
 GUARDRAIL_PII_DETECTION_ENABLED=true

--- a/package/src/inferia/services/data/app.py
+++ b/package/src/inferia/services/data/app.py
@@ -82,6 +82,10 @@ class RetrieveRequest(BaseModel):
     n_results: int = 3
 
 
+MAX_INGEST_DOCUMENTS = 500
+MAX_DOCUMENT_SIZE_BYTES = 1_000_000  # 1 MB per document
+
+
 class IngestRequest(BaseModel):
     collection_name: str
     documents: List[str]
@@ -245,6 +249,17 @@ async def ingest(request: IngestRequest):
     """
     Ingest documents into the Vector Database.
     """
+    if len(request.documents) > MAX_INGEST_DOCUMENTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Too many documents ({len(request.documents)}). Maximum is {MAX_INGEST_DOCUMENTS}.",
+        )
+    for i, doc in enumerate(request.documents):
+        if len(doc.encode("utf-8")) > MAX_DOCUMENT_SIZE_BYTES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Document at index {i} exceeds maximum size of {MAX_DOCUMENT_SIZE_BYTES} bytes.",
+            )
     try:
         success = await asyncio.to_thread(
             data_engine.add_documents,

--- a/package/src/inferia/services/data/app.py
+++ b/package/src/inferia/services/data/app.py
@@ -82,10 +82,6 @@ class RetrieveRequest(BaseModel):
     n_results: int = 3
 
 
-MAX_INGEST_DOCUMENTS = 500
-MAX_DOCUMENT_SIZE_BYTES = 1_000_000  # 1 MB per document
-
-
 class IngestRequest(BaseModel):
     collection_name: str
     documents: List[str]
@@ -249,16 +245,16 @@ async def ingest(request: IngestRequest):
     """
     Ingest documents into the Vector Database.
     """
-    if len(request.documents) > MAX_INGEST_DOCUMENTS:
+    if len(request.documents) > settings.max_ingest_documents:
         raise HTTPException(
             status_code=400,
-            detail=f"Too many documents ({len(request.documents)}). Maximum is {MAX_INGEST_DOCUMENTS}.",
+            detail=f"Too many documents ({len(request.documents)}). Maximum is {settings.max_ingest_documents}.",
         )
     for i, doc in enumerate(request.documents):
-        if len(doc.encode("utf-8")) > MAX_DOCUMENT_SIZE_BYTES:
+        if len(doc.encode("utf-8")) > settings.max_document_size_bytes:
             raise HTTPException(
                 status_code=400,
-                detail=f"Document at index {i} exceeds maximum size of {MAX_DOCUMENT_SIZE_BYTES} bytes.",
+                detail=f"Document at index {i} exceeds maximum size of {settings.max_document_size_bytes} bytes.",
             )
     try:
         success = await asyncio.to_thread(

--- a/package/src/inferia/services/data/config.py
+++ b/package/src/inferia/services/data/config.py
@@ -54,6 +54,14 @@ class Settings(BaseSettings):
     # Optional OpenAI Key for Rewriting
     openai_api_key: Optional[str] = None
 
+    # Ingest limits
+    max_ingest_documents: int = Field(
+        default=500, validation_alias="MAX_INGEST_DOCUMENTS"
+    )
+    max_document_size_bytes: int = Field(
+        default=1_000_000, validation_alias="MAX_DOCUMENT_SIZE_BYTES"
+    )
+
     # Control Plane Connection
     api_gateway_url: str = Field(
         default="http://localhost:8000", validation_alias="API_GATEWAY_URL"

--- a/package/src/inferia/services/inference/core/request_logger.py
+++ b/package/src/inferia/services/inference/core/request_logger.py
@@ -6,6 +6,7 @@ from the original OrchestrationService with a single entry point.
 """
 
 import asyncio
+import json
 import logging
 import time
 from typing import Any, Dict, List, Optional
@@ -21,6 +22,9 @@ _BINARY_FIELDS = {
     "video": "<base64_video_omitted>",
     "input_reference": "<base64_image_omitted>",
 }
+
+# Maximum serialized payload size stored in inference_logs (64 KB)
+_MAX_PAYLOAD_BYTES = 65_536
 
 
 class RequestLogger:
@@ -108,16 +112,23 @@ class RequestLogger:
 
         # Strip binary fields for image/video requests
         has_binary = any(k in payload for k in _BINARY_FIELDS)
-        if not has_binary:
-            return payload
+        if has_binary:
+            payload = {
+                k: v for k, v in payload.items() if k not in _BINARY_FIELDS
+            }
+            for field_name, placeholder in _BINARY_FIELDS.items():
+                if field_name in payload:
+                    payload[field_name] = placeholder
 
-        sanitized = {
-            k: v for k, v in payload.items() if k not in _BINARY_FIELDS
-        }
-        for field_name, placeholder in _BINARY_FIELDS.items():
-            if field_name in payload:
-                sanitized[field_name] = placeholder
-        return sanitized
+        # Truncate oversized payloads to prevent table bloat
+        try:
+            serialized = json.dumps(payload, default=str)
+            if len(serialized) > _MAX_PAYLOAD_BYTES:
+                return {"_truncated": True, "_size": len(serialized)}
+        except (TypeError, ValueError):
+            pass
+
+        return payload
 
     @staticmethod
     def _build_usage(


### PR DESCRIPTION
## Summary
- `/ingest` endpoint: rejects requests with >500 documents or any document >1MB
- Request logger: truncates payloads >64KB before storing in inference_logs (replaces with `{_truncated: true, _size: N}`)

Closes #90, closes #91

## Test plan
- [x] Validation returns 400 with descriptive error messages
- [x] Truncation preserves the payload size info for debugging