### PR TITLE
fix: Nosana instance lifecycle bugs — creation, termination, logging, insights

### DIFF
--- a/package/src/inferia/services/orchestration/config.py
+++ b/package/src/inferia/services/orchestration/config.py
@@ -117,6 +117,7 @@ class Settings(BaseSettings):
     # Deployment Retry Logic
     max_deployment_retries: int = Field(
         default=2, validation_alias="MAX_DEPLOYMENT_RETRIES"
+    )
     # Deployment Log Persistence (Elasticsearch)
     elasticsearch_url: Optional[str] = Field(
         default=None, validation_alias="ELASTICSEARCH_URL"

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/nosana/nosana_adapter.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/nosana/nosana_adapter.py
@@ -494,7 +494,7 @@ class NosanaAdapter(ProviderAdapter):
                     job_data = await resp.json()
                     node_address = job_data.get("nodeAddress")
                     job_state = job_data.get("jobState")
-                    is_finished = job_state in (2, 3, 4, "COMPLETED", "STOPPED")
+                    is_finished = job_state in TERMINAL_JOB_STATES
 
                     if not node_address and not is_finished:
                         raise RuntimeError("Job does not have a node assigned yet")

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
@@ -866,7 +866,7 @@ async def terminate_deployment(req: TerminateDeploymentRequest):
 
     return {
         "deployment_id": req.deployment_id,
-        "status": "TERMINATED",
+        "status": "TERMINATING",
     }
 
 
@@ -919,6 +919,9 @@ async def delete_deployment(deployment_id: str):
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid deployment ID format")
 
+    # Capture org_id BEFORE deletion so the audit log has it
+    audit_org_id = await _lookup_org_id("deployment", deployment_id)
+
     try:
         conn = await asyncpg.connect(POSTGRES_DSN)
         try:
@@ -970,7 +973,7 @@ async def delete_deployment(deployment_id: str):
         resource_type="deployment",
         resource_id=deployment_id,
         status="success",
-        org_id=await _lookup_org_id("deployment", deployment_id),
+        org_id=audit_org_id,
     )
 
     return {
@@ -1341,9 +1344,9 @@ async def list_deployments(pool_id: str | None = None):
                 "engine": d.engine,
                 "endpoint": d.endpoint,
                 "org_id": d.org_id,
+                "error_message": d.error_message or None,
             }
             for d in resp.deployments
-            # if not d.state.lower().startswith("terminat") # Showing all for sticky deployment visibility
         ]
     }
 
@@ -1365,10 +1368,10 @@ async def get_deployment_logs(deployment_id: str):
 
     conn = await asyncpg.connect(POSTGRES_DSN)
     try:
-        # Get pool_id to identify provider
+        # Get pool_id to identify provider and credential
         dep = await conn.fetchrow(
             """
-            SELECT d.pool_id, p.provider, d.state 
+            SELECT d.pool_id, p.provider, p.provider_credential_name, d.state
             FROM model_deployments d
             JOIN compute_pools p ON d.pool_id = p.id
             WHERE d.deployment_id = $1
@@ -1380,6 +1383,7 @@ async def get_deployment_logs(deployment_id: str):
             raise HTTPException(status_code=404, detail="Deployment/Pool not found")
 
         provider = dep["provider"]
+        provider_credential_name = dep.get("provider_credential_name")
 
         # 2. Get the Node ID / Provider Instance ID
         # Since compute_inventory lacks deployment_id, we look up via model_deployments.node_ids
@@ -1417,7 +1421,8 @@ async def get_deployment_logs(deployment_id: str):
             adapter = get_adapter(provider)
             if hasattr(adapter, "get_logs"):
                 logs_data = await adapter.get_logs(
-                    provider_instance_id=provider_instance_id
+                    provider_instance_id=provider_instance_id,
+                    provider_credential_name=provider_credential_name,
                 )
                 if logs_data and logs_data.get("logs"):
                     return logs_data
@@ -1555,7 +1560,7 @@ async def list_all_deployments(org_id: str | None = None):
             {
                 "deployment_id": d.deployment_id,
                 "model_name": d.model_name,
-                "model_version": d.model_version + (" (Compute)" if d.pool_id else ""),
+                "model_version": d.model_version,
                 "state": d.state,
                 "replicas": d.replicas,
                 "pool_id": d.pool_id,

--- a/package/src/inferia/services/orchestration/services/model_deployment/worker.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/worker.py
@@ -51,14 +51,6 @@ class ModelDeploymentWorker:
 
         current_state = d.get("state")
         log.info(f"Handling deploy request for {deployment_id}. State: {current_state}")
-        if not d:
-            log.warning(
-                f"Skipping deploy for {deployment_id} because deployment not found in database"
-            )
-            return
-
-        current_state = d.get("state")
-        log.info(f"Handling deploy request for {deployment_id}. State: {current_state}")
 
         if current_state not in ("PENDING", None):
             log.warning(
@@ -69,6 +61,8 @@ class ModelDeploymentWorker:
         # Treat NULL state as PENDING - fix for deployments with NULL state
         if current_state is None:
             log.info(f"Deployment {deployment_id} has NULL state, treating as PENDING")
+            # First set the NULL state to PENDING explicitly so the CAS can match it
+            await self.deployments.update_state(deployment_id, "PENDING")
             d = dict(d)
             d["state"] = "PENDING"
 
@@ -357,8 +351,8 @@ class ModelDeploymentWorker:
                     if d.get("engine"):
                         metadata["engine"] = d["engine"]
 
-                    # 2. Legacy / Registry Fallback
-                    elif model:
+                    # 2. Legacy / Registry Fallback (only if no configuration was set)
+                    if not metadata and model:
                         metadata = {
                             "image": model["artifact_uri"],
                             "cmd": [
@@ -417,6 +411,20 @@ class ModelDeploymentWorker:
                             f"Deployment {deployment_id} state changed to "
                             f"{d_latest.get('state') if d_latest else 'None'} during provisioning. Aborting."
                         )
+                        # Cleanup the provisioned node to avoid orphaned resources
+                        if node_spec and node_spec.get("provider_instance_id"):
+                            try:
+                                cleanup_adapter = get_adapter(pool["provider"])
+                                log.info(
+                                    f"Cleaning up orphaned node {node_spec['provider_instance_id']} "
+                                    f"after safety check abort for {deployment_id}"
+                                )
+                                await cleanup_adapter.deprovision_node(
+                                    provider_instance_id=node_spec["provider_instance_id"],
+                                    provider_credential_name=pool.get("provider_credential_name"),
+                                )
+                            except Exception as cleanup_err:
+                                log.warning(f"Failed to cleanup orphaned node on abort: {cleanup_err}")
                         return
 
                     if not expose_url or expose_url.endswith("-ready"):


### PR DESCRIPTION
## Summary

Fixes 11 bugs across 4 files affecting Nosana instance creation, termination, log retrieval, and deployment insights.

### Creation fixes
- Remove duplicated fetch/check block in worker `handle_deploy_requested` (double DB query + duplicate logs)
- Fix NULL state deployments stuck forever — CAS `WHERE state='PENDING'` never matches NULL
- Fix legacy model registry fallback overwriting configuration-based metadata (`elif` chained to wrong `if`)
- Fix SyntaxError in `config.py` — unclosed parenthesis on `max_deployment_retries` preventing service startup

### Termination fixes
- Fix `/terminate` returning `"TERMINATED"` when actual state is `"TERMINATING"`
- Fix `/delete` audit log losing `org_id` — lookup was called after record deletion
- Fix orphaned node leak when safety check aborts during provisioning

### Logging fixes
- Fix `/logs` endpoint missing `provider_credential_name` — breaks multi-credential log retrieval
- Fix `is_finished` in `nosana_adapter.py` missing FAILED/QUIT states — causes false errors for failed jobs

### Insights / API response fixes
- Fix `model_version` corrupted by appending `" (Compute)"` in list deployments API
- Fix `listDeployments` missing `error_message` field (inconsistent with `/deployments` endpoint)

## Test plan
- [x] All 3 modified Python files compile successfully
- [x] 31/31 model deployment + nosana unit tests pass
- [x] 81/81 non-infra-dependent orchestration tests pass (7 pre-existing failures from missing `elasticsearch` module — unrelated)

Closes #222, #223, #224, #225, #226, #227