### PR TITLE
fix: Nosana 400 Bad Request — drop invalid timeout/retries from health check

### DIFF
--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/nosana/job_builder.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/nosana/job_builder.py
@@ -145,8 +145,6 @@ def create_vllm_job(
                             "headers": health_headers,
                             "continuous": False,
                             "expected_status": 200,
-                            "timeout": 30,
-                            "retries": 3,
                         }
                     ],
                 }


### PR DESCRIPTION
## Summary
- Remove `timeout` and `retries` from the vLLM health_check spec in `job_builder.create_vllm_job`.
- Nosana Kit's `HttpHealthCheck` schema (from `@nosana/types`) whitelists only `type`, `path`, `method`, `expected_status`, `continuous`, `headers`, `body`. Any other key is rejected by the Nosana deployment API, which returns `400 Bad Request` on `POST /api/deployments/create`.

## Root cause
Commit 7c1e40c ("Nosana instance hardening") added `timeout: 30` and `retries: 3` to the vLLM job definition's health check. The Nosana deployment manager's schema validator treats the `http` health_check as a sealed object and 400s on unknown fields, so every vLLM deployment since that commit has failed at launch with:

```
Nosana API Error (400): {"error":"Bad Request"}
```

Deployments worked on `578052374b61c9cb91db24982d3dbc19495da363` (pre-7c1e40c).

## Fix
Drop the two invalid fields. The other health_check in the same file (LocalAI path) never had them, so nothing else changes.

## Reference
- [nosana-kit health-checks.md](https://github.com/nosana-ci/nosana-kit/blob/main/docs/deployments/jobs/job-definition/health-checks.md)
- `@nosana/types@2.2.2` `dist/Jobs/JobDefinition/args/expose.d.ts` — whitelist: `["type","path","method","expected_status","headers","body","continuous"]`

## Test plan
- [x] `python -m pytest ... -k "nosana or job_builder"` — 5 passed, 1 skipped
- [x] `create_vllm_job(...)` returns health_check with exactly the 7 whitelisted keys (no `timeout`, no `retries`)
- [ ] Verify a vLLM deployment on Nosana reaches RUNNING post-merge