### PR TITLE
Make external provider proxy hot-swappable via EXTERNAL_PROXY_URL

### DIFF
--- a/package/src/inferia/services/inference/config.py
+++ b/package/src/inferia/services/inference/config.py
@@ -59,6 +59,18 @@ class Settings(BaseSettings):
         description="Verify SSL certificates for HTTPS service calls",
     )
 
+    # External Provider Proxy (e.g., InferiaGate)
+    # When set, all external provider requests (OpenAI, Anthropic, etc.) are
+    # routed through this URL instead of directly to the provider's API.
+    # The proxy must accept OpenAI-compatible /v1/chat/completions format.
+    # Set to empty string or omit to use direct provider connections.
+    external_proxy_url: Optional[str] = Field(
+        default=None,
+        alias="EXTERNAL_PROXY_URL",
+        validation_alias="EXTERNAL_PROXY_URL",
+        description="URL of external LLM proxy (e.g., InferiaGate). Routes all external provider traffic through this proxy.",
+    )
+
     # Timeouts
     request_timeout: int = 30
 

--- a/package/src/inferia/services/inference/core/handlers/completion.py
+++ b/package/src/inferia/services/inference/core/handlers/completion.py
@@ -14,7 +14,7 @@ from fastapi.responses import StreamingResponse
 from inferia.services.inference.client import api_gateway_client
 from inferia.services.inference.config import settings
 from ..pipeline import Pipeline, RequestContext
-from ..providers import get_adapter, is_external_engine
+from ..providers import get_adapter, is_external_engine, resolve_upstream
 from ..rate_limiter import rate_limiter
 from ..request_logger import RequestLogger
 from ..service import GatewayService
@@ -125,7 +125,9 @@ class CompletionHandler:
         endpoint_url = endpoint_url.strip()
 
         engine = deployment.get("engine", "vllm")
-        adapter = get_adapter(engine)
+        adapter, endpoint_url = resolve_upstream(
+            engine, endpoint_url, settings.external_proxy_url,
+        )
 
         credentials = (
             deployment.get("credentials_json") or deployment.get("configuration") or {}

--- a/package/src/inferia/services/inference/core/pipeline.py
+++ b/package/src/inferia/services/inference/core/pipeline.py
@@ -14,7 +14,7 @@ from fastapi import BackgroundTasks, HTTPException
 
 from inferia.services.inference.client import api_gateway_client
 from inferia.services.inference.config import settings
-from .providers import ProviderAdapter, get_adapter, is_external_engine
+from .providers import ProviderAdapter, get_adapter, is_external_engine, resolve_upstream
 from .rate_limiter import rate_limiter
 from .service import GatewayService
 
@@ -118,8 +118,10 @@ class Pipeline:
         deployment = ctx.deployment
         engine = deployment.get("engine", default_engine)
         ctx.engine = engine
-        ctx.endpoint_url = deployment.get("endpoint", "")
-        ctx.adapter = get_adapter(engine)
+        raw_endpoint = deployment.get("endpoint", "")
+        ctx.adapter, ctx.endpoint_url = resolve_upstream(
+            engine, raw_endpoint, settings.external_proxy_url,
+        )
 
         # Resolve API key and model name from credentials
         if is_external_engine(engine):

--- a/package/src/inferia/services/inference/core/providers/__init__.py
+++ b/package/src/inferia/services/inference/core/providers/__init__.py
@@ -24,6 +24,7 @@ from .registry import (
     get_adapter,
     is_external_provider,
     is_external_engine,
+    resolve_upstream,
     EXTERNAL_PROVIDERS,
     TEXT_INFERENCE_ENGINES,
     EMBEDDING_ENGINES,
@@ -53,6 +54,7 @@ __all__ = [
     "get_adapter",
     "is_external_provider",
     "is_external_engine",
+    "resolve_upstream",
     # Category sets
     "EXTERNAL_PROVIDERS",
     "TEXT_INFERENCE_ENGINES",

--- a/package/src/inferia/services/inference/core/providers/registry.py
+++ b/package/src/inferia/services/inference/core/providers/registry.py
@@ -96,3 +96,28 @@ def is_external_provider(engine: str) -> bool:
 
 # Backward-compat alias
 is_external_engine = is_external_provider
+
+
+def resolve_upstream(
+    engine: str,
+    endpoint_url: str,
+    proxy_url: str | None = None,
+) -> tuple[ProviderAdapter, str]:
+    """
+    Resolve the adapter and endpoint URL for a given engine.
+
+    When proxy_url is set and the engine is an external provider, routes
+    through the proxy using OpenAI-compatible format. Otherwise uses the
+    direct provider endpoint with the engine-specific adapter.
+
+    Returns:
+        (adapter, effective_endpoint_url)
+    """
+    if is_external_provider(engine) and proxy_url:
+        logger.info(
+            "Routing external request through proxy: %s (engine=%s)",
+            proxy_url, engine,
+        )
+        return get_adapter("openai"), proxy_url.rstrip("/")
+
+    return get_adapter(engine), endpoint_url


### PR DESCRIPTION
## Summary
Adds a single env var to route ALL external provider traffic (OpenAI, Anthropic, Groq, etc.) through a unified proxy like InferiaGate.

### How it works
```bash
# Direct to providers (default — no change)
inferiallm start

# Through InferiaGate proxy
EXTERNAL_PROXY_URL=http://inferiagate:8080 inferiallm start
```

When `EXTERNAL_PROXY_URL` is set:
- External engine requests → proxy URL (OpenAI-compatible format)
- Compute engine requests (vLLM, Ollama, etc.) → direct to node (unchanged)

When unset: current direct-to-provider behavior, zero changes.

### Implementation
- `resolve_upstream(engine, endpoint_url, proxy_url)` helper in provider registry
- Completion handler uses it for the chat/completion path
- Pipeline.resolve_provider uses it for embedding/image/video paths
- Forces OpenAI adapter when proxying (proxy speaks OpenAI format)

### Files changed
- `config.py` — added `EXTERNAL_PROXY_URL` setting
- `providers/registry.py` — added `resolve_upstream()` helper
- `providers/__init__.py` — exported new helper
- `handlers/completion.py` — uses `resolve_upstream`
- `pipeline.py` — uses `resolve_upstream` in `resolve_provider`

## Test plan
- [x] 111 inference tests pass
- [x] No behavioral change when EXTERNAL_PROXY_URL is unset