### PR TITLE
Fix duplicated deploy block, NULL state CAS, metadata overwrite, and orphaned node

### DIFF
--- a/package/src/inferia/services/orchestration/services/model_deployment/worker.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/worker.py
@@ -51,14 +51,6 @@ class ModelDeploymentWorker:
 
         current_state = d.get("state")
         log.info(f"Handling deploy request for {deployment_id}. State: {current_state}")
-        if not d:
-            log.warning(
-                f"Skipping deploy for {deployment_id} because deployment not found in database"
-            )
-            return
-
-        current_state = d.get("state")
-        log.info(f"Handling deploy request for {deployment_id}. State: {current_state}")
 
         if current_state not in ("PENDING", None):
             log.warning(
@@ -69,6 +61,7 @@ class ModelDeploymentWorker:
         # Treat NULL state as PENDING - fix for deployments with NULL state
         if current_state is None:
             log.info(f"Deployment {deployment_id} has NULL state, treating as PENDING")
+            await self.deployments.update_state(deployment_id, "PENDING")
             d = dict(d)
             d["state"] = "PENDING"
 
@@ -358,7 +351,7 @@ class ModelDeploymentWorker:
                         metadata["engine"] = d["engine"]
 
                     # 2. Legacy / Registry Fallback
-                    elif model:
+                    if not metadata and model:
                         metadata = {
                             "image": model["artifact_uri"],
                             "cmd": [
@@ -417,6 +410,22 @@ class ModelDeploymentWorker:
                             f"Deployment {deployment_id} state changed to "
                             f"{d_latest.get('state') if d_latest else 'None'} during provisioning. Aborting."
                         )
+                        # Deprovision the already-provisioned node to avoid orphaned resources
+                        if node_spec and node_spec.get("provider_instance_id"):
+                            try:
+                                cleanup_adapter = get_adapter(pool["provider"])
+                                log.info(
+                                    f"Cleaning up orphaned node {node_spec['provider_instance_id']} "
+                                    f"after safety-check abort for {deployment_id}"
+                                )
+                                await cleanup_adapter.deprovision_node(
+                                    provider_instance_id=node_spec["provider_instance_id"],
+                                    provider_credential_name=pool.get("provider_credential_name"),
+                                )
+                            except Exception as cleanup_err:
+                                log.warning(
+                                    f"Failed to cleanup node after safety-check abort: {cleanup_err}"
+                                )
                         return
 
                     if not expose_url or expose_url.endswith("-ready"):


### PR DESCRIPTION
## Summary — 4 bugs in deployment worker

| Bug | Issue | Fix |
|-----|-------|-----|
| Duplicated fetch/log block | #222 | Removed duplicate lines 54-61 |
| NULL state deployments stuck forever | #222 | Explicit `update_state(PENDING)` before CAS |
| `elif model:` overwrites config metadata | #223 | Changed to `if not metadata and model:` |
| Orphaned node on safety-check abort | #223 | Added deprovision cleanup before early return |

Closes #222
Closes #223