### PR TITLE
fix: add table retention functions, gRPC limits, Docker resource limits

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -21,6 +21,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2"
+        reservations:
+          memory: 512M
     networks:
       - inferia-net
 
@@ -33,6 +40,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1"
+        reservations:
+          memory: 128M
     networks:
       - inferia-net
 
@@ -66,6 +80,13 @@ services:
       - "8004:3000"   # DePIN Sidecar
       - "3001:3001"   # Dashboard
       - "50051:50051" # gRPC
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "4"
+        reservations:
+          memory: 1G
     depends_on:
       postgres:
         condition: service_healthy
@@ -84,11 +105,18 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
     volumes:
       - esdata:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2"
+        reservations:
+          memory: 1G
     networks:
       - inferia-net
     healthcheck:
@@ -115,6 +143,13 @@ services:
       - ../docker/logstash/pipeline:/usr/share/logstash/pipeline:ro
     ports:
       - "${LOGSTASH_PORT:-5959}:5959"
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "1"
+        reservations:
+          memory: 512M
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -138,6 +173,11 @@ services:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
     ports:
       - "5601:5601"
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "1"
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/package/src/inferia/infra/schema/migrations/20260402_add_retention_cleanup.sql
+++ b/package/src/inferia/infra/schema/migrations/20260402_add_retention_cleanup.sql
@@ -1,0 +1,61 @@
+-- Migration: Add retention/cleanup support for append-only tables (#82)
+
+-- Delete PUBLISHED outbox events older than 7 days (run periodically)
+-- This is a helper function; call via pg_cron or application scheduler.
+CREATE OR REPLACE FUNCTION cleanup_published_outbox_events(retention_days int DEFAULT 7)
+RETURNS bigint
+LANGUAGE plpgsql AS $$
+DECLARE
+  deleted bigint;
+BEGIN
+  DELETE FROM outbox_events
+  WHERE status = 'PUBLISHED'
+    AND published_at < now() - make_interval(days => retention_days);
+  GET DIAGNOSTICS deleted = ROW_COUNT;
+  RETURN deleted;
+END;
+$$;
+
+-- Delete DEAD outbox events older than 30 days
+CREATE OR REPLACE FUNCTION cleanup_dead_outbox_events(retention_days int DEFAULT 30)
+RETURNS bigint
+LANGUAGE plpgsql AS $$
+DECLARE
+  deleted bigint;
+BEGIN
+  DELETE FROM outbox_events
+  WHERE status = 'DEAD'
+    AND updated_at < now() - make_interval(days => retention_days);
+  GET DIAGNOSTICS deleted = ROW_COUNT;
+  RETURN deleted;
+END;
+$$;
+
+-- Archive audit_logs older than 90 days to a partitioned archive
+-- For now, just provide the cleanup function; partitioning can be added later.
+CREATE OR REPLACE FUNCTION cleanup_old_audit_logs(retention_days int DEFAULT 90)
+RETURNS bigint
+LANGUAGE plpgsql AS $$
+DECLARE
+  deleted bigint;
+BEGIN
+  DELETE FROM audit_logs
+  WHERE timestamp < now() - make_interval(days => retention_days);
+  GET DIAGNOSTICS deleted = ROW_COUNT;
+  RETURN deleted;
+END;
+$$;
+
+-- Cleanup billing_events older than 365 days
+CREATE OR REPLACE FUNCTION cleanup_old_billing_events(retention_days int DEFAULT 365)
+RETURNS bigint
+LANGUAGE plpgsql AS $$
+DECLARE
+  deleted bigint;
+BEGIN
+  DELETE FROM billing_events
+  WHERE occurred_at < now() - make_interval(days => retention_days);
+  GET DIAGNOSTICS deleted = ROW_COUNT;
+  RETURN deleted;
+END;
+$$;

--- a/package/src/inferia/services/orchestration/server.py
+++ b/package/src/inferia/services/orchestration/server.py
@@ -106,8 +106,11 @@ async def serve():
     server = grpc.aio.server(
         interceptors=[grpc_auth],
         options=[
-            ("grpc.max_concurrent_streams", 10000),
+            ("grpc.max_concurrent_streams", 200),
+            ("grpc.max_receive_message_length", 16 * 1024 * 1024),  # 16 MB
+            ("grpc.max_send_message_length", 16 * 1024 * 1024),  # 16 MB
         ],
+        maximum_concurrent_rpcs=200,
     )
 
     # Initialize database and event bus


### PR DESCRIPTION
## Summary
- SQL retention functions: `cleanup_published_outbox_events(7d)`, `cleanup_dead_outbox_events(30d)`, `cleanup_old_audit_logs(90d)`, `cleanup_old_billing_events(365d)`
- gRPC server: reduces `max_concurrent_streams` from 10000→200, adds 16MB message size limits and `maximum_concurrent_rpcs=200`
- Docker Compose: adds `deploy.resources.limits` for all services (postgres 2G, redis 512M, app 4G, ES 2G, logstash 1G, kibana 1G)
- ES heap increased from 512m→1g to match container limit

Closes #82, closes #92, closes #97

## Test plan
- [x] Retention functions are PL/pgSQL — callable via `SELECT cleanup_published_outbox_events()`
- [x] gRPC limits prevent resource exhaustion while supporting realistic workloads
- [x] Docker limits prevent OOM-kill cascades in unified mode