### PR TITLE
feat: pluggable inferia-auth authentication provider

### DIFF
--- a/package/src/inferia/services/api_gateway/config.py
+++ b/package/src/inferia/services/api_gateway/config.py
@@ -146,10 +146,25 @@ class Settings(BaseSettings):
     )
     allowed_origins: str = "http://localhost:3001,http://localhost:8001,http://localhost:5173"  # Comma-separated list
 
+    # Auth Provider: "builtin" uses local JWT+DB, "inferia-auth" delegates to inferia-auth service
+    auth_provider: Literal["builtin", "inferia-auth"] = Field(
+        default="builtin", validation_alias="AUTH_PROVIDER"
+    )
+    inferia_auth_url: Optional[str] = Field(
+        default=None,
+        validation_alias="INFERIA_AUTH_URL",
+        description="Base URL of inferia-auth service (e.g. http://localhost:3000)",
+    )
+    inferia_auth_public_key: Optional[str] = Field(
+        default=None,
+        validation_alias="INFERIA_AUTH_PUBLIC_KEY",
+        description="Base64-encoded Ed25519 public key for local JWT validation",
+    )
+
     # RBAC Settings
     jwt_secret_key: str = Field(
-        default="placeholder-secret-key-at-least-32-chars-long", 
-        min_length=32, 
+        default="placeholder-secret-key-at-least-32-chars-long",
+        min_length=32,
         validation_alias="JWT_SECRET_KEY"
     )
     jwt_algorithm: str = "HS256"

--- a/package/src/inferia/services/api_gateway/rbac/inferia_auth_provider.py
+++ b/package/src/inferia/services/api_gateway/rbac/inferia_auth_provider.py
@@ -1,0 +1,139 @@
+"""
+Optional authentication provider that delegates token validation to inferia-auth.
+
+Supports two modes:
+  1. Local validation using an Ed25519 public key (no HTTP call, preferred)
+  2. Remote introspection via inferia-auth's /api/v1/auth/introspect endpoint
+"""
+
+import base64
+import json
+import logging
+import time
+from typing import Optional
+
+import httpx
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.exceptions import InvalidSignature
+
+logger = logging.getLogger(__name__)
+
+
+class InferiaAuthClaims:
+    """Claims extracted from an inferia-auth JWT."""
+
+    __slots__ = ("subject", "subject_type", "subject_id", "email", "org_ids")
+
+    def __init__(
+        self,
+        subject: str,
+        subject_type: str,
+        subject_id: str,
+        email: str,
+        org_ids: list[str],
+    ):
+        self.subject = subject
+        self.subject_type = subject_type
+        self.subject_id = subject_id
+        self.email = email
+        self.org_ids = org_ids
+
+
+def _base64url_decode(s: str) -> bytes:
+    padding = 4 - len(s) % 4
+    if padding != 4:
+        s += "=" * padding
+    return base64.urlsafe_b64decode(s)
+
+
+class InferiaAuthProvider:
+    """Validates inferia-auth JWTs either locally or via HTTP introspection."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        public_key_b64: Optional[str] = None,
+    ):
+        self._base_url = base_url.rstrip("/") if base_url else None
+        self._public_key: Optional[Ed25519PublicKey] = None
+
+        if public_key_b64:
+            key_bytes = base64.b64decode(public_key_b64)
+            self._public_key = Ed25519PublicKey.from_public_bytes(key_bytes)
+
+        if not self._public_key and not self._base_url:
+            raise ValueError(
+                "InferiaAuthProvider requires INFERIA_AUTH_PUBLIC_KEY "
+                "or INFERIA_AUTH_URL (or both)"
+            )
+
+    def validate_token_local(self, token: str) -> Optional[InferiaAuthClaims]:
+        """Validate JWT locally using the Ed25519 public key."""
+        if not self._public_key:
+            return None
+
+        try:
+            parts = token.split(".")
+            if len(parts) != 3:
+                return None
+
+            signature = _base64url_decode(parts[2])
+            signing_input = f"{parts[0]}.{parts[1]}".encode()
+
+            self._public_key.verify(signature, signing_input)
+
+            payload = json.loads(_base64url_decode(parts[1]))
+
+            if payload.get("exp", 0) < time.time():
+                logger.debug("inferia-auth token expired")
+                return None
+
+            sub = payload.get("sub", "")
+            return InferiaAuthClaims(
+                subject=sub,
+                subject_type=payload.get("type", ""),
+                subject_id=sub.split(":", 1)[1] if ":" in sub else sub,
+                email=payload.get("email", ""),
+                org_ids=payload.get("org_ids", []),
+            )
+        except (InvalidSignature, Exception) as exc:
+            logger.debug("local JWT validation failed: %s", exc)
+            return None
+
+    async def validate_token_remote(self, token: str) -> Optional[InferiaAuthClaims]:
+        """Validate JWT via inferia-auth's introspect endpoint."""
+        if not self._base_url:
+            return None
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(
+                    f"{self._base_url}/api/v1/auth/introspect",
+                    json={"token": token},
+                )
+                if resp.status_code != 200:
+                    return None
+
+                data = resp.json()
+                if not data.get("valid"):
+                    return None
+
+                return InferiaAuthClaims(
+                    subject=data.get("subject", ""),
+                    subject_type=data.get("subject_type", ""),
+                    subject_id=data.get("subject_id", ""),
+                    email=data.get("email", ""),
+                    org_ids=data.get("org_ids", []),
+                )
+        except Exception as exc:
+            logger.error("inferia-auth introspect failed: %s", exc)
+            return None
+
+    async def validate_token(self, token: str) -> Optional[InferiaAuthClaims]:
+        """Validate token using local key first, falling back to remote introspection."""
+        if self._public_key:
+            claims = self.validate_token_local(token)
+            if claims is not None:
+                return claims
+
+        return await self.validate_token_remote(token)

--- a/package/src/inferia/services/api_gateway/rbac/middleware.py
+++ b/package/src/inferia/services/api_gateway/rbac/middleware.py
@@ -1,3 +1,4 @@
+import logging
 from fastapi import Request, HTTPException, status, Depends
 from fastapi.security import HTTPBearer
 from typing import Optional, List
@@ -8,12 +9,29 @@ from inferia.services.api_gateway.models import UserContext, PermissionEnum
 from inferia.services.api_gateway.rbac.auth import auth_service
 from inferia.services.api_gateway.db.database import AsyncSessionLocal
 from inferia.services.api_gateway.rbac.permissions import normalize_permissions
+from inferia.services.api_gateway.config import settings
+
+logger = logging.getLogger(__name__)
 
 security = HTTPBearer()
 
 # Short-TTL cache: (token) → (user, org_id, roles, permissions)
 # 30s TTL avoids stale permissions while eliminating 3 DB queries/request
 _auth_cache: TTLCache = TTLCache(maxsize=2048, ttl=30)
+
+# Lazy-initialized inferia-auth provider (only created when auth_provider == "inferia-auth")
+_inferia_auth_provider = None
+
+
+def _get_inferia_auth_provider():
+    global _inferia_auth_provider
+    if _inferia_auth_provider is None:
+        from inferia.services.api_gateway.rbac.inferia_auth_provider import InferiaAuthProvider
+        _inferia_auth_provider = InferiaAuthProvider(
+            base_url=settings.inferia_auth_url,
+            public_key_b64=settings.inferia_auth_public_key,
+        )
+    return _inferia_auth_provider
 
 
 def _auth_error_response(
@@ -26,10 +44,138 @@ def _auth_error_response(
     )
 
 
+async def _authenticate_builtin(token: str, request: Request):
+    """Authenticate using the built-in JWT + DB auth service."""
+    async with AsyncSessionLocal() as db:
+        # Validate token and get user (Async)
+        user, org_id, roles = await auth_service.get_current_user(db, token)
+
+        # Determine permissions based on roles (Dynamic from DB)
+        from sqlalchemy.future import select
+        from inferia.services.api_gateway.db.models import Role
+
+        permissions_set = set()
+        if roles:
+            stmt = select(Role).where(Role.name.in_(roles))
+            result = await db.execute(stmt)
+            role_records = result.scalars().all()
+            for r in role_records:
+                if r.permissions:
+                    permissions_set.update(r.permissions)
+
+        permissions, _, _ = normalize_permissions(permissions_set)
+
+        quota_limit = 10000
+        quota_used = 0
+
+        return UserContext(
+            user_id=user.id,
+            username=user.email,
+            email=user.email,
+            roles=roles,
+            permissions=permissions,
+            org_id=org_id,
+            quota_limit=quota_limit,
+            quota_used=quota_used,
+        )
+
+
+async def _authenticate_inferia_auth(token: str, request: Request):
+    """Authenticate using inferia-auth service, then resolve local roles."""
+    provider = _get_inferia_auth_provider()
+    claims = await provider.validate_token(token)
+    if claims is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+        )
+
+    # Resolve local user and permissions from DB by email
+    async with AsyncSessionLocal() as db:
+        from sqlalchemy.future import select
+        from sqlalchemy import func
+        from inferia.services.api_gateway.db.models import (
+            User as DBUser,
+            UserOrganization,
+            Role,
+        )
+
+        result = await db.execute(
+            select(DBUser).where(func.lower(DBUser.email) == claims.email.lower())
+        )
+        user = result.scalars().first()
+
+        if not user:
+            # Auto-provision: create a local user record for the externally-authenticated user
+            user = DBUser(email=claims.email, password_hash="external:inferia-auth")
+            db.add(user)
+            await db.flush()
+
+            # Link to first available org if any org_ids came from inferia-auth
+            from inferia.services.api_gateway.db.models import Organization
+
+            if claims.org_ids:
+                org_result = await db.execute(
+                    select(Organization).limit(1)
+                )
+                org = org_result.scalars().first()
+                if org:
+                    uo = UserOrganization(
+                        user_id=user.id, org_id=org.id, role="member"
+                    )
+                    db.add(uo)
+                    user.default_org_id = org.id
+            await db.commit()
+            await db.refresh(user)
+
+        # Resolve org membership and roles
+        org_id = None
+        roles = ["member"]
+
+        membership_stmt = (
+            select(UserOrganization)
+            .where(UserOrganization.user_id == user.id)
+            .order_by(UserOrganization.created_at.asc())
+        )
+        membership_res = await db.execute(membership_stmt)
+        membership = membership_res.scalars().first()
+
+        if membership:
+            org_id = membership.org_id
+            roles = [membership.role]
+
+        # Resolve permissions from roles
+        permissions_set = set()
+        if roles:
+            stmt = select(Role).where(Role.name.in_(roles))
+            result = await db.execute(stmt)
+            role_records = result.scalars().all()
+            for r in role_records:
+                if r.permissions:
+                    permissions_set.update(r.permissions)
+
+        permissions, _, _ = normalize_permissions(permissions_set)
+
+        return UserContext(
+            user_id=user.id,
+            username=user.email,
+            email=claims.email,
+            roles=roles,
+            permissions=permissions,
+            org_id=org_id,
+            quota_limit=10000,
+            quota_used=0,
+        )
+
+
 async def auth_middleware(request: Request, call_next):
     """
     Authentication middleware that validates JWT token and extracts user context.
     Adds user context to request.state if authenticated.
+
+    Supports two auth providers controlled by AUTH_PROVIDER env var:
+      - "builtin" (default): local JWT validation + DB user lookup
+      - "inferia-auth": delegates to inferia-auth service for token validation
     """
     # Skip auth for WebSocket connections - they handle auth differently (via query params)
     # Check both 'upgrade' header and the connection type
@@ -96,64 +242,32 @@ async def auth_middleware(request: Request, call_next):
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Check cache first to avoid 3 DB queries per request
+    # Check cache first to avoid repeated DB/HTTP queries
     cached = _auth_cache.get(token)
     if cached is not None:
         request.state.user = cached
     else:
-        # Create DB Session for Auth
-        async with AsyncSessionLocal() as db:
-            try:
-                # Validate token and get user (Async)
-                user, org_id, roles = await auth_service.get_current_user(db, token)
+        try:
+            if settings.auth_provider == "inferia-auth":
+                user_context = await _authenticate_inferia_auth(token, request)
+            else:
+                user_context = await _authenticate_builtin(token, request)
 
-                # Determine permissions based on roles (Dynamic from DB)
-                from sqlalchemy.future import select
-                from inferia.services.api_gateway.db.models import Role
+            request.state.user = user_context
+            _auth_cache[token] = user_context
 
-                permissions_set = set()
-                if roles:
-                    stmt = select(Role).where(Role.name.in_(roles))
-                    result = await db.execute(stmt)
-                    role_records = result.scalars().all()
-                    for r in role_records:
-                        if r.permissions:
-                            permissions_set.update(r.permissions)
-
-                permissions, _, _ = normalize_permissions(permissions_set)
-
-                # Mock Quota (until quota model implemented)
-                # Default to high limit
-                quota_limit = 10000
-                quota_used = 0
-
-                # Create user context
-                user_context = UserContext(
-                    user_id=user.id,
-                    username=user.email,
-                    email=user.email,
-                    roles=roles,
-                    permissions=permissions,
-                    org_id=org_id,
-                    quota_limit=quota_limit,
-                    quota_used=quota_used,
-                )
-
-                # Add user context to request state and cache
-                request.state.user = user_context
-                _auth_cache[token] = user_context
-
-            except HTTPException as e:
-                return _auth_error_response(
-                    e.status_code,
-                    e.detail if isinstance(e.detail, str) else str(e.detail),
-                    headers=getattr(e, "headers", None),
-                )
-            except Exception as e:
-                return _auth_error_response(
-                    status.HTTP_401_UNAUTHORIZED,
-                    f"Authentication failed: {str(e)}",
-                )
+        except HTTPException as e:
+            return _auth_error_response(
+                e.status_code,
+                e.detail if isinstance(e.detail, str) else str(e.detail),
+                headers=getattr(e, "headers", None),
+            )
+        except Exception as e:
+            logger.exception("Authentication failed")
+            return _auth_error_response(
+                status.HTTP_401_UNAUTHORIZED,
+                f"Authentication failed: {str(e)}",
+            )
 
     response = await call_next(request)
     return response


### PR DESCRIPTION
## Summary

- Adds optional integration with [inferia-auth](https://github.com/InferiaAI/inferiaAuth) as an external authentication service
- Controlled via `AUTH_PROVIDER` env var: `builtin` (default, no change) or `inferia-auth`
- When using inferia-auth, tokens are validated either locally with an Ed25519 public key (`INFERIA_AUTH_PUBLIC_KEY`) or via HTTP introspection (`INFERIA_AUTH_URL`)
- Externally-authenticated users are auto-provisioned in the local DB so existing RBAC/permissions continue to work
- Zero impact when `AUTH_PROVIDER=builtin` (default) — all existing behavior is preserved

## Configuration

| Env Var | Required | Description |
|---------|----------|-------------|
| `AUTH_PROVIDER` | No | `builtin` (default) or `inferia-auth` |
| `INFERIA_AUTH_URL` | When using inferia-auth without public key | Base URL of inferia-auth service |
| `INFERIA_AUTH_PUBLIC_KEY` | When using inferia-auth without URL | Base64-encoded Ed25519 public key |

## Test plan

- [ ] Verify existing auth flow works unchanged with default config (`AUTH_PROVIDER=builtin`)
- [ ] Set `AUTH_PROVIDER=inferia-auth` with `INFERIA_AUTH_PUBLIC_KEY` and verify Ed25519 JWT validation
- [ ] Set `AUTH_PROVIDER=inferia-auth` with `INFERIA_AUTH_URL` and verify HTTP introspection flow
- [ ] Verify auto-provisioning creates local user on first external auth
- [ ] Verify cached tokens skip re-validation