### PR TITLE
feat: integrate inferia-auth as external auth provider

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,7 @@
 **/*.pyc
 **/*.pyo
 **/*.pyd
-.venv
+**/.venv
 .pytest_cache
 .coverage
 htmlcov

--- a/.env.sample
+++ b/.env.sample
@@ -33,6 +33,12 @@ REDIS_SSL=false
 SUPERADMIN_EMAIL="admin@example.com"
 SUPERADMIN_PASSWORD="CHANGE_THIS_TO_STRONG_PASSWORD"
 
+# External auth provider (inferia-auth).
+# Set AUTH_PROVIDER=external to delegate login/token-validation to inferia-auth.
+# Superadmin login always works locally regardless of this setting.
+AUTH_PROVIDER="local"
+EXTERNAL_AUTH_URL=""
+
 # JWT Secret Key - used for signing authentication tokens
 # Generate: openssl rand -hex 32
 JWT_SECRET_KEY="YOUR_32_BYTE_SECRET_KEY_HERE"

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -12,7 +12,13 @@ LOG_LEVEL="INFO"
 # --- Security & Authentication ---
 # CRITICAL: Change these in production!
 SUPERADMIN_EMAIL="admin@example.com"
-SUPERADMIN_PASSWORD="change-me-immediately"
+SUPERADMIN_PASSWORD="CHANGE_THIS_TO_STRONG_PASSWORD"
+
+# External auth provider (inferia-auth).
+# Set AUTH_PROVIDER=external to delegate login/token-validation to inferia-auth.
+# Superadmin login always works locally regardless of this setting.
+AUTH_PROVIDER="local"
+EXTERNAL_AUTH_URL=""
 
 # Used for signing JWT tokens. Generate with: openssl rand -hex 32
 JWT_SECRET_KEY="replace-this-with-a-very-long-random-string"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -56,7 +56,6 @@ services:
       dockerfile: docker/Dockerfile
     container_name: inferia-app
     restart: unless-stopped
-    pull_policy: always
     env_file: .env
     environment:
       - SERVICE_TYPE=unified
@@ -72,14 +71,9 @@ services:
     volumes:
       - appdata:/data
     ports:
-      - "8000:8000"   # Filtration Gateway
-      - "8001:8001"   # Inference Gateway
-      - "8002:8002"   # Guardrail Engine
-      - "8003:8003"   # Data Engine
-      - "8080:8080"   # Orchestration Gateway
-      - "8004:3000"   # DePIN Sidecar
-      - "3001:3001"   # Dashboard
-      - "50051:50051" # gRPC
+      - "8000:8000"   # Filtration Gateway (external API)
+      - "8001:8001"   # Inference Gateway (external API)
+      - "3001:3001"   # Dashboard (web UI)
     deploy:
       resources:
         limits:
@@ -108,8 +102,6 @@ services:
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
     volumes:
       - esdata:/usr/share/elasticsearch/data
-    ports:
-      - "9200:9200"
     deploy:
       resources:
         limits:
@@ -141,8 +133,6 @@ services:
       - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_PASSWORD:-}
     volumes:
       - ../docker/logstash/pipeline:/usr/share/logstash/pipeline:ro
-    ports:
-      - "${LOGSTASH_PORT:-5959}:5959"
     deploy:
       resources:
         limits:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       POSTGRES_DB: inferia
     volumes:
       - pgdata:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
     networks:
       - inferia-net
     healthcheck:
@@ -21,8 +19,6 @@ services:
   redis:
     image: redis:7
     container_name: inferia-redis
-    ports:
-      - "${REDIS_PORT:-6379}:6379"
     networks:
       - inferia-net
     healthcheck:
@@ -245,3 +241,4 @@ volumes:
 
 networks:
   inferia-net:
+    external: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,7 +46,17 @@ services:
       - ../.env
     environment:
       - POSTGRES_DSN=postgresql://inferia:inferia@inferia-postgres:5432/inferia
+      - DATABASE_URL=postgresql://inferia:inferia@inferia-postgres:5432/inferia
       - REDIS_URL=redis://inferia-redis:6379/0
+      - REDIS_HOST=inferia-redis
+      - PG_ADMIN_USER=${PG_ADMIN_USER:-inferia}
+      - PG_ADMIN_PASSWORD=${PG_ADMIN_PASSWORD:-inferia}
+      - PG_HOST=inferia-postgres
+      - PG_PORT=5432
+      - INFERIA_DB_USER=inferia
+      - INFERIA_DB_PASSWORD=inferia
+      - INFERIA_DB=inferia
+      - DATABASE_SSL=false
       - SERVICE_TYPE=unified
       # Dashboard frontend URLs (DASHBOARD_ prefix avoids colliding with
       # backend service URL env vars like INFERENCE_URL used by Pydantic config)
@@ -57,6 +67,8 @@ services:
       - LOGSTASH_HOST=${LOGSTASH_HOST:-}
       - LOGSTASH_PORT=${LOGSTASH_PORT:-5959}
       - FORWARDED_ALLOW_IPS=${FORWARDED_ALLOW_IPS:-}
+    volumes:
+      - appdata:/data
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -228,6 +240,7 @@ services:
 
 volumes:
   pgdata:
+  appdata:
   esdata:
 
 networks:

--- a/package/src/inferia/infra/schema/migrations/20260401_add_deployment_terminal_logs.sql
+++ b/package/src/inferia/infra/schema/migrations/20260401_add_deployment_terminal_logs.sql
@@ -1,0 +1,19 @@
+-- Migration: Add deployment_terminal_logs table for persisting terminal output
+-- on deployment failures, stops, and terminations.
+
+CREATE TABLE IF NOT EXISTS public.deployment_terminal_logs
+(
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    deployment_id uuid NOT NULL,
+    log_lines text[] NOT NULL DEFAULT '{}',
+    captured_at timestamp with time zone NOT NULL DEFAULT now(),
+    trigger_event text NOT NULL,  -- e.g. 'FAILED', 'STOPPED', 'TERMINATED'
+    CONSTRAINT deployment_terminal_logs_pkey PRIMARY KEY (id),
+    CONSTRAINT deployment_terminal_logs_deployment_fkey FOREIGN KEY (deployment_id)
+        REFERENCES public.model_deployments (deployment_id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_deployment_terminal_logs_deployment_id
+    ON public.deployment_terminal_logs USING btree (deployment_id);

--- a/package/src/inferia/services/api_gateway/app.py
+++ b/package/src/inferia/services/api_gateway/app.py
@@ -75,6 +75,9 @@ async def lifespan(app: FastAPI):
     await config_manager.initialize()
     config_manager.start_polling()
 
+    if settings.auth_provider == "external" and settings.external_auth_url:
+        logger.info(f"External auth enabled via: {settings.external_auth_url}")
+
     yield
     # Shutdown
     logger.info(f"Shutting down {settings.app_name}")
@@ -85,6 +88,10 @@ async def lifespan(app: FastAPI):
 
     await gateway_http_client.close_all()
     await rate_limiter.close()
+
+    if settings.auth_provider == "external":
+        from inferia.services.api_gateway.rbac.external_auth import close_client
+        await close_client()
 
 
 # Create FastAPI app

--- a/package/src/inferia/services/api_gateway/config.py
+++ b/package/src/inferia/services/api_gateway/config.py
@@ -133,6 +133,18 @@ class Settings(BaseSettings):
     # Multi-tenancy / Organization Settings
     default_org_name: str = "Default Organization"
 
+    # External Auth Provider (inferia-auth)
+    # Set to "external" to delegate authentication to inferia-auth service.
+    # Superadmin login always works locally regardless of this setting.
+    auth_provider: Literal["local", "external"] = Field(
+        default="local", validation_alias="AUTH_PROVIDER"
+    )
+    external_auth_url: Optional[str] = Field(
+        default=None,
+        validation_alias="EXTERNAL_AUTH_URL",
+        description="Base URL of the inferia-auth service (e.g. http://inferia-auth:3000)",
+    )
+
     # Superadmin credentials - MUST be set via environment variables in production
     superadmin_email: Optional[str] = Field(default=None, validation_alias="SUPERADMIN_EMAIL")
     superadmin_password: Optional[str] = Field(

--- a/package/src/inferia/services/api_gateway/rbac/external_auth.py
+++ b/package/src/inferia/services/api_gateway/rbac/external_auth.py
@@ -1,0 +1,105 @@
+"""
+HTTP client for delegating authentication to inferia-auth service.
+"""
+
+import logging
+from typing import Optional
+
+import httpx
+
+from inferia.services.api_gateway.config import settings
+
+logger = logging.getLogger(__name__)
+
+_client: Optional[httpx.AsyncClient] = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(
+            base_url=settings.external_auth_url.rstrip("/") + "/api/v1",
+            timeout=10.0,
+        )
+    return _client
+
+
+async def close_client():
+    global _client
+    if _client and not _client.is_closed:
+        await _client.aclose()
+        _client = None
+
+
+async def external_login(email: str, password: str) -> Optional[dict]:
+    """
+    Login via inferia-auth.
+
+    Returns the raw JSON response on success, None on auth failure.
+    Raises on network/unexpected errors.
+    """
+    client = _get_client()
+    resp = await client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+    )
+    if resp.status_code == 200:
+        return resp.json()
+    if resp.status_code in (401, 403):
+        return None
+    resp.raise_for_status()
+
+
+async def external_register(email: str, password: str, display_name: str) -> Optional[dict]:
+    """
+    Register a new user via inferia-auth.
+
+    Returns the raw JSON response on success, None on conflict/validation failure.
+    """
+    client = _get_client()
+    resp = await client.post(
+        "/auth/register",
+        json={"email": email, "password": password, "display_name": display_name},
+    )
+    if resp.status_code in (200, 201):
+        return resp.json()
+    if resp.status_code in (400, 409):
+        return None
+    resp.raise_for_status()
+
+
+async def external_introspect(token: str) -> Optional[dict]:
+    """
+    Validate a token via inferia-auth's introspect endpoint.
+
+    Returns introspect payload on success:
+      {"valid": bool, "subject": str, "subject_type": str,
+       "subject_id": str, "email": str, "org_ids": [...]}
+
+    Returns None on network error (caller should reject the token).
+    """
+    client = _get_client()
+    try:
+        resp = await client.post("/auth/introspect", json={"token": token})
+        if resp.status_code == 200:
+            return resp.json()
+        return None
+    except httpx.HTTPError:
+        logger.warning("Failed to reach inferia-auth for token introspection")
+        return None
+
+
+async def external_refresh(refresh_token: str) -> Optional[dict]:
+    """
+    Refresh tokens via inferia-auth.
+
+    Returns {"access_token": ..., "refresh_token": ...} on success.
+    """
+    client = _get_client()
+    resp = await client.post(
+        "/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    if resp.status_code == 200:
+        return resp.json()
+    return None

--- a/package/src/inferia/services/api_gateway/rbac/middleware.py
+++ b/package/src/inferia/services/api_gateway/rbac/middleware.py
@@ -3,11 +3,15 @@ from fastapi.security import HTTPBearer
 from typing import Optional, List
 from fastapi.responses import JSONResponse
 from cachetools import TTLCache
+import logging
 
 from inferia.services.api_gateway.models import UserContext, PermissionEnum
 from inferia.services.api_gateway.rbac.auth import auth_service
+from inferia.services.api_gateway.config import settings
 from inferia.services.api_gateway.db.database import AsyncSessionLocal
 from inferia.services.api_gateway.rbac.permissions import normalize_permissions
+
+logger = logging.getLogger(__name__)
 
 security = HTTPBearer()
 
@@ -26,10 +30,92 @@ def _auth_error_response(
     )
 
 
+async def _resolve_local_token(db, token: str) -> UserContext:
+    """Validate a locally-issued JWT and build UserContext."""
+    user, org_id, roles = await auth_service.get_current_user(db, token)
+
+    from sqlalchemy.future import select
+    from inferia.services.api_gateway.db.models import Role
+
+    permissions_set = set()
+    if roles:
+        stmt = select(Role).where(Role.name.in_(roles))
+        result = await db.execute(stmt)
+        role_records = result.scalars().all()
+        for r in role_records:
+            if r.permissions:
+                permissions_set.update(r.permissions)
+
+    permissions, _, _ = normalize_permissions(permissions_set)
+
+    return UserContext(
+        user_id=user.id,
+        username=user.email,
+        email=user.email,
+        roles=roles,
+        permissions=permissions,
+        org_id=org_id,
+        quota_limit=10000,
+        quota_used=0,
+    )
+
+
+async def _resolve_external_token(db, token: str) -> UserContext:
+    """
+    Validate a token issued by inferia-auth via its introspect endpoint,
+    then map the external identity to a local shadow user.
+    """
+    from inferia.services.api_gateway.rbac.external_auth import external_introspect
+    from inferia.services.api_gateway.rbac.shadow_user import get_or_create_shadow_user
+
+    result = await external_introspect(token)
+    if result is None or not result.get("valid"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    email = result.get("email", "")
+    external_user_id = result.get("subject_id", "")
+
+    user, org_id, roles = await get_or_create_shadow_user(
+        db, email=email, external_id=external_user_id
+    )
+
+    from sqlalchemy.future import select
+    from inferia.services.api_gateway.db.models import Role as RoleModel
+
+    permissions_set = set()
+    if roles:
+        stmt = select(RoleModel).where(RoleModel.name.in_(roles))
+        res = await db.execute(stmt)
+        for r in res.scalars().all():
+            if r.permissions:
+                permissions_set.update(r.permissions)
+
+    permissions, _, _ = normalize_permissions(permissions_set)
+
+    return UserContext(
+        user_id=user.id,
+        username=user.email,
+        email=user.email,
+        roles=roles,
+        permissions=permissions,
+        org_id=org_id,
+        quota_limit=10000,
+        quota_used=0,
+    )
+
+
 async def auth_middleware(request: Request, call_next):
     """
     Authentication middleware that validates JWT token and extracts user context.
     Adds user context to request.state if authenticated.
+
+    When AUTH_PROVIDER=external, tokens are validated in two steps:
+      1. Try local JWT decode (covers superadmin and locally-issued tokens).
+      2. If local decode fails, call inferia-auth introspect.
     """
     # Skip auth for WebSocket connections - they handle auth differently (via query params)
     # Check both 'upgrade' header and the connection type
@@ -96,50 +182,25 @@ async def auth_middleware(request: Request, call_next):
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Check cache first to avoid 3 DB queries per request
+    # Check cache first to avoid DB/network queries per request
     cached = _auth_cache.get(token)
     if cached is not None:
         request.state.user = cached
     else:
-        # Create DB Session for Auth
+        use_external = settings.auth_provider == "external" and settings.external_auth_url
+
         async with AsyncSessionLocal() as db:
             try:
-                # Validate token and get user (Async)
-                user, org_id, roles = await auth_service.get_current_user(db, token)
+                if not use_external:
+                    # Pure local auth
+                    user_context = await _resolve_local_token(db, token)
+                else:
+                    # External mode: try local first (superadmin), fall back to external
+                    try:
+                        user_context = await _resolve_local_token(db, token)
+                    except HTTPException:
+                        user_context = await _resolve_external_token(db, token)
 
-                # Determine permissions based on roles (Dynamic from DB)
-                from sqlalchemy.future import select
-                from inferia.services.api_gateway.db.models import Role
-
-                permissions_set = set()
-                if roles:
-                    stmt = select(Role).where(Role.name.in_(roles))
-                    result = await db.execute(stmt)
-                    role_records = result.scalars().all()
-                    for r in role_records:
-                        if r.permissions:
-                            permissions_set.update(r.permissions)
-
-                permissions, _, _ = normalize_permissions(permissions_set)
-
-                # Mock Quota (until quota model implemented)
-                # Default to high limit
-                quota_limit = 10000
-                quota_used = 0
-
-                # Create user context
-                user_context = UserContext(
-                    user_id=user.id,
-                    username=user.email,
-                    email=user.email,
-                    roles=roles,
-                    permissions=permissions,
-                    org_id=org_id,
-                    quota_limit=quota_limit,
-                    quota_used=quota_used,
-                )
-
-                # Add user context to request state and cache
                 request.state.user = user_context
                 _auth_cache[token] = user_context
 

--- a/package/src/inferia/services/api_gateway/rbac/router.py
+++ b/package/src/inferia/services/api_gateway/rbac/router.py
@@ -62,13 +62,18 @@ async def login(
 ):
     """
     Login endpoint to authenticate user and receive JWT tokens.
-    Authentication against Postgres Database.
-    Supports TOTP 2FA.
+
+    When AUTH_PROVIDER=external:
+      1. Try superadmin credentials locally first (always available).
+      2. If not superadmin, delegate to inferia-auth and auto-provision
+         a shadow user in the local DB.
+
+    When AUTH_PROVIDER=local (default): standard local-DB authentication.
     Rate limited: 5 attempts per minute.
     """
-    # Rate limiting check — use ASGI-level client IP only.
-    # Never trust X-Forwarded-For from the client; if behind a reverse proxy,
-    # configure uvicorn with --proxy-headers so it sets request.client correctly.
+    from inferia.services.api_gateway.config import settings as _settings
+
+    # Rate limiting check
     client_ip = http_request.client.host if http_request.client else "unknown"
 
     is_allowed, retry_after = login_rate_limiter.is_allowed(request.username, client_ip)
@@ -79,39 +84,59 @@ async def login(
             headers={"Retry-After": str(retry_after)},
         )
 
-    # 1. Authenticate user credentials first
+    use_external = (
+        _settings.auth_provider == "external" and _settings.external_auth_url
+    )
+
+    # --- Superadmin local login (always active) ---
     user = await auth_service.authenticate_user(db, request.username, request.password)
 
-    if not user:
-        # Log failed logic
-        await auth_service.log_failed_login(db, request.username)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Bearer"},
+    if user:
+        # 2FA check
+        enable_2fa = os.getenv("ENABLE_2FA", "true").lower() == "true"
+        if user.totp_enabled and enable_2fa:
+            if not request.totp_code:
+                raise HTTPException(status_code=403, detail="TOTP_REQUIRED")
+            totp = pyotp.TOTP(user.totp_secret)
+            if not totp.verify(request.totp_code):
+                raise HTTPException(status_code=401, detail="Invalid 2FA Code")
+        return await auth_service.login(db, request)
+
+    # --- External auth path ---
+    if use_external:
+        from inferia.services.api_gateway.rbac.external_auth import external_login
+        from inferia.services.api_gateway.rbac.shadow_user import get_or_create_shadow_user
+
+        ext_result = await external_login(request.username, request.password)
+        if ext_result is None:
+            await auth_service.log_failed_login(db, request.username)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Incorrect username or password",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # Provision shadow user so local DB references work
+        ext_email = (ext_result.get("user") or {}).get("email", request.username)
+        ext_user_id = (ext_result.get("user") or {}).get("id", "")
+        await get_or_create_shadow_user(db, email=ext_email, external_id=ext_user_id)
+
+        # Return the external tokens directly — the middleware will
+        # introspect them on subsequent requests.
+        return AuthToken(
+            access_token=ext_result["access_token"],
+            refresh_token=ext_result.get("refresh_token"),
+            token_type="bearer",
+            expires_in=900,
         )
 
-    # 2. Check 2FA
-    enable_2fa = os.getenv("ENABLE_2FA", "true").lower() == "true"
-
-    if user.totp_enabled and enable_2fa:
-        if not request.totp_code:
-            # Return specific error code for frontend to prompt 2FA
-            raise HTTPException(
-                status_code=403,
-                detail="TOTP_REQUIRED",
-            )
-
-        # Verify Code
-        totp = pyotp.TOTP(user.totp_secret)
-        if not totp.verify(request.totp_code):
-            raise HTTPException(
-                status_code=401,
-                detail="Invalid 2FA Code",
-            )
-
-    # 3. Proceed to Login
-    return await auth_service.login(db, request)
+    # --- Local auth failure ---
+    await auth_service.log_failed_login(db, request.username)
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Incorrect username or password",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 @router.post("/register", response_model=AuthToken)
@@ -362,7 +387,31 @@ async def refresh_token(
     db: AsyncSession = Depends(get_db),
 ):
     """Refresh access token using refresh token."""
-    return await auth_service.refresh_access_token(credentials.credentials, db)
+    from inferia.services.api_gateway.config import settings as _settings
+
+    # Try local refresh first (covers superadmin tokens)
+    try:
+        return await auth_service.refresh_access_token(credentials.credentials, db)
+    except HTTPException:
+        pass
+
+    # Fall back to external refresh if configured
+    use_external = (
+        _settings.auth_provider == "external" and _settings.external_auth_url
+    )
+    if use_external:
+        from inferia.services.api_gateway.rbac.external_auth import external_refresh
+
+        ext_result = await external_refresh(credentials.credentials)
+        if ext_result:
+            return AuthToken(
+                access_token=ext_result["access_token"],
+                refresh_token=ext_result.get("refresh_token"),
+                token_type="bearer",
+                expires_in=900,
+            )
+
+    raise HTTPException(status_code=401, detail="Refresh failed")
 
 
 @router.post("/logout")

--- a/package/src/inferia/services/api_gateway/rbac/shadow_user.py
+++ b/package/src/inferia/services/api_gateway/rbac/shadow_user.py
@@ -1,0 +1,111 @@
+"""
+Shadow-user provisioning for external auth (inferia-auth).
+
+When a user authenticates through inferia-auth, we need a corresponding
+row in InferiaLLM's local DB so that org membership, permissions, API keys,
+and audit logs can reference a real user record.
+
+The shadow user is created on first login and reused on subsequent ones.
+"""
+
+import logging
+import uuid
+from typing import Tuple, List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy import func
+
+from inferia.services.api_gateway.db.models import (
+    User as DBUser,
+    Organization,
+    UserOrganization,
+)
+
+logger = logging.getLogger(__name__)
+
+# Placeholder hash — shadow users never authenticate locally.
+_EXTERNAL_PASSWORD_PLACEHOLDER = "!external-auth-managed!"
+
+
+async def get_or_create_shadow_user(
+    db: AsyncSession,
+    *,
+    email: str,
+    external_id: str,
+) -> Tuple[DBUser, str, List[str]]:
+    """
+    Return (user, org_id, roles) for the given external identity.
+
+    If no local user exists with this email a shadow record is created,
+    added to the default organization as a ``member``.
+    """
+    normalized_email = email.strip().lower()
+
+    result = await db.execute(
+        select(DBUser).where(func.lower(DBUser.email) == normalized_email)
+    )
+    user = result.scalars().first()
+
+    if user is None:
+        # Create shadow user
+        org_stmt = select(Organization).limit(1)
+        org_res = await db.execute(org_stmt)
+        default_org = org_res.scalars().first()
+
+        user = DBUser(
+            id=str(uuid.uuid4()),
+            email=normalized_email,
+            password_hash=_EXTERNAL_PASSWORD_PLACEHOLDER,
+            default_org_id=default_org.id if default_org else None,
+        )
+        db.add(user)
+        await db.flush()
+
+        if default_org:
+            uo = UserOrganization(
+                user_id=user.id, org_id=default_org.id, role="member"
+            )
+            db.add(uo)
+
+        await db.commit()
+        await db.refresh(user)
+        logger.info("Created shadow user for external identity: %s", normalized_email)
+
+    # Resolve org membership
+    membership_stmt = (
+        select(UserOrganization)
+        .where(UserOrganization.user_id == user.id)
+        .order_by(UserOrganization.created_at.asc())
+    )
+    membership_res = await db.execute(membership_stmt)
+    memberships = membership_res.scalars().all()
+
+    if not memberships:
+        # Assign to default org as fallback
+        org_stmt = select(Organization).limit(1)
+        org_res = await db.execute(org_stmt)
+        default_org = org_res.scalars().first()
+        if default_org:
+            uo = UserOrganization(
+                user_id=user.id, org_id=default_org.id, role="member"
+            )
+            db.add(uo)
+            await db.commit()
+            memberships = [uo]
+
+    target_org_id = user.default_org_id
+    target_role = "member"
+    found = False
+
+    for m in memberships:
+        if target_org_id and m.org_id == target_org_id:
+            target_role = m.role
+            found = True
+            break
+
+    if not found and memberships:
+        target_org_id = memberships[0].org_id
+        target_role = memberships[0].role
+
+    return user, target_org_id, [target_role]

--- a/package/src/inferia/services/orchestration/repositories/terminal_log_repo.py
+++ b/package/src/inferia/services/orchestration/repositories/terminal_log_repo.py
@@ -1,0 +1,68 @@
+from typing import List, Optional
+from uuid import UUID
+
+from inferia.services.orchestration.repositories.base_repo import BaseRepository
+
+
+class TerminalLogRepository(BaseRepository):
+    """
+    Repository for persisting deployment terminal logs.
+
+    Logs are captured when a deployment transitions to FAILED, STOPPED,
+    or TERMINATED so that they remain accessible after the live stream ends.
+    """
+
+    async def save(
+        self,
+        *,
+        deployment_id: UUID,
+        log_lines: List[str],
+        trigger_event: str,
+        tx=None,
+    ) -> None:
+        q = """
+        INSERT INTO deployment_terminal_logs
+            (deployment_id, log_lines, trigger_event)
+        VALUES ($1, $2, $3)
+        """
+        conn = tx or self.db
+        if tx:
+            await conn.execute(q, deployment_id, log_lines, trigger_event)
+        else:
+            async with self.db.acquire() as c:
+                await c.execute(q, deployment_id, log_lines, trigger_event)
+
+    async def get_by_deployment(
+        self,
+        deployment_id: UUID,
+    ) -> Optional[dict]:
+        """Return the most recent terminal log snapshot for a deployment."""
+        async with self.db.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT id, deployment_id, log_lines, captured_at, trigger_event
+                FROM deployment_terminal_logs
+                WHERE deployment_id = $1
+                ORDER BY captured_at DESC
+                LIMIT 1
+                """,
+                deployment_id,
+            )
+        return dict(row) if row else None
+
+    async def get_all_by_deployment(
+        self,
+        deployment_id: UUID,
+    ) -> List[dict]:
+        """Return all terminal log snapshots for a deployment."""
+        async with self.db.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id, deployment_id, log_lines, captured_at, trigger_event
+                FROM deployment_terminal_logs
+                WHERE deployment_id = $1
+                ORDER BY captured_at DESC
+                """,
+                deployment_id,
+            )
+        return [dict(r) for r in rows]


### PR DESCRIPTION
## Summary

- Adds `AUTH_PROVIDER` config flag (`local`/`external`) and `EXTERNAL_AUTH_URL` to delegate authentication to the inferia-auth microservice
- Superadmin login remains active against the local database regardless of the auth provider setting
- External users are auto-provisioned as shadow users in the local DB with `member` role in the Default Organization
- Token validation middleware tries local JWT decode first (superadmin), then falls back to inferia-auth introspect
- Cleans up docker-compose port mappings and removes `pull_policy: always`

## New Files

- `rbac/external_auth.py` — HTTP client wrapping inferia-auth REST API (login, introspect, refresh, register)
- `rbac/shadow_user.py` — Auto-provisions local DB user records for external identities

## Config

```env
AUTH_PROVIDER="external"          # or "local" (default)
EXTERNAL_AUTH_URL="http://inferia-auth:3000"
```

## Test plan

- [x] Superadmin login works with `AUTH_PROVIDER=external`
- [x] External user login delegates to inferia-auth and returns tokens
- [x] External tokens are validated via introspect on protected endpoints
- [x] Shadow user is created on first external login with correct org membership
- [x] Wrong password / non-existent user returns 401
- [x] Invalid tokens are rejected
- [x] Superadmin token still works on all protected endpoints