### PR TITLE
Fix Ollama model naming format in deployment config

### DIFF
--- a/apps/dashboard/src/pages/NewDeployment.tsx
+++ b/apps/dashboard/src/pages/NewDeployment.tsx
@@ -736,7 +736,8 @@ export default function NewDeployment() {
       }
       return JSON.stringify(spec, null, 4)
     } else if (selectedEngine === "ollama") {
-      return JSON.stringify({ image: "ollama/ollama:latest", cmd: ["serve"], expose: [{ port: 11434, type: "http" }], gpu: true }, null, 4)
+      const finalModelId = modelId || "llama3:8b";
+      return JSON.stringify({ model_id: finalModelId, engine: "ollama", image: "ollama/ollama:latest", cmd: ["serve"], expose: [{ port: 11434, type: "http" }], gpu: true }, null, 4)
     } else if (selectedEngine === "infinity") {
       const finalModelId = modelId || "sentence-transformers/all-MiniLM-L6-v2";
       const spec = {


### PR DESCRIPTION
## Summary
Ollama config preview was missing `model_id` and `engine` fields, so the backend wouldn't know which model to `ollama pull`.

Added `model_id` (defaulting to `llama3:8b` in Ollama's `model:tag` format) and `engine: "ollama"` to the generated config.

Closes #232