### PR TITLE
feat(dashboard): adopt cream + ember editorial theme from new-website

### DIFF
--- a/apps/dashboard/src/components/InferenceLogs.tsx
+++ b/apps/dashboard/src/components/InferenceLogs.tsx
@@ -129,7 +129,7 @@ export default function InferenceLogs({ deploymentId }: InferenceLogsProps) {
                                 <div className="flex items-center gap-2 min-w-0">
                                     <span className="font-medium text-sm truncate max-w-[200px] md:max-w-none">{log.model}</span>
                                     {log.is_streaming && (
-                                        <span className="px-1.5 py-0.5 text-[10px] bg-emerald-500/20 text-emerald-500 rounded shrink-0">
+                                        <span className="px-1.5 py-0.5 text-[10px] bg-ember-500/20 text-ember-500 rounded shrink-0">
                                             STREAM
                                         </span>
                                     )}
@@ -247,7 +247,7 @@ export default function InferenceLogs({ deploymentId }: InferenceLogsProps) {
                             <div className="min-w-0 flex-1">
                                 <div className="text-xs text-muted-foreground mb-2 font-medium uppercase tracking-tight">Request Payload</div>
                                 {log.request_payload ? (
-                                    <pre className="p-3 bg-slate-950 text-slate-300 rounded-md text-xs overflow-x-auto max-h-96 overflow-y-auto whitespace-pre-wrap break-all scrollbar-thin scrollbar-thumb-slate-700">
+                                    <pre className="p-3 bg-background text-cream/70 rounded-md text-xs overflow-x-auto max-h-96 overflow-y-auto whitespace-pre-wrap break-all scrollbar-thin scrollbar-thumb-slate-700">
                                         {JSON.stringify(log.request_payload, null, 2)}
                                     </pre>
                                 ) : (

--- a/apps/dashboard/src/components/SpotlightSearch.tsx
+++ b/apps/dashboard/src/components/SpotlightSearch.tsx
@@ -130,10 +130,10 @@ export function SpotlightSearch({ isOpen, onClose }: SpotlightSearchProps) {
 
             {/* Modal */}
             <div className="fixed top-[20%] left-1/2 -translate-x-1/2 w-full max-w-xl z-50 animate-in fade-in zoom-in-95 duration-200">
-                <div className="bg-white dark:bg-zinc-900 rounded-xl shadow-lg border dark:border-zinc-800 overflow-hidden">
+                <div className="bg-card rounded-xl shadow-lg border dark:border-border overflow-hidden">
                     {/* Search Input */}
-                    <div className="flex items-center px-4 border-b dark:border-zinc-800">
-                        <Search className="w-5 h-5 text-slate-400 shrink-0" />
+                    <div className="flex items-center px-4 border-b dark:border-border">
+                        <Search className="w-5 h-5 text-muted-foreground shrink-0" />
                         <input
                             autoFocus
                             value={query}
@@ -142,13 +142,13 @@ export function SpotlightSearch({ isOpen, onClose }: SpotlightSearchProps) {
                                 setSelectedIndex(0)
                             }}
                             placeholder="Search pages and actions..."
-                            className="flex-1 h-14 px-4 bg-transparent border-none outline-none text-base text-slate-900 dark:text-zinc-100 placeholder:text-slate-400"
+                            className="flex-1 h-14 px-4 bg-transparent border-none outline-none text-base text-foreground dark:text-cream placeholder:text-muted-foreground"
                         />
                         <button
                             onClick={onClose}
-                            className="p-1.5 hover:bg-slate-100 dark:hover:bg-zinc-800 rounded-md transition-colors"
+                            className="p-1.5 hover:bg-muted dark:hover:bg-card rounded-md transition-colors"
                         >
-                            <X className="w-4 h-4 text-slate-400" />
+                            <X className="w-4 h-4 text-muted-foreground" />
                         </button>
                     </div>
 
@@ -156,7 +156,7 @@ export function SpotlightSearch({ isOpen, onClose }: SpotlightSearchProps) {
                     <div className="max-h-[400px] overflow-y-auto">
                         {Object.entries(groupedItems).map(([category, items]) => (
                             <div key={category}>
-                                <div className="px-4 py-2 text-xs font-semibold text-slate-500 dark:text-zinc-500 uppercase tracking-wider bg-slate-50 dark:bg-zinc-950">
+                                <div className="px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider bg-muted dark:bg-background">
                                     {category}
                                 </div>
                                 {items.map((item) => {
@@ -171,38 +171,38 @@ export function SpotlightSearch({ isOpen, onClose }: SpotlightSearchProps) {
                                             className={cn(
                                                 "w-full flex items-center gap-3 px-4 py-3 text-left transition-colors",
                                                 isSelected
-                                                    ? "bg-emerald-50 dark:bg-emerald-900/20"
-                                                    : "hover:bg-slate-50 dark:hover:bg-zinc-800/50"
+                                                    ? "bg-ember-50 dark:bg-ember-900/20"
+                                                    : "hover:bg-muted dark:hover:bg-card/80"
                                             )}
                                         >
                                             <div className={cn(
                                                 "p-2 rounded-lg",
                                                 isSelected
-                                                    ? "bg-emerald-100 dark:bg-emerald-900/40"
-                                                    : "bg-slate-100 dark:bg-zinc-800"
+                                                    ? "bg-ember-100 dark:bg-ember-900/40"
+                                                    : "bg-muted dark:bg-card"
                                             )}>
                                                 <item.icon className={cn(
                                                     "w-4 h-4",
                                                     isSelected
-                                                        ? "text-emerald-600 dark:text-emerald-400"
-                                                        : "text-slate-500 dark:text-zinc-400"
+                                                        ? "text-ember-600 dark:text-ember-400"
+                                                        : "text-muted-foreground"
                                                 )} />
                                             </div>
                                             <div className="flex-1 min-w-0">
                                                 <div className={cn(
                                                     "font-medium text-sm",
                                                     isSelected
-                                                        ? "text-emerald-700 dark:text-emerald-300"
-                                                        : "text-slate-900 dark:text-zinc-100"
+                                                        ? "text-ember-700 dark:text-ember-300"
+                                                        : "text-foreground dark:text-cream"
                                                 )}>
                                                     {item.title}
                                                 </div>
-                                                <div className="text-xs text-slate-500 dark:text-zinc-500 truncate">
+                                                <div className="text-xs text-muted-foreground truncate">
                                                     {item.path}
                                                 </div>
                                             </div>
                                             {isSelected && (
-                                                <kbd className="hidden sm:flex items-center gap-1 px-2 py-1 text-xs bg-slate-100 dark:bg-zinc-800 text-slate-500 dark:text-zinc-400 rounded border dark:border-zinc-700">
+                                                <kbd className="hidden sm:flex items-center gap-1 px-2 py-1 text-xs bg-muted dark:bg-card text-muted-foreground rounded border dark:border-border">
                                                     Enter ↵
                                                 </kbd>
                                             )}
@@ -213,7 +213,7 @@ export function SpotlightSearch({ isOpen, onClose }: SpotlightSearchProps) {
                         ))}
 
                         {filteredItems.length === 0 && (
-                            <div className="p-8 text-center text-slate-500 dark:text-zinc-500">
+                            <div className="p-8 text-center text-muted-foreground">
                                 <Search className="w-8 h-8 mx-auto mb-2 opacity-30" />
                                 <p>No results found for "{query}"</p>
                             </div>
@@ -221,19 +221,19 @@ export function SpotlightSearch({ isOpen, onClose }: SpotlightSearchProps) {
                     </div>
 
                     {/* Footer */}
-                    <div className="px-4 py-2 border-t dark:border-zinc-800 bg-slate-50 dark:bg-zinc-950 flex items-center justify-between text-xs text-slate-500 dark:text-zinc-500">
+                    <div className="px-4 py-2 border-t dark:border-border bg-muted dark:bg-background flex items-center justify-between text-xs text-muted-foreground">
                         <div className="flex items-center gap-4">
                             <span className="flex items-center gap-1">
-                                <kbd className="px-1.5 py-0.5 bg-white dark:bg-zinc-800 border dark:border-zinc-700 rounded text-[10px]">↑</kbd>
-                                <kbd className="px-1.5 py-0.5 bg-white dark:bg-zinc-800 border dark:border-zinc-700 rounded text-[10px]">↓</kbd>
+                                <kbd className="px-1.5 py-0.5 bg-card border dark:border-border rounded text-[10px]">↑</kbd>
+                                <kbd className="px-1.5 py-0.5 bg-card border dark:border-border rounded text-[10px]">↓</kbd>
                                 Navigate
                             </span>
                             <span className="flex items-center gap-1">
-                                <kbd className="px-1.5 py-0.5 bg-white dark:bg-zinc-800 border dark:border-zinc-700 rounded text-[10px]">↵</kbd>
+                                <kbd className="px-1.5 py-0.5 bg-card border dark:border-border rounded text-[10px]">↵</kbd>
                                 Select
                             </span>
                             <span className="flex items-center gap-1">
-                                <kbd className="px-1.5 py-0.5 bg-white dark:bg-zinc-800 border dark:border-zinc-700 rounded text-[10px]">esc</kbd>
+                                <kbd className="px-1.5 py-0.5 bg-card border dark:border-border rounded text-[10px]">esc</kbd>
                                 Close
                             </span>
                         </div>

--- a/apps/dashboard/src/components/deployment/CompatibilityProjectionChart.tsx
+++ b/apps/dashboard/src/components/deployment/CompatibilityProjectionChart.tsx
@@ -120,11 +120,11 @@ export function CompatibilityProjectionChart({
                                 if (!active || !payload || payload.length === 0) return null;
                                 const point = payload[0].payload as ProjectionDatum;
                                 return (
-                                    <div className="rounded-md border border-slate-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-xs shadow-lg">
-                                        <div className="font-semibold text-slate-900 dark:text-zinc-100 mb-1">
+                                    <div className="rounded-md border border-border bg-card px-3 py-2 text-xs shadow-lg">
+                                        <div className="font-semibold text-foreground dark:text-cream mb-1">
                                             {point.concurrency} concurrent users
                                         </div>
-                                        <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-slate-600 dark:text-zinc-300">
+                                        <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-muted-foreground dark:text-cream/70">
                                             <span>Projected TTFT</span>
                                             <span className="text-right font-mono">{formatSeconds(point.ttftSeconds)}</span>
                                             <span>Reference TTFT</span>

--- a/apps/dashboard/src/components/deployment/DeploymentConfig.tsx
+++ b/apps/dashboard/src/components/deployment/DeploymentConfig.tsx
@@ -362,12 +362,12 @@ function Header({ loading, onSave, onRefresh }: { loading: boolean; onSave: () =
     return (
         <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-                <div className="p-2 bg-emerald-500/10 rounded-lg"><Settings2 className="w-5 h-5 text-emerald-500" /></div>
+                <div className="p-2 bg-ember-500/10 rounded-lg"><Settings2 className="w-5 h-5 text-ember-500" /></div>
                 <div><h2 className="text-xl font-bold tracking-tight">Deployment Configuration</h2><p className="text-sm text-muted-foreground font-mono">Customize engine parameters and runtime settings</p></div>
             </div>
             <div className="flex items-center gap-2">
                 <button onClick={() => onRefresh?.()} className="p-2 text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors"><RotateCcw className="w-5 h-5" /></button>
-                <button onClick={onSave} disabled={loading} className="flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg font-medium transition-colors shadow-lg shadow-emerald-500/20 active:scale-95 disabled:opacity-50">{loading ? <Zap className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />} Save Changes</button>
+                <button onClick={onSave} disabled={loading} className="flex items-center gap-2 px-4 py-2 bg-ember-600 hover:bg-ember-500 text-white rounded-lg font-medium transition-colors shadow-lg shadow-ember-500/20 active:scale-95 disabled:opacity-50">{loading ? <Zap className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />} Save Changes</button>
             </div>
         </div>
     );
@@ -375,11 +375,11 @@ function Header({ loading, onSave, onRefresh }: { loading: boolean; onSave: () =
 
 function GeneralSettings({ replicas, inferenceModel, dispatch }: { replicas: number; inferenceModel: string; dispatch: React.Dispatch<Action> }) {
     return (
-        <div className="bg-card border border-border rounded-2xl p-6 hover:border-emerald-500/30 transition-colors duration-300">
-            <div className="flex items-center gap-2 mb-6 text-foreground"><Server className="w-4 h-4 text-emerald-500 dark:text-emerald-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">General Settings</h3></div>
+        <div className="bg-card border border-border rounded-2xl p-6 hover:border-ember-500/30 transition-colors duration-300">
+            <div className="flex items-center gap-2 mb-6 text-foreground"><Server className="w-4 h-4 text-ember-500 dark:text-ember-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">General Settings</h3></div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="space-y-2"><label htmlFor="replicas" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Replicas</label><div className="relative group/input"><input id="replicas" type="number" min="1" value={replicas} onChange={e => dispatch({ type: 'SET_FIELD', field: 'replicas', value: parseInt(e.target.value) })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono" /><div className="absolute right-3 top-3.5 text-muted-foreground pointer-events-none group-focus-within/input:text-emerald-500"><Layers className="w-4 h-4" /></div></div></div>
-                <div className="space-y-2"><label htmlFor="inference-model" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Inference Model</label><div className="relative group/input"><input id="inference-model" value={inferenceModel} onChange={e => dispatch({ type: 'SET_FIELD', field: 'inferenceModel', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono" placeholder="e.g. meta-llama/Llama-3-8B" /><div className="absolute right-3 top-3.5 text-muted-foreground pointer-events-none group-focus-within/input:text-emerald-500"><Cloud className="w-4 h-4" /></div></div></div>
+                <div className="space-y-2"><label htmlFor="replicas" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Replicas</label><div className="relative group/input"><input id="replicas" type="number" min="1" value={replicas} onChange={e => dispatch({ type: 'SET_FIELD', field: 'replicas', value: parseInt(e.target.value) })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono" /><div className="absolute right-3 top-3.5 text-muted-foreground pointer-events-none group-focus-within/input:text-ember-500"><Layers className="w-4 h-4" /></div></div></div>
+                <div className="space-y-2"><label htmlFor="inference-model" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Inference Model</label><div className="relative group/input"><input id="inference-model" value={inferenceModel} onChange={e => dispatch({ type: 'SET_FIELD', field: 'inferenceModel', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono" placeholder="e.g. meta-llama/Llama-3-8B" /><div className="absolute right-3 top-3.5 text-muted-foreground pointer-events-none group-focus-within/input:text-ember-500"><Cloud className="w-4 h-4" /></div></div></div>
             </div>
         </div>
     );
@@ -399,15 +399,15 @@ function VllmSettings({
     dispatch: React.Dispatch<Action>
 }) {
     return (
-        <m.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="bg-card border border-border rounded-2xl p-6 hover:border-emerald-500/30 transition-colors duration-300">
-            <div className="flex items-center gap-2 mb-6 text-foreground"><Zap className="w-4 h-4 text-emerald-500 dark:text-emerald-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">vLLM Optimization</h3></div>
+        <m.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="bg-card border border-border rounded-2xl p-6 hover:border-ember-500/30 transition-colors duration-300">
+            <div className="flex items-center gap-2 mb-6 text-foreground"><Zap className="w-4 h-4 text-ember-500 dark:text-ember-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">vLLM Optimization</h3></div>
             <div className="space-y-6">
-                <div className="space-y-2"><label htmlFor="vllm-image" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Container Image</label><input id="vllm-image" value={vllmImage} onChange={e => dispatch({ type: 'SET_FIELD', field: 'vllmImage', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm" /></div>
+                <div className="space-y-2"><label htmlFor="vllm-image" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Container Image</label><input id="vllm-image" value={vllmImage} onChange={e => dispatch({ type: 'SET_FIELD', field: 'vllmImage', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm" /></div>
                 <div className="space-y-2">
                     <label className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Required CUDA Versions</label>
                     <div className="flex flex-wrap gap-2">
                         {["12.0", "12.1", "12.2", "12.3", "12.4", "12.5", "12.6", "12.7", "12.8", "12.9", "13.0", "13.1", "13.2"].map(v => (
-                            <label key={v} className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-xs font-bold cursor-pointer transition-colors", cudaVersions.includes(v) ? "bg-emerald-50 border-emerald-300 text-emerald-700 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-400" : "bg-white border-border text-muted-foreground dark:bg-zinc-900 hover:border-emerald-300 dark:hover:border-emerald-700")}>
+                            <label key={v} className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-xs font-bold cursor-pointer transition-colors", cudaVersions.includes(v) ? "bg-ember-50 border-ember-300 text-ember-700 dark:bg-ember-900/20 dark:border-ember-700 dark:text-ember-400" : "bg-card border-border text-muted-foreground dark:bg-card hover:border-ember-300 dark:hover:border-ember-700")}>
                                 <input
                                     type="checkbox"
                                     checked={cudaVersions.includes(v)}
@@ -425,15 +425,15 @@ function VllmSettings({
                     </div>
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div className="space-y-2"><label htmlFor="max-model-len" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Max Model Length</label><input id="max-model-len" value={maxModelLen} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxModelLen', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono" /></div>
-                    <div className="space-y-2"><label htmlFor="gpu-util" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">GPU Util</label><input id="gpu-util" value={gpuUtil} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gpuUtil', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono" /></div>
+                    <div className="space-y-2"><label htmlFor="max-model-len" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Max Model Length</label><input id="max-model-len" value={maxModelLen} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxModelLen', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono" /></div>
+                    <div className="space-y-2"><label htmlFor="gpu-util" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">GPU Util</label><input id="gpu-util" value={gpuUtil} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gpuUtil', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono" /></div>
                 </div>
 
                 {/* Advanced Config Section */}
                 <div className="border-t border-border pt-4">
                     <button
                         onClick={() => setIsAdvancedOpen(!isAdvancedOpen)}
-                        className="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-wider hover:text-emerald-500 transition-colors"
+                        className="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-wider hover:text-ember-500 transition-colors"
                     >
                         {isAdvancedOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                         Advanced Configuration
@@ -448,7 +448,7 @@ function VllmSettings({
                         >
                             <div className="space-y-2">
                                 <label htmlFor="dtype" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Data Type (dtype)</label>
-                                <select id="dtype" value={dtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'dtype', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm">
+                                <select id="dtype" value={dtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'dtype', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm">
                                     <option value="auto">auto</option>
                                     <option value="float16">float16</option>
                                     <option value="bfloat16">bfloat16</option>
@@ -458,7 +458,7 @@ function VllmSettings({
 
                             <div className="space-y-2">
                                 <label htmlFor="kv-cache-dtype" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">KV Cache dtype</label>
-                                <select id="kv-cache-dtype" value={kvCacheDtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'kvCacheDtype', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm">
+                                <select id="kv-cache-dtype" value={kvCacheDtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'kvCacheDtype', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm">
                                     <option value="auto">auto</option>
                                     <option value="fp8">fp8</option>
                                     <option value="fp8_e4m3">fp8_e4m3</option>
@@ -468,12 +468,12 @@ function VllmSettings({
 
                             <div className="space-y-2">
                                 <label htmlFor="max-num-seqs" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Max Num Sequences</label>
-                                <input id="max-num-seqs" type="number" min="1" value={maxNumSeqs} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxNumSeqs', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm" />
+                                <input id="max-num-seqs" type="number" min="1" value={maxNumSeqs} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxNumSeqs', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm" />
                             </div>
 
                             <div className="space-y-2">
                                 <label htmlFor="quantization" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Quantization</label>
-                                <select id="quantization" value={quantization} onChange={e => dispatch({ type: 'SET_FIELD', field: 'quantization', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm">
+                                <select id="quantization" value={quantization} onChange={e => dispatch({ type: 'SET_FIELD', field: 'quantization', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm">
                                     <option value="">None</option>
                                     <option value="awq">AWQ</option>
                                     <option value="awq_marlin">AWQ Marlin</option>
@@ -499,7 +499,7 @@ function VllmSettings({
                                     type="checkbox"
                                     checked={trustRemoteCode}
                                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'trustRemoteCode', value: e.target.checked })}
-                                    className="w-4 h-4 rounded border-border bg-background text-emerald-500 focus:ring-emerald-500/40"
+                                    className="w-4 h-4 rounded border-border bg-background text-ember-500 focus:ring-ember-500/40"
                                 />
                                 <label htmlFor="trust-remote-code" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter">Trust Remote Code</label>
                             </div>
@@ -510,7 +510,7 @@ function VllmSettings({
                                     type="checkbox"
                                     checked={enforceEager}
                                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'enforceEager', value: e.target.checked })}
-                                    className="w-4 h-4 rounded border-border bg-background text-emerald-500 focus:ring-emerald-500/40"
+                                    className="w-4 h-4 rounded border-border bg-background text-ember-500 focus:ring-ember-500/40"
                                 />
                                 <label htmlFor="enforce-eager" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter">Enforce Eager Mode</label>
                             </div>
@@ -521,7 +521,7 @@ function VllmSettings({
                                     type="checkbox"
                                     checked={!!cudaModuleLoading}
                                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'cudaModuleLoading', value: e.target.checked ? "LAZY" : "" })}
-                                    className="w-4 h-4 rounded border-border bg-background text-emerald-500 focus:ring-emerald-500/40"
+                                    className="w-4 h-4 rounded border-border bg-background text-ember-500 focus:ring-ember-500/40"
                                 />
                                 <label htmlFor="cuda-module-loading" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter">CUDA Module Loading: LAZY</label>
                             </div>
@@ -532,7 +532,7 @@ function VllmSettings({
                                     type="checkbox"
                                     checked={!!nvidiaDisableCudaCompat}
                                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'nvidiaDisableCudaCompat', value: e.target.checked ? "1" : "" })}
-                                    className="w-4 h-4 rounded border-border bg-background text-emerald-500 focus:ring-emerald-500/40"
+                                    className="w-4 h-4 rounded border-border bg-background text-ember-500 focus:ring-ember-500/40"
                                 />
                                 <label htmlFor="nvidia-disable-cuda-compat" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter">NVIDIA Disable CUDA Compat</label>
                             </div>
@@ -554,15 +554,15 @@ function EmbeddingSettings({
     dispatch: React.Dispatch<Action>
 }) {
     return (
-        <m.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="bg-card border border-border rounded-2xl p-6 hover:border-emerald-500/30 transition-colors duration-300">
-            <div className="flex items-center gap-2 mb-6 text-foreground"><Database className="w-4 h-4 text-emerald-500 dark:text-emerald-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">Embedding Optimization</h3></div>
+        <m.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="bg-card border border-border rounded-2xl p-6 hover:border-ember-500/30 transition-colors duration-300">
+            <div className="flex items-center gap-2 mb-6 text-foreground"><Database className="w-4 h-4 text-ember-500 dark:text-ember-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">Embedding Optimization</h3></div>
             <div className="space-y-6">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     {engine === "infinity" && (
-                        <div className="space-y-2"><label htmlFor="batch-size" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Batch Size</label><input id="batch-size" type="number" value={batchSize} onChange={e => dispatch({ type: 'SET_FIELD', field: 'batchSize', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono" /></div>
+                        <div className="space-y-2"><label htmlFor="batch-size" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Batch Size</label><input id="batch-size" type="number" value={batchSize} onChange={e => dispatch({ type: 'SET_FIELD', field: 'batchSize', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono" /></div>
                     )}
                     {engine === "tei" && (
-                        <div className="space-y-2"><label htmlFor="max-batch-tokens" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Max Batch Tokens</label><input id="max-batch-tokens" type="number" value={maxBatchTokens} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxBatchTokens', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono" /></div>
+                        <div className="space-y-2"><label htmlFor="max-batch-tokens" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Max Batch Tokens</label><input id="max-batch-tokens" type="number" value={maxBatchTokens} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxBatchTokens', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono" /></div>
                     )}
                     <div className="flex items-center gap-3 pt-6">
                         <input
@@ -570,7 +570,7 @@ function EmbeddingSettings({
                             type="checkbox"
                             checked={gpuEnabled}
                             onChange={e => dispatch({ type: 'SET_FIELD', field: 'gpuEnabled', value: e.target.checked })}
-                            className="w-4 h-4 rounded border-border bg-background text-emerald-500 focus:ring-emerald-500/40"
+                            className="w-4 h-4 rounded border-border bg-background text-ember-500 focus:ring-ember-500/40"
                         />
                         <label htmlFor="gpu-enabled" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter">Enable GPU Acceleration</label>
                     </div>
@@ -579,7 +579,7 @@ function EmbeddingSettings({
                 <div className="border-t border-border pt-4">
                     <button
                         onClick={() => setIsAdvancedOpen(!isAdvancedOpen)}
-                        className="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-wider hover:text-emerald-500 transition-colors"
+                        className="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-wider hover:text-ember-500 transition-colors"
                     >
                         {isAdvancedOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                         Advanced Hardware Configuration
@@ -594,18 +594,18 @@ function EmbeddingSettings({
                         >
                             <div className="space-y-2">
                                 <label htmlFor="req-cpu" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">CPU Cores</label>
-                                <input id="req-cpu" type="number" value={requiredCpu} onChange={e => dispatch({ type: 'SET_FIELD', field: 'requiredCpu', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm" />
+                                <input id="req-cpu" type="number" value={requiredCpu} onChange={e => dispatch({ type: 'SET_FIELD', field: 'requiredCpu', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm" />
                             </div>
 
                             <div className="space-y-2">
                                 <label htmlFor="req-ram" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">RAM (MB)</label>
-                                <input id="req-ram" type="number" value={requiredRam} onChange={e => dispatch({ type: 'SET_FIELD', field: 'requiredRam', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm" />
+                                <input id="req-ram" type="number" value={requiredRam} onChange={e => dispatch({ type: 'SET_FIELD', field: 'requiredRam', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm" />
                             </div>
 
                             {engine === "tei" && (
                                 <div className="space-y-2">
                                     <label htmlFor="pooling-strategy" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Pooling Strategy</label>
-                                    <select id="pooling-strategy" value={pooling} onChange={e => dispatch({ type: 'SET_FIELD', field: 'pooling', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm">
+                                    <select id="pooling-strategy" value={pooling} onChange={e => dispatch({ type: 'SET_FIELD', field: 'pooling', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm">
                                         <option value="cls">CLS</option>
                                         <option value="mean">Mean</option>
                                         <option value="last_token">Last Token</option>
@@ -615,7 +615,7 @@ function EmbeddingSettings({
 
                             <div className="space-y-2">
                                 <label htmlFor="port" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Service Port</label>
-                                <input id="port" type="number" value={port} onChange={e => dispatch({ type: 'SET_FIELD', field: 'port', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm" />
+                                <input id="port" type="number" value={port} onChange={e => dispatch({ type: 'SET_FIELD', field: 'port', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm" />
                             </div>
                         </m.div>
                     )}
@@ -630,9 +630,9 @@ function TrainingSettings({ gitRepo, trainingScript, datasetUrl, dispatch }: { g
         <m.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="bg-card border border-border rounded-2xl p-6 hover:border-amber-500/30 transition-colors duration-300">
             <div className="flex items-center gap-2 mb-6 text-foreground"><Terminal className="w-4 h-4 text-amber-500 focus:text-amber-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">Training Orchestration</h3></div>
             <div className="space-y-6">
-                <div className="space-y-2"><label htmlFor="git-repo" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Git Repository</label><input id="git-repo" value={gitRepo} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gitRepo', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500/40 font-mono text-sm" placeholder="https://..." /></div>
-                <div className="space-y-2"><label htmlFor="training-script" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Training Command</label><textarea id="training-script" rows={3} value={trainingScript} onChange={e => dispatch({ type: 'SET_FIELD', field: 'trainingScript', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500/40 font-mono text-sm resize-none" /></div>
-                <div className="space-y-2"><label htmlFor="dataset-url" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Dataset URL</label><input id="dataset-url" value={datasetUrl} onChange={e => dispatch({ type: 'SET_FIELD', field: 'datasetUrl', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-amber-500/40 font-mono text-sm" /></div>
+                <div className="space-y-2"><label htmlFor="git-repo" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Git Repository</label><input id="git-repo" value={gitRepo} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gitRepo', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-amber-500/40 font-mono text-sm" placeholder="https://..." /></div>
+                <div className="space-y-2"><label htmlFor="training-script" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Training Command</label><textarea id="training-script" rows={3} value={trainingScript} onChange={e => dispatch({ type: 'SET_FIELD', field: 'trainingScript', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-amber-500/40 font-mono text-sm resize-none" /></div>
+                <div className="space-y-2"><label htmlFor="dataset-url" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Dataset URL</label><input id="dataset-url" value={datasetUrl} onChange={e => dispatch({ type: 'SET_FIELD', field: 'datasetUrl', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-amber-500/40 font-mono text-sm" /></div>
             </div>
         </m.div>
     );
@@ -647,25 +647,25 @@ function DiffusionSettings({
     dispatch: React.Dispatch<Action>
 }) {
     return (
-        <m.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="bg-card border border-border rounded-2xl p-6 hover:border-emerald-500/30 transition-colors duration-300">
-            <div className="flex items-center gap-2 mb-6 text-foreground"><Image className="w-4 h-4 text-emerald-500 dark:text-emerald-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">{isVideoGen ? "Video Generation" : "Image Generation"} Settings</h3></div>
+        <m.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="bg-card border border-border rounded-2xl p-6 hover:border-ember-500/30 transition-colors duration-300">
+            <div className="flex items-center gap-2 mb-6 text-foreground"><Image className="w-4 h-4 text-ember-500 dark:text-ember-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">{isVideoGen ? "Video Generation" : "Image Generation"} Settings</h3></div>
             <div className="space-y-6">
-                <div className="space-y-2"><label htmlFor="diffusion-image" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Container Image</label><input id="diffusion-image" value={diffusionImage} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionImage', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono text-sm" /></div>
+                <div className="space-y-2"><label htmlFor="diffusion-image" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Container Image</label><input id="diffusion-image" value={diffusionImage} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionImage', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono text-sm" /></div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div className="space-y-2"><label htmlFor="diffusion-port" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Service Port</label><input id="diffusion-port" type="number" value={diffusionPort} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionPort', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono" /></div>
-                    <div className="space-y-2"><label htmlFor="diffusion-min-vram" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Min VRAM (GB)</label><input id="diffusion-min-vram" type="number" min="1" value={diffusionMinVram} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionMinVram', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/40 font-mono" /></div>
+                    <div className="space-y-2"><label htmlFor="diffusion-port" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Service Port</label><input id="diffusion-port" type="number" value={diffusionPort} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionPort', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono" /></div>
+                    <div className="space-y-2"><label htmlFor="diffusion-min-vram" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Min VRAM (GB)</label><input id="diffusion-min-vram" type="number" min="1" value={diffusionMinVram} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionMinVram', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-ember-500/40 font-mono" /></div>
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div className="flex items-center gap-3">
-                        <input id="diffusion-trust-remote" type="checkbox" checked={diffusionTrustRemoteCode} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionTrustRemoteCode', value: e.target.checked })} className="w-4 h-4 rounded border-border bg-background text-emerald-500 focus:ring-emerald-500/40" />
+                        <input id="diffusion-trust-remote" type="checkbox" checked={diffusionTrustRemoteCode} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionTrustRemoteCode', value: e.target.checked })} className="w-4 h-4 rounded border-border bg-background text-ember-500 focus:ring-ember-500/40" />
                         <label htmlFor="diffusion-trust-remote" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter">Trust Remote Code</label>
                     </div>
                     <div className="flex items-center gap-3">
-                        <input id="diffusion-model-offload" type="checkbox" checked={diffusionModelOffload} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionModelOffload', value: e.target.checked })} className="w-4 h-4 rounded border-border bg-background text-emerald-500 focus:ring-emerald-500/40" />
+                        <input id="diffusion-model-offload" type="checkbox" checked={diffusionModelOffload} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionModelOffload', value: e.target.checked })} className="w-4 h-4 rounded border-border bg-background text-ember-500 focus:ring-ember-500/40" />
                         <label htmlFor="diffusion-model-offload" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter">Model Offload</label>
                     </div>
                     <div className="flex items-center gap-3">
-                        <input id="diffusion-group-offload" type="checkbox" checked={diffusionGroupOffload} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionGroupOffload', value: e.target.checked })} className="w-4 h-4 rounded border-border bg-background text-emerald-500 focus:ring-emerald-500/40" />
+                        <input id="diffusion-group-offload" type="checkbox" checked={diffusionGroupOffload} onChange={e => dispatch({ type: 'SET_FIELD', field: 'diffusionGroupOffload', value: e.target.checked })} className="w-4 h-4 rounded border-border bg-background text-ember-500 focus:ring-ember-500/40" />
                         <label htmlFor="diffusion-group-offload" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter">Group Offload</label>
                     </div>
                 </div>
@@ -678,16 +678,16 @@ function EnvironmentSecrets({ hfToken, dispatch }: { hfToken: string; dispatch: 
     return (
         <div className="bg-card border border-border rounded-2xl p-6">
             <div className="flex items-center gap-2 mb-6 text-foreground"><ShieldCheck className="w-4 h-4 text-purple-600 dark:text-purple-400" /><h3 className="text-sm font-bold uppercase tracking-wider font-mono">Environment Secrets</h3></div>
-            <div className="space-y-2"><label htmlFor="hf-token" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Hugging Face Token</label><input id="hf-token" type="password" value={hfToken} onChange={e => dispatch({ type: 'SET_FIELD', field: 'hfToken', value: e.target.value })} className="w-full bg-white dark:bg-zinc-900 border border-border rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500/40 font-mono text-sm" placeholder="hf_••••••••" /><p className="text-[10px] text-muted-foreground font-mono mt-2">Required for gated models.</p></div>
+            <div className="space-y-2"><label htmlFor="hf-token" className="text-xs font-bold text-muted-foreground uppercase tracking-tighter ml-1">Hugging Face Token</label><input id="hf-token" type="password" value={hfToken} onChange={e => dispatch({ type: 'SET_FIELD', field: 'hfToken', value: e.target.value })} className="w-full bg-card border border-border rounded-xl px-4 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/40 font-mono text-sm" placeholder="hf_••••••••" /><p className="text-[10px] text-muted-foreground font-mono mt-2">Required for gated models.</p></div>
         </div>
     );
 }
 
 function ProTip() {
     return (
-        <div className="bg-emerald-600/10 border border-emerald-500/20 rounded-2xl p-6">
-            <h4 className="text-sm font-bold text-emerald-600 dark:text-emerald-400 mb-2">Pro Tip</h4>
-            <p className="text-xs text-emerald-600/70 dark:text-emerald-300/70 leading-relaxed font-mono">Wait for <span className="text-emerald-600 dark:text-emerald-400 underline">STOPPED</span> state before applying major changes.</p>
+        <div className="bg-ember-600/10 border border-ember-500/20 rounded-2xl p-6">
+            <h4 className="text-sm font-bold text-ember-600 dark:text-ember-400 mb-2">Pro Tip</h4>
+            <p className="text-xs text-ember-600/70 dark:text-ember-300/70 leading-relaxed font-mono">Wait for <span className="text-ember-600 dark:text-ember-400 underline">STOPPED</span> state before applying major changes.</p>
         </div>
     );
 }

--- a/apps/dashboard/src/components/deployment/DeploymentGuardrails.tsx
+++ b/apps/dashboard/src/components/deployment/DeploymentGuardrails.tsx
@@ -146,7 +146,7 @@ export default function DeploymentGuardrails({ deploymentId }: DeploymentGuardra
                         <Cpu className="w-4 h-4" /> Guardrail Engine
                     </label>
                     <select
-                        className="w-full p-2 border rounded-md bg-white dark:bg-zinc-900 text-slate-900 dark:text-white"
+                        className="w-full p-2 border rounded-md bg-card text-foreground"
                         value={config.guardrail_engine || "llm-guard"}
                         onChange={(e) => updateConfig({ ...config, guardrail_engine: e.target.value })}
                     >
@@ -178,7 +178,7 @@ export default function DeploymentGuardrails({ deploymentId }: DeploymentGuardra
                     )}
 
                     {config.guardrail_engine === "llama-guard" && isEngineConfigured("llama-guard") && (
-                        <p className="text-xs text-muted-foreground bg-emerald-50 dark:bg-emerald-950/20 text-emerald-600 dark:text-emerald-400 p-2 rounded">
+                        <p className="text-xs text-muted-foreground bg-ember-50 dark:bg-ember-950/20 text-ember-600 dark:text-ember-400 p-2 rounded">
                             Uses meta-llama/llama-guard-4-12b via Groq. Optimized for chat safety (Violence, Hate, Sexual Content, etc.).
                         </p>
                     )}

--- a/apps/dashboard/src/components/deployment/DeploymentOverview.tsx
+++ b/apps/dashboard/src/components/deployment/DeploymentOverview.tsx
@@ -130,7 +130,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                         <div className={cn(
                             "flex items-center gap-2 font-medium",
                             (state === "READY" || state === "RUNNING") ? "text-green-600 dark:text-green-500" :
-                                state === "STOPPED" ? "text-slate-500" :
+                                state === "STOPPED" ? "text-muted-foreground" :
                                     state === "FAILED" ? "text-red-600" :
                                         state === "RETRYING" ? "text-amber-600 dark:text-amber-500" :
                                             "text-yellow-600"
@@ -248,7 +248,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                 <div className="flex flex-col gap-1">
                                     <span className="text-muted-foreground text-xs uppercase">TensorBoard URL</span>
                                     {deployment.endpoint_url ? (
-                                        <a href={deployment.endpoint_url} target="_blank" rel="noopener noreferrer" className="text-emerald-600 hover:underline break-all">
+                                        <a href={deployment.endpoint_url} target="_blank" rel="noopener noreferrer" className="text-ember-600 hover:underline break-all">
                                             {deployment.endpoint_url}
                                         </a>
                                     ) : (
@@ -263,7 +263,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                         href={deployment.endpoint_url}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="ml-4 px-4 py-2 bg-emerald-600 text-white rounded-md text-xs font-medium hover:bg-emerald-700 transition-colors shrink-0"
+                                        className="ml-4 px-4 py-2 bg-ember-600 text-white rounded-md text-xs font-medium hover:bg-ember-700 transition-colors shrink-0"
                                     >
                                         Open Board
                                     </a>
@@ -305,7 +305,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                 <div className="flex items-center gap-2">
                                     <button
                                         onClick={() => setShowRawEndpoint(!showRawEndpoint)}
-                                        className="p-2 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-md transition-colors text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 shrink-0"
+                                        className="p-2 hover:bg-accent rounded-md transition-colors text-muted-foreground hover:text-foreground dark:hover:text-cream shrink-0"
                                         title={showRawEndpoint ? "Hide Endpoint" : "Show Endpoint"}
                                         disabled={!deployment.endpoint_url}
                                     >
@@ -318,7 +318,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                                 toast.success("Raw endpoint copied to clipboard")
                                             }
                                         }}
-                                        className="p-2 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-md transition-colors text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 shrink-0"
+                                        className="p-2 hover:bg-accent rounded-md transition-colors text-muted-foreground hover:text-foreground dark:hover:text-cream shrink-0"
                                         title="Copy Endpoint"
                                         disabled={!deployment.endpoint_url}
                                     >
@@ -345,7 +345,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                         navigator.clipboard.writeText(publicEmbeddingEndpoint)
                                         toast.success("Endpoint copied to clipboard")
                                     }}
-                                    className="ml-4 p-2 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-md transition-colors text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 shrink-0"
+                                    className="ml-4 p-2 hover:bg-accent rounded-md transition-colors text-muted-foreground hover:text-foreground dark:hover:text-cream shrink-0"
                                     title="Copy Endpoint"
                                 >
                                     <Copy className="w-4 h-4" />
@@ -393,7 +393,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                 <div className="flex items-center gap-2">
                                     <button
                                         onClick={() => setShowRawEndpoint(!showRawEndpoint)}
-                                        className="p-2 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-md transition-colors text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 shrink-0"
+                                        className="p-2 hover:bg-accent rounded-md transition-colors text-muted-foreground hover:text-foreground dark:hover:text-cream shrink-0"
                                         title={showRawEndpoint ? "Hide Endpoint" : "Show Endpoint"}
                                         disabled={!deployment.endpoint_url}
                                     >
@@ -406,7 +406,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                                 toast.success("Raw endpoint copied to clipboard")
                                             }
                                         }}
-                                        className="p-2 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-md transition-colors text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 shrink-0"
+                                        className="p-2 hover:bg-accent rounded-md transition-colors text-muted-foreground hover:text-foreground dark:hover:text-cream shrink-0"
                                         title="Copy Endpoint"
                                         disabled={!deployment.endpoint_url}
                                     >
@@ -433,7 +433,7 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                         navigator.clipboard.writeText(publicInferenceEndpoint)
                                         toast.success("Endpoint copied to clipboard")
                                     }}
-                                    className="ml-4 p-2 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-md transition-colors text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 shrink-0"
+                                    className="ml-4 p-2 hover:bg-accent rounded-md transition-colors text-muted-foreground hover:text-foreground dark:hover:text-cream shrink-0"
                                     title="Copy Endpoint"
                                 >
                                     <Copy className="w-4 h-4" />

--- a/apps/dashboard/src/components/deployment/DeploymentPromptTemplate.tsx
+++ b/apps/dashboard/src/components/deployment/DeploymentPromptTemplate.tsx
@@ -113,7 +113,7 @@ export default function DeploymentPromptTemplate({ deploymentId }: DeploymentPro
                                 checked={config.enabled}
                                 onChange={(e) => updateConfig({ ...config, enabled: e.target.checked })}
                             />
-                            <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-background after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+                            <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-background after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
                         </label>
                     </div>
 
@@ -122,7 +122,7 @@ export default function DeploymentPromptTemplate({ deploymentId }: DeploymentPro
                             <div className="grid gap-2">
                                 <label className="text-sm font-medium">Base Template</label>
                                 <select
-                                    className="flex h-10 w-full rounded-md border border-input bg-white dark:bg-zinc-900 text-slate-900 dark:text-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                    className="flex h-10 w-full rounded-md border border-input bg-card text-foreground px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                                     value={config.base_template_id || ""}
                                     onChange={(e) => {
                                         const newConfig = { ...config }
@@ -164,7 +164,7 @@ export default function DeploymentPromptTemplate({ deploymentId }: DeploymentPro
                                                 <div className="col-span-1 text-center text-muted-foreground">←</div>
                                                 <div className="col-span-3">
                                                     <select
-                                                        className="flex h-9 w-full rounded-md border border-input bg-white dark:bg-zinc-900 text-slate-900 dark:text-white px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                                        className="flex h-9 w-full rounded-md border border-input bg-card text-foreground px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                                                         value={varConfig.source}
                                                         onChange={(e) => {
                                                             const newConfig = { ...config }
@@ -180,7 +180,7 @@ export default function DeploymentPromptTemplate({ deploymentId }: DeploymentPro
                                                 <div className="col-span-5">
                                                     {varConfig.source === "rag" ? (
                                                         <select
-                                                            className="flex h-9 w-full rounded-md border border-input bg-white dark:bg-zinc-900 text-slate-900 dark:text-white px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                                            className="flex h-9 w-full rounded-md border border-input bg-card text-foreground px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                                                             value={varConfig.collection_id || ""}
                                                             onChange={(e) => {
                                                                 const newConfig = { ...config }
@@ -193,7 +193,7 @@ export default function DeploymentPromptTemplate({ deploymentId }: DeploymentPro
                                                         </select>
                                                     ) : varConfig.source === "static" ? (
                                                         <input
-                                                            className="flex h-9 w-full rounded-md border border-input bg-white dark:bg-zinc-900 text-slate-900 dark:text-white px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                                            className="flex h-9 w-full rounded-md border border-input bg-card text-foreground px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                                                             placeholder="Static Value"
                                                             value={varConfig.value || ""}
                                                             onChange={(e) => {
@@ -204,7 +204,7 @@ export default function DeploymentPromptTemplate({ deploymentId }: DeploymentPro
                                                         />
                                                     ) : (
                                                         <input
-                                                            className="flex h-9 w-full rounded-md border border-input bg-white dark:bg-zinc-900 text-slate-900 dark:text-white px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                                            className="flex h-9 w-full rounded-md border border-input bg-card text-foreground px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                                                             placeholder="JSON Key (default: same as var)"
                                                             value={varConfig.key || varName}
                                                             onChange={(e) => {
@@ -232,7 +232,7 @@ export default function DeploymentPromptTemplate({ deploymentId }: DeploymentPro
                                     </summary>
                                     <div className="text-neutral-600 group-open:animate-fadeIn mt-3 text-sm">
                                         <textarea
-                                            className="min-h-[200px] w-full rounded-md border border-input bg-zinc-950 text-zinc-50 font-mono px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                            className="min-h-[200px] w-full rounded-md border border-input bg-background text-foreground font-mono px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                                             placeholder="{{ system_prompt }} ... {{ user_input }}"
                                             value={config.content || ""}
                                             onChange={(e) => updateConfig({ ...config, content: e.target.value })}

--- a/apps/dashboard/src/components/deployment/DeploymentRag.tsx
+++ b/apps/dashboard/src/components/deployment/DeploymentRag.tsx
@@ -119,7 +119,7 @@ export default function DeploymentRag({ deploymentId }: DeploymentRagProps) {
                                 checked={config.enabled !== false}
                                 onChange={(e) => updateConfig({ ...config, enabled: e.target.checked })}
                             />
-                            <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-background after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+                            <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-background after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
                         </label>
                     </div>
 
@@ -151,7 +151,7 @@ export default function DeploymentRag({ deploymentId }: DeploymentRagProps) {
                             <div className="grid gap-2">
                                 <label className="text-sm font-medium">Knowledge Base Collection</label>
                                 <select
-                                    className="flex h-10 w-full rounded-md border border-input bg-white dark:bg-zinc-900 text-slate-900 dark:text-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                    className="flex h-10 w-full rounded-md border border-input bg-card text-foreground px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                                     value={config.default_collection || ""}
                                     onChange={(e) => updateConfig({ ...config, default_collection: e.target.value })}
                                 >
@@ -166,7 +166,7 @@ export default function DeploymentRag({ deploymentId }: DeploymentRagProps) {
                                 <label className="text-sm font-medium">Top K Results</label>
                                 <input
                                     type="number"
-                                    className="flex h-10 w-full rounded-md border border-input bg-white dark:bg-zinc-900 text-slate-900 dark:text-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                    className="flex h-10 w-full rounded-md border border-input bg-card text-foreground px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                                     value={config.top_k || 3}
                                     onChange={(e) => updateConfig({ ...config, top_k: parseInt(e.target.value) })}
                                     min={1}

--- a/apps/dashboard/src/components/deployment/DeploymentRateLimit.tsx
+++ b/apps/dashboard/src/components/deployment/DeploymentRateLimit.tsx
@@ -94,7 +94,7 @@ export default function DeploymentRateLimit({ deploymentId }: DeploymentRateLimi
                                 checked={config.enabled}
                                 onChange={(e) => updateConfig({ ...config, enabled: e.target.checked })}
                             />
-                            <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-background after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+                            <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-background after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
                         </label>
                     </div>
 
@@ -103,7 +103,7 @@ export default function DeploymentRateLimit({ deploymentId }: DeploymentRateLimi
                             <label className="text-sm font-medium">Requests Per Minute (RPM)</label>
                             <input
                                 type="number"
-                                className="flex h-10 w-full rounded-md border border-input bg-white dark:bg-zinc-900 text-slate-900 dark:text-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                className="flex h-10 w-full rounded-md border border-input bg-card text-foreground px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                                 value={config.rpm}
                                 onChange={(e) => updateConfig({ ...config, rpm: parseInt(e.target.value) })}
                                 min={1}

--- a/apps/dashboard/src/components/deployment/TrainingLogs.tsx
+++ b/apps/dashboard/src/components/deployment/TrainingLogs.tsx
@@ -98,7 +98,7 @@ export default function TrainingLogs({ deploymentId }: TrainingLogsProps) {
                 </div>
             </div>
 
-            <div className="bg-zinc-950 rounded-lg border border-zinc-800 p-4 font-mono text-xs md:text-sm text-zinc-300 min-h-[500px] shadow-inner font-ligth">
+            <div className="bg-background rounded-lg border border-border p-4 font-mono text-xs md:text-sm text-cream/70 min-h-[500px] shadow-inner font-ligth">
                 <div
                     ref={scrollRef}
                     className="h-[500px] w-full overflow-y-auto scrollbar-thin scrollbar-thumb-zinc-700 scrollbar-track-transparent pr-2 leading-tight"
@@ -106,12 +106,12 @@ export default function TrainingLogs({ deploymentId }: TrainingLogsProps) {
                     {displayLogs.length > 0 ? (
                         displayLogs.map((line, i) => (
                             <div key={i} className="whitespace-pre-wrap break-all py-0.5 min-h-[1.2em]">
-                                <span className="text-zinc-500 mr-2 select-none">$</span>
+                                <span className="text-muted-foreground mr-2 select-none">$</span>
                                 {line}
                             </div>
                         ))
                     ) : (
-                        <div className="text-zinc-600 italic">
+                        <div className="text-muted-foreground italic">
                             {loading ? "Fetching logs..." : "No logs available yet..."}
                         </div>
                     )}

--- a/apps/dashboard/src/components/ui/Pagination.tsx
+++ b/apps/dashboard/src/components/ui/Pagination.tsx
@@ -22,17 +22,17 @@ export function Pagination({
     const endItem = Math.min(currentPage * pageSize, totalItems);
 
     return (
-        <div className="flex items-center justify-between px-4 py-3 bg-slate-50 dark:bg-zinc-900/50 border-t dark:border-zinc-800">
-            <div className="text-xs text-slate-500 dark:text-zinc-500 font-mono">
+        <div className="flex items-center justify-between px-4 py-3 bg-muted dark:bg-card/50 border-t dark:border-border">
+            <div className="text-xs text-muted-foreground font-mono">
                 Showing {startItem}-{endItem} of {totalItems} items
             </div>
             <div className="flex items-center gap-4">
                 <div className="flex items-center gap-2">
-                    <span className="text-xs text-slate-500 dark:text-zinc-500">Rows per page:</span>
+                    <span className="text-xs text-muted-foreground">Rows per page:</span>
                     <select
                         value={pageSize}
                         onChange={(e) => onPageSizeChange(Number(e.target.value))}
-                        className="bg-white dark:bg-zinc-900 border dark:border-zinc-800 rounded px-2 py-0.5 text-xs outline-none focus:ring-1 focus:ring-emerald-500"
+                        className="bg-card border dark:border-border rounded px-2 py-0.5 text-xs outline-none focus:ring-1 focus:ring-ember-500"
                     >
                         <option value={10}>10</option>
                         <option value={20}>20</option>
@@ -45,20 +45,20 @@ export function Pagination({
                         onClick={() => onPageChange(currentPage - 1)}
                         disabled={currentPage <= 1}
                         className={cn(
-                            "p-1 rounded hover:bg-slate-200 dark:hover:bg-zinc-800 transition-colors",
+                            "p-1 rounded hover:bg-muted dark:hover:bg-card transition-colors",
                             currentPage <= 1 && "opacity-50 cursor-not-allowed"
                         )}
                     >
                         <ChevronLeft className="w-4 h-4" />
                     </button>
-                    <span className="text-xs text-slate-500 dark:text-zinc-500 font-mono px-2">
+                    <span className="text-xs text-muted-foreground font-mono px-2">
                         Page {currentPage} of {totalPages || 1}
                     </span>
                     <button
                         onClick={() => onPageChange(currentPage + 1)}
                         disabled={currentPage >= totalPages}
                         className={cn(
-                            "p-1 rounded hover:bg-slate-200 dark:hover:bg-zinc-800 transition-colors",
+                            "p-1 rounded hover:bg-muted dark:hover:bg-card transition-colors",
                             currentPage >= totalPages && "opacity-50 cursor-not-allowed"
                         )}
                     >

--- a/apps/dashboard/src/components/ui/button.tsx
+++ b/apps/dashboard/src/components/ui/button.tsx
@@ -22,12 +22,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const baseStyles = "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
     
     const variants = {
-      default: "bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-700",
+      default: "bg-ember-600 text-white hover:bg-ember-700 dark:bg-ember-600 dark:hover:bg-ember-700",
       destructive: "bg-red-500 text-white hover:bg-red-600 dark:bg-red-900 dark:text-red-50 dark:hover:bg-red-900/90",
-      outline: "border border-slate-200 bg-white hover:bg-slate-100 hover:text-slate-900 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:bg-zinc-800 dark:hover:text-zinc-50",
-      secondary: "bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-zinc-800 dark:text-zinc-50 dark:hover:bg-zinc-800/80",
-      ghost: "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50",
-      link: "text-emerald-600 underline-offset-4 hover:underline dark:text-emerald-500",
+      outline: "border border-border bg-card hover:bg-muted hover:text-foreground dark:border-border dark:bg-background dark:hover:bg-card dark:hover:text-foreground",
+      secondary: "bg-muted text-foreground hover:bg-muted/80 dark:bg-card dark:text-foreground dark:hover:bg-card/80",
+      ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-card dark:hover:text-foreground",
+      link: "text-ember-600 underline-offset-4 hover:underline dark:text-ember-500",
     }
     
     const sizes = {

--- a/apps/dashboard/src/components/ui/empty-state.tsx
+++ b/apps/dashboard/src/components/ui/empty-state.tsx
@@ -24,17 +24,17 @@ export function EmptyState({
     return (
         <div
             className={cn(
-                "flex flex-col items-center justify-center py-12 px-4 text-center border-2 border-dashed border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-50/50 dark:bg-zinc-900/50",
+                "flex flex-col items-center justify-center py-12 px-4 text-center border-2 border-dashed border-border rounded-lg bg-muted/50 dark:bg-card/50",
                 className
             )}
         >
-            <div className="bg-white dark:bg-zinc-800 p-3 rounded-full shadow-sm mb-4">
-                <Icon className="w-8 h-8 text-slate-400 dark:text-zinc-500" />
+            <div className="bg-card p-3 rounded-full shadow-sm mb-4">
+                <Icon className="w-8 h-8 text-muted-foreground" />
             </div>
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-zinc-100 mb-1">
+            <h3 className="text-lg font-semibold text-foreground dark:text-cream mb-1">
                 {title}
             </h3>
-            <p className="text-sm text-slate-500 dark:text-zinc-400 max-w-sm mb-6">
+            <p className="text-sm text-muted-foreground max-w-sm mb-6">
                 {description}
             </p>
             {action && (

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -6,74 +6,67 @@
 
 @layer base {
   :root {
-    /* Clean Light Mode - Minimal & Airy */
-    --background: 0 0% 100%;
-    --foreground: 222 47% 11%;
-    --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
+    /* Editorial palette — cream + ember, matches InferiaAI/new-website */
+    /* Surfaces */
+    --background: 40 41% 97%;        /* #FAF7F2 cream */
+    --foreground: 0 0% 5%;           /* #0C0C0C dark */
+    --card: 37 35% 92%;              /* #F2EDE4 cream-deep */
+    --card-foreground: 0 0% 5%;
+    --popover: 40 41% 97%;
+    --popover-foreground: 0 0% 5%;
 
-    /* Primary: Supabase Green */
-    --primary: 158 66% 42%;
-    /* #24b47e */
-    --primary-foreground: 0 0% 100%;
+    /* Primary: Ember */
+    --primary: 13 65% 48%;           /* #C94D2A ember */
+    --primary-foreground: 40 41% 97%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222 47% 11.2%;
+    --secondary: 37 35% 92%;         /* cream-deep */
+    --secondary-foreground: 0 0% 24%; /* #3D3D3D fg-secondary */
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 37 35% 92%;
+    --muted-foreground: 0 0% 54%;    /* #8A8A8A fg-muted */
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 24 50% 92%;            /* #F4E8E0 ember-light */
+    --accent-foreground: 13 65% 48%; /* ember */
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 40 41% 97%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 158 66% 42%;
+    --border: 37 22% 88%;            /* #E6E1D8 */
+    --input: 37 22% 88%;
+    --ring: 13 65% 48%;              /* ember */
 
     --radius: 0.5rem;
   }
 
   .dark {
-    /* Supabase-inspired Dark Theme */
-    --background: 0 0% 11%;
-    /* #1c1c1c */
-    --foreground: 0 0% 93%;
-    /* #ededed */
+    /* Dark mode from new-website */
+    --background: 0 0% 6%;           /* #0F0F0F */
+    --foreground: 36 18% 89%;        /* #E8E4DE */
 
-    --card: 0 0% 14%;
-    /* #232323 */
-    --card-foreground: 0 0% 93%;
+    --card: 0 0% 10%;                /* #1A1A1A cream-deep dark */
+    --card-foreground: 36 18% 89%;
 
-    --popover: 0 0% 14%;
-    --popover-foreground: 0 0% 93%;
+    --popover: 0 0% 7%;              /* #111111 dark-raised */
+    --popover-foreground: 36 18% 89%;
 
-    --primary: 158 66% 42%;
-    /* Supabase Green #24b47e */
-    --primary-foreground: 0 0% 100%;
+    --primary: 14 71% 57%;           /* #E06640 ember in dark */
+    --primary-foreground: 0 0% 6%;
 
-    --secondary: 0 0% 18%;
-    /* #2e2e2e */
-    --secondary-foreground: 0 0% 93%;
+    --secondary: 0 0% 10%;
+    --secondary-foreground: 0 0% 66%; /* #A8A8A8 fg-secondary dark */
 
-    --muted: 0 0% 18%;
-    --muted-foreground: 240 5% 65%;
-    /* #a1a1aa */
+    --muted: 0 0% 10%;
+    --muted-foreground: 0 0% 40%;    /* #666666 fg-muted dark */
 
-    --accent: 0 0% 18%;
-    --accent-foreground: 0 0% 98%;
+    --accent: 14 35% 12%;            /* #2A1A14 ember-light dark */
+    --accent-foreground: 14 71% 57%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 0 63% 45%;
+    --destructive-foreground: 36 18% 89%;
 
-    --border: 0 0% 18%;
-    /* #2e2e2e */
-    --input: 0 0% 18%;
-    --ring: 158 66% 42%;
+    --border: 0 0% 15%;              /* ~rgba(255,255,255,0.1) */
+    --input: 0 0% 15%;
+    --ring: 14 71% 57%;              /* ember in dark */
   }
 }
 
@@ -84,10 +77,25 @@
 
   body {
     @apply bg-background text-foreground font-sans antialiased;
+    font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+  }
+
+  ::selection {
+    background: #E8D5C4;
+    color: #0C0C0C;
+  }
+  .dark ::selection {
+    background: #5C3D2A;
+    color: #E8E4DE;
+  }
+
+  :focus-visible {
+    outline: 1.5px solid hsl(var(--ring));
+    outline-offset: 2px;
   }
 }
 
-/* Custom Scrollbar for cleaner look */
+/* Custom Scrollbar — tuned to warm palette */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;

--- a/apps/dashboard/src/layouts/AuthLayout.tsx
+++ b/apps/dashboard/src/layouts/AuthLayout.tsx
@@ -17,7 +17,7 @@ export default function AuthLayout() {
 
                         <button
                             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-                            className="relative rounded-xl border border-border/70 bg-background/60 p-2 text-slate-500 transition-colors hover:bg-accent hover:text-foreground dark:text-zinc-400"
+                            className="relative rounded-xl border border-border/70 bg-background/60 p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground dark:text-muted-foreground"
                             aria-label="Toggle theme"
                         >
                             <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />

--- a/apps/dashboard/src/layouts/DashboardLayout.tsx
+++ b/apps/dashboard/src/layouts/DashboardLayout.tsx
@@ -92,8 +92,8 @@ function SidebarItem({
         cn(
           "group relative flex items-center gap-2.5 rounded-xl px-3 py-2 text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
           isActive
-            ? "bg-emerald-500/12 text-emerald-700 dark:bg-primary/15 dark:text-primary"
-            : "text-slate-600 hover:bg-slate-900/[0.03] hover:text-slate-900 dark:text-muted-foreground dark:hover:bg-white/5 dark:hover:text-foreground",
+            ? "bg-ember-500/12 text-ember-700 dark:bg-primary/15 dark:text-primary"
+            : "text-fg-secondary hover:bg-foreground/[0.04] hover:text-foreground dark:text-muted-foreground dark:hover:bg-white/5 dark:hover:text-foreground",
           isCollapsed && "justify-center px-2.5"
         )
       }
@@ -102,7 +102,7 @@ function SidebarItem({
         <>
           <span
             className={cn(
-              "absolute left-0 top-1/2 h-6 w-1 -translate-y-1/2 rounded-r-md bg-emerald-600 transition-opacity dark:bg-primary",
+              "absolute left-0 top-1/2 h-6 w-1 -translate-y-1/2 rounded-r-md bg-ember-600 transition-opacity dark:bg-primary",
               isActive ? "opacity-100" : "opacity-0"
             )}
             aria-hidden="true"
@@ -111,8 +111,8 @@ function SidebarItem({
             className={cn(
               "h-4 w-4 shrink-0 transition-colors",
               isActive
-                ? "text-emerald-700 dark:text-primary"
-                : "text-slate-500 group-hover:text-slate-900 dark:text-muted-foreground dark:group-hover:text-foreground"
+                ? "text-ember-700 dark:text-primary"
+                : "text-fg-muted group-hover:text-foreground dark:text-muted-foreground dark:group-hover:text-foreground"
             )}
           />
           <span className={cn("truncate", isCollapsed && "sr-only")}>{item.label}</span>

--- a/apps/dashboard/src/pages/AcceptInvite.tsx
+++ b/apps/dashboard/src/pages/AcceptInvite.tsx
@@ -100,7 +100,7 @@ export default function AcceptInvite() {
 
       <div className="overflow-hidden rounded-3xl border border-border/70 bg-card/90 shadow-2xl shadow-black/10 backdrop-blur-xl">
         <div className="grid lg:grid-cols-[1.1fr_0.9fr]">
-          <aside className="relative overflow-hidden border-b border-border/70 bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 p-6 text-slate-100 lg:border-b-0 lg:border-r lg:p-10">
+          <aside className="relative overflow-hidden border-b border-border/70 bg-gradient-to-br from-[#0C0C0C] via-[#0C0C0C] to-[#161616] p-6 text-cream lg:border-b-0 lg:border-r lg:p-10">
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(36,180,126,0.25),_transparent_45%),radial-gradient(circle_at_bottom_right,_rgba(125,211,252,0.16),_transparent_48%)]" />
             <div className="relative space-y-6">
               <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em]">
@@ -112,32 +112,32 @@ export default function AcceptInvite() {
                 <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
                   Join Your Team Workspace with a Secure Invite
                 </h1>
-                <p className="max-w-md text-sm text-slate-300 sm:text-base">
+                <p className="max-w-md text-sm text-cream/70 sm:text-base">
                   Provisioned access is linked to your invite token and role scope so your onboarding stays controlled and auditable.
                 </p>
               </div>
 
               <div className="space-y-3">
                 <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/70">
                     <Mail className="h-3.5 w-3.5" />
                     Invited Email
                   </div>
-                  <p className="break-all text-sm text-slate-100">{inviteInfo?.email || "Checking invitation..."}</p>
+                  <p className="break-all text-sm text-cream">{inviteInfo?.email || "Checking invitation..."}</p>
                 </div>
                 <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/70">
                     <ShieldCheck className="h-3.5 w-3.5" />
                     Assigned Role
                   </div>
-                  <p className="text-sm capitalize text-slate-100">{inviteInfo?.role || "Member"}</p>
+                  <p className="text-sm capitalize text-cream">{inviteInfo?.role || "Member"}</p>
                 </div>
                 <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/70">
                     <KeyRound className="h-3.5 w-3.5" />
                     Invite Expires
                   </div>
-                  <p className="text-sm text-slate-100">{formattedExpiry}</p>
+                  <p className="text-sm text-cream">{formattedExpiry}</p>
                 </div>
               </div>
             </div>

--- a/apps/dashboard/src/pages/ApiKeys.tsx
+++ b/apps/dashboard/src/pages/ApiKeys.tsx
@@ -166,7 +166,7 @@ export default function ApiKeys() {
                                     <td className="px-6 py-4 font-mono text-xs text-muted-foreground">{key.prefix}...</td>
                                     <td className="px-6 py-4 text-muted-foreground text-xs">{new Date(key.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}</td>
                                     <td className="px-6 py-4 flex items-center justify-between">
-                                        <span className={`inline-flex items-center px-2.5 py-1 rounded bg-background border text-xs font-medium shadow-sm ${key.is_active ? 'border-emerald-500/20 text-emerald-600 dark:text-emerald-400 bg-emerald-500/10' : 'border-red-500/20 text-red-600 dark:text-red-400 bg-red-500/10'}`}>
+                                        <span className={`inline-flex items-center px-2.5 py-1 rounded bg-background border text-xs font-medium shadow-sm ${key.is_active ? 'border-ember-500/20 text-ember-600 dark:text-ember-400 bg-ember-500/10' : 'border-red-500/20 text-red-600 dark:text-red-400 bg-red-500/10'}`}>
                                             {key.is_active ? 'Active' : 'Revoked'}
                                         </span>
                                         {key.is_active && canRevokeKey && (

--- a/apps/dashboard/src/pages/Auth/Setup2FA.tsx
+++ b/apps/dashboard/src/pages/Auth/Setup2FA.tsx
@@ -95,7 +95,7 @@ export default function Setup2FA() {
 
       <div className="overflow-hidden rounded-3xl border border-border/70 bg-card/90 shadow-2xl shadow-black/10 backdrop-blur-xl">
         <div className="grid lg:grid-cols-[1.1fr_0.9fr]">
-          <aside className="relative overflow-hidden border-b border-border/70 bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 p-6 text-slate-100 lg:border-b-0 lg:border-r lg:p-10">
+          <aside className="relative overflow-hidden border-b border-border/70 bg-gradient-to-br from-[#0C0C0C] via-[#0C0C0C] to-[#161616] p-6 text-cream lg:border-b-0 lg:border-r lg:p-10">
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(36,180,126,0.25),_transparent_45%),radial-gradient(circle_at_bottom_right,_rgba(125,211,252,0.16),_transparent_48%)]" />
             <div className="relative space-y-6">
               <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em]">
@@ -107,32 +107,32 @@ export default function Setup2FA() {
                 <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
                   Finalize Two-Factor Authentication
                 </h1>
-                <p className="max-w-md text-sm text-slate-300 sm:text-base">
+                <p className="max-w-md text-sm text-cream/70 sm:text-base">
                   Protect organization access with one-time code verification before entering the dashboard.
                 </p>
               </div>
 
               <div className="space-y-3">
                 <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/70">
                     <QrCode className="h-3.5 w-3.5" />
                     Step 1
                   </div>
-                  <p className="text-sm text-slate-100">Scan the QR code in your authenticator app.</p>
+                  <p className="text-sm text-cream">Scan the QR code in your authenticator app.</p>
                 </div>
                 <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/70">
                     <KeyRound className="h-3.5 w-3.5" />
                     Step 2
                   </div>
-                  <p className="text-sm text-slate-100">Save the secret key as backup enrollment data.</p>
+                  <p className="text-sm text-cream">Save the secret key as backup enrollment data.</p>
                 </div>
                 <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/70">
                     <CheckCircle2 className="h-3.5 w-3.5" />
                     Step 3
                   </div>
-                  <p className="text-sm text-slate-100">Enter a valid 6-digit code to activate 2FA.</p>
+                  <p className="text-sm text-cream">Enter a valid 6-digit code to activate 2FA.</p>
                 </div>
               </div>
             </div>
@@ -169,7 +169,7 @@ export default function Setup2FA() {
               ) : (
                 <div className="space-y-5">
                   <div className="flex flex-col items-center gap-4 rounded-2xl border border-border/70 bg-muted/20 p-5">
-                    <div className="rounded-xl border border-border/60 bg-white p-4 shadow-sm">
+                    <div className="rounded-xl border border-border/60 bg-card p-4 shadow-sm">
                       {setupData.qr_code.startsWith("data:image/") ? (
                         <img src={setupData.qr_code} alt="2FA QR Code" className="h-48 w-48" />
                       ) : (

--- a/apps/dashboard/src/pages/Compute/InstanceDetail.tsx
+++ b/apps/dashboard/src/pages/Compute/InstanceDetail.tsx
@@ -93,7 +93,7 @@ export default function InstanceDetail() {
   }, [id, poolDetails?.lifecycle_state, fetchInventory]);
 
   if (loading) {
-    return <div className="p-10 text-center text-slate-500">Loading pool details...</div>;
+    return <div className="p-10 text-center text-muted-foreground">Loading pool details...</div>;
   }
 
   const lifecycleState = (poolDetails?.lifecycle_state || "running") as PoolLifecycleState;
@@ -199,8 +199,8 @@ export default function InstanceDetail() {
                 isTerminating
                   ? "border-amber-500/20 text-amber-600 dark:text-amber-400 bg-amber-500/10"
                   : isTerminated
-                    ? "border-slate-500/20 text-slate-600 dark:text-slate-400 bg-slate-500/10"
-                    : "border-emerald-500/20 text-emerald-600 dark:text-emerald-400 bg-emerald-500/10",
+                    ? "border-muted-foreground/20 text-muted-foreground bg-muted-foreground/10"
+                    : "border-ember-500/20 text-ember-600 dark:text-ember-400 bg-ember-500/10",
               )}
             >
               {isTerminating ? "Terminating" : isTerminated ? "Terminated" : "Running"}
@@ -276,22 +276,22 @@ export default function InstanceDetail() {
         {activeTab === "overview" && (
           <div className="grid grid-cols-1 gap-6">
             <div className="rounded-xl border bg-card text-card-foreground shadow-sm p-6">
-              <h3 className="font-mono text-sm font-semibold mb-4 text-slate-900 dark:text-zinc-100">Pool Information</h3>
+              <h3 className="font-mono text-sm font-semibold mb-4 text-foreground dark:text-cream">Pool Information</h3>
               <div className="grid grid-cols-2 lg:grid-cols-5 gap-6">
                 <div>
                   <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Total Nodes</div>
-                  <div className="text-2xl font-bold text-slate-800 dark:text-zinc-200">{nodes.length}</div>
+                  <div className="text-2xl font-bold text-fg-secondary dark:text-cream/85">{nodes.length}</div>
                 </div>
                 <div>
                   <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Active Nodes</div>
-                  <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">{nodes.filter(n => n.state === "active" || n.state === "ready").length}</div>
+                  <div className="text-2xl font-bold text-ember-600 dark:text-ember-400">{nodes.filter(n => n.state === "active" || n.state === "ready").length}</div>
                 </div>
 
                 {poolDetails && (
                   <>
                     <div>
                       <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Provider</div>
-                      <div className="text-sm font-medium capitalize bg-slate-100 dark:bg-zinc-800 px-2 py-1 rounded inline-flex mt-1 text-slate-800 dark:text-zinc-200">
+                      <div className="text-sm font-medium capitalize bg-muted dark:bg-card px-2 py-1 rounded inline-flex mt-1 text-fg-secondary dark:text-cream/85">
                         {poolDetails.provider}
                       </div>
                     </div>
@@ -300,7 +300,7 @@ export default function InstanceDetail() {
                       <div className="flex flex-wrap gap-1 mt-1">
                         {poolDetails.allowed_gpu_types?.length > 0 ? (
                           poolDetails.allowed_gpu_types.map((gpu: string) => (
-                            <span key={gpu} className="text-xs font-mono bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300 px-1.5 py-0.5 rounded border border-emerald-100 dark:border-emerald-800">
+                            <span key={gpu} className="text-xs font-mono bg-ember-50 text-ember-700 dark:bg-ember-900/30 dark:text-ember-300 px-1.5 py-0.5 rounded border border-ember-100 dark:border-ember-800">
                               {gpu}
                             </span>
                           ))
@@ -311,7 +311,7 @@ export default function InstanceDetail() {
                     </div>
                     <div>
                       <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Max Cost</div>
-                      <div className="text-sm font-medium mt-1 text-slate-800 dark:text-zinc-200">
+                      <div className="text-sm font-medium mt-1 text-fg-secondary dark:text-cream/85">
                         {poolDetails.max_cost_per_hour > 0
                           ? `$${poolDetails.max_cost_per_hour.toFixed(2)} / hr`
                           : "Uncapped"}
@@ -349,13 +349,13 @@ export default function InstanceDetail() {
                   ) : (
                     nodes.map((node) => (
                       <tr key={node.node_id} className="bg-background hover:bg-muted/50 dark:hover:bg-muted/10 transition-colors">
-                        <td className="px-6 py-4 font-mono text-emerald-600 truncate max-w-[120px]" title={node.node_id}>{node.node_id}</td>
+                        <td className="px-6 py-4 font-mono text-ember-600 truncate max-w-[120px]" title={node.node_id}>{node.node_id}</td>
                         <td className="px-6 py-4">
                           <span className={cn(
                             "inline-flex items-center gap-1.5 px-2.5 py-1 rounded border text-xs font-medium shadow-sm",
                             node.state === "active" || node.state === "ready"
-                              ? "border-emerald-500/20 text-emerald-600 dark:text-emerald-400 bg-emerald-500/10"
-                              : "border-slate-500/20 text-slate-600 dark:text-slate-400 bg-slate-500/10"
+                              ? "border-ember-500/20 text-ember-600 dark:text-ember-400 bg-ember-500/10"
+                              : "border-muted-foreground/20 text-muted-foreground bg-muted-foreground/10"
                           )}>
                             {node.state}
                           </span>
@@ -369,14 +369,14 @@ export default function InstanceDetail() {
                               href={node.expose_url}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="text-emerald-600 hover:text-emerald-800 flex items-center gap-1 font-mono text-xs truncate max-w-[200px]"
+                              className="text-ember-600 hover:text-ember-800 flex items-center gap-1 font-mono text-xs truncate max-w-[200px]"
                               title={node.expose_url}
                             >
                               <ExternalLink className="w-3 h-3 flex-shrink-0" />
                               {node.expose_url}
                             </a>
                           ) : (
-                            <span className="text-slate-400 font-mono text-xs">-</span>
+                            <span className="text-muted-foreground font-mono text-xs">-</span>
                           )}
                         </td>
                       </tr>

--- a/apps/dashboard/src/pages/Compute/Instances.tsx
+++ b/apps/dashboard/src/pages/Compute/Instances.tsx
@@ -68,14 +68,14 @@ export default function Instances() {
   );
 
   return (
-    <div className="space-y-4 font-sans text-slate-900 dark:text-zinc-100">
+    <div className="space-y-4 font-sans text-foreground dark:text-cream">
       {/* Header */}
       <div className="flex flex-col gap-4">
         <h1 className="text-2xl font-bold tracking-tight">Pools</h1>
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2">
             <button
-              className="h-9 px-3 flex items-center gap-2 border rounded-md bg-white dark:bg-zinc-900 dark:border-zinc-800 hover:bg-slate-50 dark:hover:bg-zinc-800 transition-colors text-sm font-medium text-slate-700 dark:text-zinc-200 shadow-sm"
+              className="h-9 px-3 flex items-center gap-2 border rounded-md bg-card dark:border-border hover:bg-muted dark:hover:bg-card transition-colors text-sm font-medium text-fg-secondary dark:text-cream/85 shadow-sm"
               onClick={handleRefresh}
             >
               <RefreshCw
@@ -84,11 +84,11 @@ export default function Instances() {
               Refresh
             </button>
             <div className="relative">
-              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-slate-400" />
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
               <input
                 name="poolSearch"
                 placeholder="Search pools…"
-                className="h-9 w-64 rounded-md border dark:border-zinc-800 bg-white dark:bg-zinc-900 pl-9 pr-4 text-sm outline-none focus:ring-1 focus:ring-emerald-500 shadow-sm placeholder:text-slate-400 dark:text-zinc-200"
+                className="h-9 w-64 rounded-md border dark:border-border bg-card pl-9 pr-4 text-sm outline-none focus:ring-1 focus:ring-ember-500 shadow-sm placeholder:text-muted-foreground dark:text-cream/85"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 autoComplete="off"
@@ -100,7 +100,7 @@ export default function Instances() {
             <div className="flex gap-2">
               <Link
                 to="/dashboard/compute/pools/new"
-                className="h-9 px-4 bg-emerald-600 text-white rounded-md text-sm font-medium hover:bg-emerald-700 transition-colors shadow-sm inline-flex items-center gap-2"
+                className="h-9 px-4 bg-ember-600 text-white rounded-md text-sm font-medium hover:bg-ember-700 transition-colors shadow-sm inline-flex items-center gap-2"
               >
                 <Play className="w-4 h-4" />
                 New
@@ -122,14 +122,14 @@ export default function Instances() {
                 <th className="px-4 py-3 font-medium text-right">ID</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100 dark:divide-zinc-800">
+            <tbody className="divide-y divide-border">
               {isLoading ? (
                 <tr>
-                  <td colSpan={4} className="px-4 py-8 text-center text-slate-500 dark:text-zinc-500">Loading pools...</td>
+                  <td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">Loading pools...</td>
                 </tr>
               ) : filteredInstances.length === 0 ? (
                 <tr>
-                  <td colSpan={4} className="px-4 py-8 text-center text-slate-500 dark:text-zinc-500">No compute pools found. Create one to get started.</td>
+                  <td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">No compute pools found. Create one to get started.</td>
                 </tr>
               ) : (
                 filteredInstances.map((instance) => (
@@ -138,7 +138,7 @@ export default function Instances() {
                     className="bg-background hover:bg-muted/50 dark:hover:bg-muted/10 transition-colors"
                   >
 
-                    <td className="px-6 py-4 font-medium text-foreground hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">
+                    <td className="px-6 py-4 font-medium text-foreground hover:text-ember-500 dark:hover:text-ember-400 transition-colors">
                       <Link
                         to={`/dashboard/compute/pools/${instance.pool_id}`}
                       >
@@ -160,20 +160,20 @@ export default function Instances() {
                           Terminating
                         </span>
                       ) : instance.lifecycle_state === "terminated" ? (
-                        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded border border-slate-500/20 text-xs font-medium text-slate-600 dark:text-slate-400 bg-slate-500/10 shadow-sm">
-                          <div className="h-1.5 w-1.5 rounded-full bg-slate-500" />
+                        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded border border-muted-foreground/20 text-xs font-medium text-muted-foreground bg-muted-foreground/10 shadow-sm">
+                          <div className="h-1.5 w-1.5 rounded-full bg-muted-foreground" />
                           Terminated
                         </span>
                       ) : (
                         <span className={cn(
                           "inline-flex items-center gap-1.5 px-2.5 py-1 rounded bg-background border text-xs font-medium shadow-sm",
                           instance.is_active
-                            ? "border-emerald-500/20 text-emerald-600 dark:text-emerald-400 bg-emerald-500/10"
-                            : "border-slate-500/20 text-slate-600 dark:text-slate-400 bg-slate-500/10"
+                            ? "border-ember-500/20 text-ember-600 dark:text-ember-400 bg-ember-500/10"
+                            : "border-muted-foreground/20 text-muted-foreground bg-muted-foreground/10"
                         )}>
                           <div className={cn(
                             "h-1.5 w-1.5 rounded-full",
-                            instance.is_active ? "bg-emerald-500" : "bg-slate-500"
+                            instance.is_active ? "bg-ember-500" : "bg-muted-foreground"
                           )} />
                           {instance.is_active ? "Active" : "Inactive"}
                         </span>

--- a/apps/dashboard/src/pages/Compute/NewPool.tsx
+++ b/apps/dashboard/src/pages/Compute/NewPool.tsx
@@ -22,7 +22,7 @@ const providerIcons: Record<string, React.ComponentType<{ className?: string }>>
 const providerColors: Record<string, string> = {
     nosana: "text-green-500 bg-green-500/10",
     akash: "text-purple-500 bg-purple-500/10",
-    aws: "text-emerald-500 bg-emerald-500/10",
+    aws: "text-ember-500 bg-ember-500/10",
     gcp: "text-blue-500 bg-blue-500/10",
     k8s: "text-orange-500 bg-orange-500/10",
     skypilot: "text-cyan-500 bg-cyan-500/10",
@@ -236,7 +236,7 @@ export default function NewPool() {
             name: `${id.charAt(0).toUpperCase() + id.slice(1)} Network`,
             description: providerDescriptions[id] || `${id} compute provider`,
             icon: providerIcons[id] || Server,
-            color: providerColors[id] || "text-slate-500 bg-slate-500/10",
+            color: providerColors[id] || "text-muted-foreground bg-muted-foreground/10",
             category: data.adapter_type || "cloud",
             configPath: `/dashboard/settings/providers/${data.adapter_type || 'cloud'}/${id}`,
             capabilities: data.capabilities,
@@ -430,7 +430,7 @@ export default function NewPool() {
     }
 
     return (
-        <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in duration-500 font-sans text-slate-900 dark:text-zinc-50">
+        <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in duration-500 font-sans text-foreground">
             <div>
                 <h2 className="text-3xl font-bold tracking-tight">Create New Compute Pool</h2>
                 <p className="text-muted-foreground mt-2">
@@ -460,7 +460,7 @@ export default function NewPool() {
             {/* Step 2: Configure Compute - Cluster Providers (GCP/SkyPilot) */}
             {step === 2 && isClusterProvider && (
                 <div className="space-y-6">
-                    <div className="p-6 rounded-xl border bg-slate-50 dark:bg-zinc-900/50 dark:border-zinc-800">
+                    <div className="p-6 rounded-xl border bg-muted dark:bg-card/50 dark:border-border">
                         <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
                             <Cloud className="w-5 h-5" />
                             {selectedProvider === 'gcp' ? 'Google Cloud Platform' : 'SkyPilot'} Configuration
@@ -477,12 +477,12 @@ export default function NewPool() {
                                         className={cn(
                                             "p-3 rounded-lg border text-left text-sm transition-colors",
                                             selectedRegion === region.id
-                                                ? "border-emerald-600 bg-emerald-50 dark:bg-emerald-900/20"
-                                                : "border-slate-200 dark:border-zinc-700 hover:border-emerald-400"
+                                                ? "border-ember-600 bg-ember-50 dark:bg-ember-900/20"
+                                                : "border-border hover:border-ember-400"
                                         )}
                                     >
                                         <div className="font-medium">{region.name}</div>
-                                        <div className="text-xs text-slate-500">{region.id}</div>
+                                        <div className="text-xs text-muted-foreground">{region.id}</div>
                                     </button>
                                 ))}
                             </div>
@@ -499,13 +499,13 @@ export default function NewPool() {
                                         className={cn(
                                             "p-3 rounded-lg border text-left transition-colors",
                                             selectedResource?.gpu_type === gpu.gpu_type
-                                                ? "border-emerald-600 bg-emerald-50 dark:bg-emerald-900/20"
-                                                : "border-slate-200 dark:border-zinc-700 hover:border-emerald-400"
+                                                ? "border-ember-600 bg-ember-50 dark:bg-ember-900/20"
+                                                : "border-border hover:border-ember-400"
                                         )}
                                     >
                                         <div className="font-bold">{gpu.gpu_type}</div>
-                                        <div className="text-xs text-slate-500">{gpu.gpu_memory_gb}GB VRAM</div>
-                                        <div className="text-xs text-slate-400">{gpu.vcpu} vCPU</div>
+                                        <div className="text-xs text-muted-foreground">{gpu.gpu_memory_gb}GB VRAM</div>
+                                        <div className="text-xs text-muted-foreground">{gpu.vcpu} vCPU</div>
                                     </button>
                                 ))}
                             </div>
@@ -522,15 +522,15 @@ export default function NewPool() {
                                         className={cn(
                                             "p-3 rounded-lg border text-center font-bold transition-colors",
                                             gpuCount === count
-                                                ? "border-emerald-600 bg-emerald-50 dark:bg-emerald-900/20"
-                                                : "border-slate-200 dark:border-zinc-700 hover:border-emerald-400"
+                                                ? "border-ember-600 bg-ember-50 dark:bg-ember-900/20"
+                                                : "border-border hover:border-ember-400"
                                         )}
                                     >
                                         {count}x
                                     </button>
                                 ))}
                             </div>
-                            <p className="text-xs text-slate-500 mt-1">
+                            <p className="text-xs text-muted-foreground mt-1">
                                 {gpuCount > 1
                                     ? `${gpuCount} GPUs will be provisioned on a single node (multi-GPU).`
                                     : "Single GPU per node."}
@@ -538,27 +538,27 @@ export default function NewPool() {
                         </div>
 
                         {/* Spot Toggle */}
-                        <div className="p-4 rounded-lg border border-slate-200 dark:border-zinc-700 bg-white dark:bg-zinc-800">
+                        <div className="p-4 rounded-lg border border-border bg-card">
                             <div className="flex items-center justify-between">
                                 <div>
                                     <div className="font-medium">Use Spot Instances</div>
-                                    <div className="text-xs text-slate-500">Up to 60% cheaper, but may be interrupted</div>
+                                    <div className="text-xs text-muted-foreground">Up to 60% cheaper, but may be interrupted</div>
                                 </div>
                                 <button
                                     onClick={() => dispatch({ type: "SET_USE_SPOT", payload: !useSpot })}
                                     className={cn(
                                         "relative w-12 h-6 rounded-full transition-colors",
-                                        useSpot ? "bg-emerald-600" : "bg-slate-300 dark:bg-zinc-600"
+                                        useSpot ? "bg-ember-600" : "bg-muted dark:bg-card"
                                     )}
                                 >
                                     <div className={cn(
-                                        "absolute top-1 w-4 h-4 bg-white rounded-full transition-transform",
+                                        "absolute top-1 w-4 h-4 bg-card rounded-full transition-transform",
                                         useSpot ? "translate-x-7" : "translate-x-1"
                                     )} />
                                 </button>
                             </div>
                             {useSpot && (
-                                <div className="mt-2 text-xs text-emerald-600">
+                                <div className="mt-2 text-xs text-ember-600">
                                     Estimated cost: ~${(estimateGcpCost(selectedResource?.gpu_type || 'A100', true) * gpuCount).toFixed(2)}/hr (60% savings)
                                 </div>
                             )}
@@ -566,12 +566,12 @@ export default function NewPool() {
 
                         {/* Summary */}
                         {selectedRegion && selectedResource && (
-                            <div className="mt-4 p-4 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800">
-                                <div className="text-sm font-medium text-emerald-800 dark:text-emerald-200">
+                            <div className="mt-4 p-4 rounded-lg bg-ember-50 dark:bg-ember-900/20 border border-ember-200 dark:border-ember-800">
+                                <div className="text-sm font-medium text-ember-800 dark:text-ember-200">
                                     Summary: {gpuCount}x {selectedResource.gpu_type} in {selectedRegion}
                                     {useSpot && " (Spot)"}
                                 </div>
-                                <div className="text-xs text-emerald-600 dark:text-emerald-400">
+                                <div className="text-xs text-ember-600 dark:text-ember-400">
                                     Estimated: ${(estimateGcpCost(selectedResource.gpu_type, useSpot) * gpuCount).toFixed(2)}/hr
                                 </div>
                             </div>
@@ -581,14 +581,14 @@ export default function NewPool() {
                     <div className="flex justify-between pt-6">
                         <button
                             onClick={() => dispatch({ type: "SET_STEP", payload: 1 })}
-                            className="px-4 py-2 text-sm font-medium text-slate-500 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-zinc-200"
+                            className="px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground dark:hover:text-cream/85"
                         >
                             Back
                         </button>
                         <button
                             onClick={() => selectedRegion && selectedResource && dispatch({ type: "SET_STEP", payload: 3 })}
                             disabled={!selectedRegion || !selectedResource}
-                            className="px-6 py-2 bg-emerald-600 text-white rounded-md text-sm font-medium hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="px-6 py-2 bg-ember-600 text-white rounded-md text-sm font-medium hover:bg-ember-700 disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             Continue
                         </button>
@@ -609,7 +609,7 @@ export default function NewPool() {
                     />
 
                     {loadingResources ? (
-                        <div className="text-center py-12 text-slate-500">Loading available resources...</div>
+                        <div className="text-center py-12 text-muted-foreground">Loading available resources...</div>
                     ) : (
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                             {availableResources
@@ -639,14 +639,14 @@ export default function NewPool() {
                     <div className="flex justify-between pt-6">
                         <button
                             onClick={() => dispatch({ type: "SET_STEP", payload: 1 })}
-                            className="px-4 py-2 text-sm font-medium text-slate-500 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-zinc-200"
+                            className="px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground dark:hover:text-cream/85"
                         >
                             Back
                         </button>
                         <button
                             onClick={() => selectedResource && dispatch({ type: "SET_STEP", payload: 3 })}
                             disabled={!selectedResource}
-                            className="px-6 py-2 bg-emerald-600 text-white rounded-md text-sm font-medium hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="px-6 py-2 bg-ember-600 text-white rounded-md text-sm font-medium hover:bg-ember-700 disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             Continue
                         </button>
@@ -657,12 +657,12 @@ export default function NewPool() {
             {/* Step 3: Review */}
             {step === 3 && (
                 <div className="max-w-xl mx-auto space-y-6">
-                    <div className="p-6 rounded-xl border bg-slate-50 dark:bg-zinc-900/50 dark:border-zinc-800 space-y-4">
+                    <div className="p-6 rounded-xl border bg-muted dark:bg-card/50 dark:border-border space-y-4">
                         <div className="space-y-2">
                             <label htmlFor="pool-name" className="text-sm font-medium">Pool Name</label>
                             <input
                                 id="pool-name"
-                                className="w-full px-3 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:border-zinc-700 focus:ring-2 focus:ring-emerald-500/20 outline-none dark:text-zinc-100"
+                                className="w-full px-3 py-2 border rounded-md bg-card dark:border-border focus:ring-2 focus:ring-ember-500/20 outline-none dark:text-cream"
                                 placeholder={isClusterProvider ? "e.g. My GCP Production Pool" : "e.g. My Nosana Pool"}
                                 value={poolName}
                                 onChange={(e) => dispatch({ type: "SET_POOL_NAME", payload: e.target.value })}
@@ -679,12 +679,12 @@ export default function NewPool() {
 
                         {/* Cluster-specific info */}
                         {isClusterProvider && (
-                            <div className="pt-4 border-t border-slate-200/60 dark:border-zinc-800/60">
-                                <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+                            <div className="pt-4 border-t border-border/60 dark:border-border/60">
+                                <div className="flex items-center gap-2 text-sm text-ember-600 dark:text-ember-400">
                                     <Cloud className="w-4 h-4" />
                                     <span className="font-medium">Cluster-based provisioning</span>
                                 </div>
-                                <p className="text-xs text-slate-500 mt-1">
+                                <p className="text-xs text-muted-foreground mt-1">
                                     A persistent GPU cluster will be created. Deployments run on the cluster and can be started/stopped without recreating infrastructure.
                                 </p>
                             </div>
@@ -704,14 +704,14 @@ export default function NewPool() {
                     <div className="flex gap-3">
                         <button
                             onClick={() => dispatch({ type: "SET_STEP", payload: 2 })}
-                            className="flex-1 px-4 py-2 text-sm font-medium border rounded-md hover:bg-slate-50 dark:hover:bg-zinc-800 text-slate-700 dark:text-zinc-300 bg-white dark:bg-zinc-900 dark:border-zinc-700"
+                            className="flex-1 px-4 py-2 text-sm font-medium border rounded-md hover:bg-muted dark:hover:bg-card text-fg-secondary dark:text-cream/70 bg-card dark:border-border"
                         >
                             Back
                         </button>
                         <button
                             onClick={handleCreate}
                             disabled={isCreating || !poolName}
-                            className="flex-[2] px-6 py-2 bg-emerald-600 text-white rounded-md text-sm font-medium hover:bg-emerald-700 disabled:opacity-50 flex items-center justify-center gap-2"
+                            className="flex-[2] px-6 py-2 bg-ember-600 text-white rounded-md text-sm font-medium hover:bg-ember-700 disabled:opacity-50 flex items-center justify-center gap-2"
                         >
                             {isCreating ? (
                                 <>Creating Pool...</>
@@ -728,14 +728,14 @@ export default function NewPool() {
 
 function StepProgress({ currentStep }: { currentStep: number }) {
     return (
-        <div className="flex items-center gap-4 text-sm font-medium text-muted-foreground border-b dark:border-zinc-800 pb-4">
+        <div className="flex items-center gap-4 text-sm font-medium text-muted-foreground border-b dark:border-border pb-4">
             {[1, 2, 3].map((s, i) => (
                 <div key={s} className="flex items-center gap-4">
-                    <div className={cn("flex items-center gap-2", currentStep >= s && "text-emerald-600 dark:text-emerald-400")}>
-                        <div className={cn("w-6 h-6 rounded-full flex items-center justify-center text-xs border transition-colors", currentStep >= s ? "bg-emerald-600 text-white border-emerald-600 dark:border-emerald-500 dark:bg-emerald-600" : "border-slate-300 dark:border-zinc-700 bg-white dark:bg-zinc-800")}>{s}</div>
+                    <div className={cn("flex items-center gap-2", currentStep >= s && "text-ember-600 dark:text-ember-400")}>
+                        <div className={cn("w-6 h-6 rounded-full flex items-center justify-center text-xs border transition-colors", currentStep >= s ? "bg-ember-600 text-white border-ember-600 dark:border-ember-500 dark:bg-ember-600" : "border-border bg-card")}>{s}</div>
                         {s === 1 ? "Select Provider" : s === 2 ? "Compute Config" : "Review & Create"}
                     </div>
-                    {i < 2 && <div className="h-px w-8 bg-slate-200 dark:bg-zinc-800" />}
+                    {i < 2 && <div className="h-px w-8 bg-muted dark:bg-card" />}
                 </div>
             ))}
         </div>
@@ -749,20 +749,20 @@ function ProviderCard({ provider: p, onSelect }: { provider: any, onSelect: (id:
                 disabled={p.disabled}
                 onClick={() => onSelect(p.id)}
                 className={cn(
-                    "text-left group relative p-6 rounded-xl border bg-white dark:bg-zinc-900 dark:border-zinc-800 hover:border-emerald-500/50 dark:hover:border-emerald-500/50 transition-colors hover:shadow-md flex flex-col gap-4",
-                    p.disabled && "opacity-50 cursor-not-allowed hover:border-slate-200 dark:hover:border-zinc-800 hover:shadow-none bg-slate-50 dark:bg-zinc-900/50"
+                    "text-left group relative p-6 rounded-xl border bg-card dark:border-border hover:border-ember-500/50 dark:hover:border-ember-500/50 transition-colors hover:shadow-md flex flex-col gap-4",
+                    p.disabled && "opacity-50 cursor-not-allowed hover:border-border dark:hover:border-border hover:shadow-none bg-muted dark:bg-card/50"
                 )}
             >
                 <div className={cn("w-12 h-12 rounded-lg flex items-center justify-center transition-colors", p.color)}>
                     <p.icon className="w-6 h-6" />
                 </div>
                 <div>
-                    <h3 className="font-bold text-lg mb-1 group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors uppercase tracing-tight text-xs">{p.name}</h3>
-                    <p className="text-sm text-slate-500 dark:text-zinc-400 leading-relaxed">{p.description}</p>
+                    <h3 className="font-bold text-lg mb-1 group-hover:text-ember-600 dark:group-hover:text-ember-400 transition-colors uppercase tracing-tight text-xs">{p.name}</h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">{p.description}</p>
                     {p.capabilities && (
                         <div className="mt-2 flex flex-wrap gap-1">
                             {p.capabilities.is_ephemeral && <span className="text-[10px] bg-orange-100 text-orange-700 px-1.5 py-0.5 rounded">Ephemeral</span>}
-                            {p.capabilities.pricing_model !== 'fixed' && <span className="text-[10px] bg-emerald-100 text-emerald-700 px-1.5 py-0.5 rounded capitalize">{p.capabilities.pricing_model}</span>}
+                            {p.capabilities.pricing_model !== 'fixed' && <span className="text-[10px] bg-ember-100 text-ember-700 px-1.5 py-0.5 rounded capitalize">{p.capabilities.pricing_model}</span>}
                         </div>
                     )}
                 </div>
@@ -774,16 +774,16 @@ function ProviderCard({ provider: p, onSelect }: { provider: any, onSelect: (id:
     return (
         <Link
             to={p.configPath}
-            className="text-left group relative p-6 rounded-xl border border-dashed border-slate-300 dark:border-zinc-800 bg-slate-50/30 dark:bg-zinc-900/20 hover:border-slate-400 dark:hover:border-zinc-700 transition-colors flex flex-col gap-4"
+            className="text-left group relative p-6 rounded-xl border border-dashed border-border bg-muted/30 dark:bg-card/20 hover:border-border dark:hover:border-border transition-colors flex flex-col gap-4"
         >
             <div className={cn("w-12 h-12 rounded-lg flex items-center justify-center opacity-40 grayscale", p.color)}>
                 <p.icon className="w-6 h-6" />
             </div>
             <div>
-                <h3 className="font-bold text-lg mb-1 text-slate-400 dark:text-zinc-500">{p.name}</h3>
-                <p className="text-xs text-slate-400 dark:text-zinc-600">Configuration required to create pools on this network.</p>
+                <h3 className="font-bold text-lg mb-1 text-muted-foreground">{p.name}</h3>
+                <p className="text-xs text-muted-foreground">Configuration required to create pools on this network.</p>
             </div>
-            <div className="mt-auto flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400 text-xs font-bold uppercase tracking-wider opacity-0 group-hover:opacity-100 transition-opacity">
+            <div className="mt-auto flex items-center gap-1.5 text-ember-600 dark:text-ember-400 text-xs font-bold uppercase tracking-wider opacity-0 group-hover:opacity-100 transition-opacity">
                 Connect Provider <ArrowRight className="w-3 h-3" />
             </div>
         </Link>
@@ -794,17 +794,17 @@ function ResourceFilter({ searchQuery, setSearchQuery, minVram, setMinVram, sort
     return (
         <div className="flex flex-col md:flex-row gap-3">
             <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                 <input
                     name="gpuSearch"
                     placeholder="Search GPUs (v100, t4, a100)…"
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     autoComplete="off"
-                    className="w-full pl-10 pr-4 py-2 bg-white dark:bg-zinc-900 border dark:border-zinc-800 rounded-lg outline-none focus:ring-2 focus:ring-emerald-500/20 transition-colors text-sm"
+                    className="w-full pl-10 pr-4 py-2 bg-card border dark:border-border rounded-lg outline-none focus:ring-2 focus:ring-ember-500/20 transition-colors text-sm"
                 />
             </div>
-            <select value={minVram} onChange={(e) => setMinVram(Number(e.target.value))} className="px-3 py-2 bg-white dark:bg-zinc-900 border dark:border-zinc-800 rounded-lg text-sm outline-none focus:ring-2 focus:ring-emerald-500/20">
+            <select value={minVram} onChange={(e) => setMinVram(Number(e.target.value))} className="px-3 py-2 bg-card border dark:border-border rounded-lg text-sm outline-none focus:ring-2 focus:ring-ember-500/20">
                 <option value={0}>All Memory</option>
                 <option value={8}>8GB+ VRAM</option>
                 <option value={16}>16GB+ VRAM</option>
@@ -812,7 +812,7 @@ function ResourceFilter({ searchQuery, setSearchQuery, minVram, setMinVram, sort
                 <option value={40}>40GB+ VRAM</option>
                 <option value={80}>80GB+ VRAM</option>
             </select>
-            <select value={sortBy} onChange={(e) => setSortBy(e.target.value as any)} className="px-3 py-2 bg-white dark:bg-zinc-900 border dark:border-zinc-800 rounded-lg text-sm outline-none focus:ring-2 focus:ring-emerald-500/20">
+            <select value={sortBy} onChange={(e) => setSortBy(e.target.value as any)} className="px-3 py-2 bg-card border dark:border-border rounded-lg text-sm outline-none focus:ring-2 focus:ring-ember-500/20">
                 <option value="price_asc">Price: Low to High</option>
                 <option value="price_desc">Price: High to Low</option>
                 <option value="memory">Memory: High to Low</option>
@@ -828,21 +828,21 @@ function ResourceCard({ resource: res, isSelected, onSelect }: { resource: any, 
             aria-pressed={isSelected}
             onClick={() => onSelect(res)}
             className={cn(
-                "w-full cursor-pointer p-4 rounded-xl border bg-white dark:bg-zinc-900 dark:border-zinc-800 transition-colors relative text-left",
-                isSelected ? "border-emerald-600 dark:border-emerald-500 ring-1 ring-emerald-600 dark:ring-emerald-500 shadow-sm" : "hover:border-emerald-400/30 dark:hover:border-emerald-600/30"
+                "w-full cursor-pointer p-4 rounded-xl border bg-card dark:border-border transition-colors relative text-left",
+                isSelected ? "border-ember-600 dark:border-ember-500 ring-1 ring-ember-600 dark:ring-ember-500 shadow-sm" : "hover:border-ember-400/30 dark:hover:border-ember-600/30"
             )}
         >
             <div className="flex justify-between items-start mb-2">
-                <div className="p-2 bg-slate-100 dark:bg-zinc-800 rounded-md"><Cpu className="w-5 h-5 text-slate-700 dark:text-zinc-200" /></div>
+                <div className="p-2 bg-muted dark:bg-card rounded-md"><Cpu className="w-5 h-5 text-fg-secondary dark:text-cream/85" /></div>
                 <span className="font-bold text-green-600 dark:text-green-400">${res.price_per_hour}/hr</span>
             </div>
             <h4 className="font-bold">{res.provider_resource_id}</h4>
-            <p className="text-sm text-slate-500 dark:text-zinc-400">{res.gpu_type} ({res.gpu_memory_gb}GB VRAM)</p>
-            <div className="mt-2 flex gap-2 text-xs text-slate-400 dark:text-zinc-500">
+            <p className="text-sm text-muted-foreground">{res.gpu_type} ({res.gpu_memory_gb}GB VRAM)</p>
+            <div className="mt-2 flex gap-2 text-xs text-muted-foreground">
                 <span>{res.vcpu} vCPU</span> • <span>{res.ram_gb}GB RAM</span>
             </div>
-            {res.pricing_model && res.pricing_model !== 'fixed' && <div className="mt-1"><span className="text-[10px] bg-emerald-100 text-emerald-700 px-1.5 py-0.5 rounded capitalize">{res.pricing_model}</span></div>}
-            {isSelected && <div className="absolute top-4 right-4 w-5 h-5 bg-emerald-600 text-white rounded-full flex items-center justify-center"><Check className="w-3 h-3" /></div>}
+            {res.pricing_model && res.pricing_model !== 'fixed' && <div className="mt-1"><span className="text-[10px] bg-ember-100 text-ember-700 px-1.5 py-0.5 rounded capitalize">{res.pricing_model}</span></div>}
+            {isSelected && <div className="absolute top-4 right-4 w-5 h-5 bg-ember-600 text-white rounded-full flex items-center justify-center"><Check className="w-3 h-3" /></div>}
         </button>
     )
 }
@@ -855,36 +855,36 @@ function PoolDetails({ providerName, resource, isClusterProvider, region, useSpo
     useSpot?: boolean
 }) {
     return (
-        <div className="pt-4 border-t border-slate-200/60 dark:border-zinc-800/60 space-y-3">
+        <div className="pt-4 border-t border-border/60 dark:border-border/60 space-y-3">
             <div className="flex justify-between text-sm">
-                <span className="text-slate-500 dark:text-zinc-400">Provider</span>
+                <span className="text-muted-foreground">Provider</span>
                 <span className="font-medium capitalize">{providerName}</span>
             </div>
             
             {isClusterProvider ? (
                 <>
                     <div className="flex justify-between text-sm">
-                        <span className="text-slate-500 dark:text-zinc-400">Region</span>
+                        <span className="text-muted-foreground">Region</span>
                         <span className="font-medium">{region || 'N/A'}</span>
                     </div>
                     <div className="flex justify-between text-sm">
-                        <span className="text-slate-500 dark:text-zinc-400">GPU Type</span>
+                        <span className="text-muted-foreground">GPU Type</span>
                         <span className="font-medium">{resource?.gpu_type || 'N/A'}</span>
                     </div>
                     <div className="flex justify-between text-sm">
-                        <span className="text-slate-500 dark:text-zinc-400">Instance Type</span>
+                        <span className="text-muted-foreground">Instance Type</span>
                         <span className="font-medium capitalize">{useSpot ? 'Spot' : 'On-demand'}</span>
                     </div>
                 </>
             ) : (
                 <>
                     <div className="flex justify-between text-sm">
-                        <span className="text-slate-500 dark:text-zinc-400">GPU Type</span>
+                        <span className="text-muted-foreground">GPU Type</span>
                         <span className="font-medium">{resource?.gpu_type}</span>
                     </div>
                     {resource?.pricing_model && resource?.pricing_model !== 'fixed' && (
                         <div className="flex justify-between text-sm">
-                            <span className="text-slate-500 dark:text-zinc-400">Pricing Model</span>
+                            <span className="text-muted-foreground">Pricing Model</span>
                             <span className="font-medium capitalize">{resource?.pricing_model}</span>
                         </div>
                     )}
@@ -892,7 +892,7 @@ function PoolDetails({ providerName, resource, isClusterProvider, region, useSpo
             )}
             
             <div className="flex justify-between text-sm">
-                <span className="text-slate-500 dark:text-zinc-400">Est. Cost per Hour</span>
+                <span className="text-muted-foreground">Est. Cost per Hour</span>
                 <span className="font-medium">${resource?.price_per_hour || '0.00'}</span>
             </div>
         </div>
@@ -901,11 +901,11 @@ function PoolDetails({ providerName, resource, isClusterProvider, region, useSpo
 
 function CredentialSelection({ provider, credentials, selectedCredential, setSelectedCredential, loading }: any) {
     return (
-        <div className="pt-4 border-t border-slate-200/60 dark:border-zinc-800/60 space-y-3">
+        <div className="pt-4 border-t border-border/60 dark:border-border/60 space-y-3">
             <div className="space-y-2">
                 <label htmlFor="credential-select" className="text-sm font-medium flex items-center gap-2"><Key className="w-4 h-4" /> {provider === "nosana" ? "Nosana API Key" : provider === "akash" ? "Akash Wallet" : "Provider Credential"}</label>
                 {loading ? <div className="text-sm text-muted-foreground">Loading credentials...</div> : (
-                    <select id="credential-select" value={selectedCredential} onChange={(e) => setSelectedCredential(e.target.value)} className="w-full px-3 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:border-zinc-700 focus:ring-2 focus:ring-emerald-500/20 outline-none dark:text-zinc-100 text-sm">
+                    <select id="credential-select" value={selectedCredential} onChange={(e) => setSelectedCredential(e.target.value)} className="w-full px-3 py-2 border rounded-md bg-card dark:border-border focus:ring-2 focus:ring-ember-500/20 outline-none dark:text-cream text-sm">
                         <option value="">Select a credential…</option>
                         {credentials.filter((key: any) => key.is_active).map((key: any) => <option key={key.name} value={key.name}>{key.name}</option>)}
                     </select>

--- a/apps/dashboard/src/pages/DeploymentDetail.tsx
+++ b/apps/dashboard/src/pages/DeploymentDetail.tsx
@@ -258,18 +258,18 @@ function DeploymentHeader({
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <button onClick={onRefresh} disabled={processing} className="px-4 py-1.5 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-zinc-900 dark:text-zinc-300 rounded-md text-sm font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800 flex items-center gap-2 disabled:opacity-50 transition-colors"><RefreshCcw className={cn("w-4 h-4", processing && "animate-spin")} /> {processing ? "..." : "Refresh"}</button>
+        <button onClick={onRefresh} disabled={processing} className="px-4 py-1.5 bg-card border border-border text-foreground dark:text-cream/70 rounded-md text-sm font-medium hover:bg-muted dark:hover:bg-card flex items-center gap-2 disabled:opacity-50 transition-colors"><RefreshCcw className={cn("w-4 h-4", processing && "animate-spin")} /> {processing ? "..." : "Refresh"}</button>
         {isRunning ? (
           canUpdateDeployment && (
-          <button onClick={() => onAction('stop')} disabled={processing} className="px-4 py-1.5 bg-white dark:bg-zinc-900 border border-amber-500/20 text-amber-600 dark:text-amber-500 rounded-md text-sm font-medium hover:bg-amber-50 dark:hover:bg-amber-500/10 flex items-center gap-2 disabled:opacity-50 transition-colors"><Square className="w-4 h-4" /> Stop</button>
+          <button onClick={() => onAction('stop')} disabled={processing} className="px-4 py-1.5 bg-card border border-amber-500/20 text-amber-600 dark:text-amber-500 rounded-md text-sm font-medium hover:bg-amber-50 dark:hover:bg-amber-500/10 flex items-center gap-2 disabled:opacity-50 transition-colors"><Square className="w-4 h-4" /> Stop</button>
           )
         ) : (
           <div className="flex gap-2">
             {canUpdateDeployment && (
-              <button onClick={() => onAction('start')} disabled={processing} className="px-5 py-1.5 bg-emerald-600 text-white rounded-md text-sm font-semibold hover:bg-emerald-500 flex items-center gap-2 disabled:opacity-50"><Play className="w-4 h-4 fill-current" /> Start</button>
+              <button onClick={() => onAction('start')} disabled={processing} className="px-5 py-1.5 bg-ember-600 text-white rounded-md text-sm font-semibold hover:bg-ember-500 flex items-center gap-2 disabled:opacity-50"><Play className="w-4 h-4 fill-current" /> Start</button>
             )}
             {canDeleteDeployment && (
-              <button onClick={() => onAction('delete')} disabled={deleting} className="px-4 py-1.5 bg-white dark:bg-zinc-900 border border-red-500/20 text-red-600 dark:text-red-400 rounded-md text-sm font-medium hover:bg-red-50 dark:hover:bg-red-500/10 flex items-center gap-2 disabled:opacity-50 transition-colors"><Trash2 className="w-4 h-4" /> Delete</button>
+              <button onClick={() => onAction('delete')} disabled={deleting} className="px-4 py-1.5 bg-card border border-red-500/20 text-red-600 dark:text-red-400 rounded-md text-sm font-medium hover:bg-red-50 dark:hover:bg-red-500/10 flex items-center gap-2 disabled:opacity-50 transition-colors"><Trash2 className="w-4 h-4" /> Delete</button>
             )}
           </div>
         )}
@@ -317,7 +317,7 @@ function ActionModal({ type, onCancel, onConfirm }: { type: ActionModalType; onC
         </div>
         <div className="mt-5 flex items-center justify-end gap-2">
           <button type="button" onClick={onCancel} className="px-3 py-1.5 text-sm rounded-md border hover:bg-muted">Cancel</button>
-          <button type="button" onClick={onConfirm} className={cn("px-3 py-1.5 text-sm rounded-md text-white", type === "delete" ? "bg-red-600 hover:bg-red-700" : "bg-emerald-600 hover:bg-emerald-700")}>{type === "delete" ? "Delete" : type === "stop" ? "Stop" : "Start"}</button>
+          <button type="button" onClick={onConfirm} className={cn("px-3 py-1.5 text-sm rounded-md text-white", type === "delete" ? "bg-red-600 hover:bg-red-700" : "bg-ember-600 hover:bg-ember-700")}>{type === "delete" ? "Delete" : type === "stop" ? "Stop" : "Start"}</button>
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/pages/Deployments.tsx
+++ b/apps/dashboard/src/pages/Deployments.tsx
@@ -62,7 +62,7 @@ function getStatusStyles(status: string) {
     return "border-green-200 bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800";
   }
   if (status === "STOPPED" || status === "TERMINATED") {
-    return "border-slate-200 bg-slate-50 text-slate-700 dark:bg-zinc-800 dark:text-zinc-400 dark:border-zinc-700";
+    return "border-border bg-muted text-fg-secondary dark:bg-card dark:text-muted-foreground dark:border-border";
   }
   if (status === "FAILED") {
     return "border-red-200 bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800";
@@ -75,7 +75,7 @@ function getStatusStyles(status: string) {
 
 function getStatusDot(status: string) {
   if (status === "READY" || status === "RUNNING") return "bg-green-500";
-  if (status === "STOPPED" || status === "TERMINATED") return "bg-zinc-400";
+  if (status === "STOPPED" || status === "TERMINATED") return "bg-muted-foreground";
   if (status === "FAILED") return "bg-red-500";
   if (status === "RETRYING") return "bg-amber-500 animate-pulse";
   return "bg-yellow-500";
@@ -161,7 +161,7 @@ export default function Deployments() {
   };
 
   return (
-    <div className="space-y-5 font-sans text-slate-900 dark:text-zinc-100">
+    <div className="space-y-5 font-sans text-foreground dark:text-cream">
       <DeploymentHeader
         canCreateDeployment={canCreateDeployment}
         onRefresh={() => queryClient.invalidateQueries({ queryKey: ["deployments"] })}
@@ -170,12 +170,12 @@ export default function Deployments() {
 
       <div className="flex items-center justify-between gap-3">
         <div className="relative w-full max-w-sm">
-          <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
+          <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
           <input
             name="deployment-search"
             autoComplete="off"
             placeholder="Search deployments…"
-            className="h-9 w-full rounded-md border dark:border-zinc-800 bg-white dark:bg-zinc-900 pl-9 pr-4 text-sm outline-none focus:ring-1 focus:ring-emerald-500 shadow-sm"
+            className="h-9 w-full rounded-md border dark:border-border bg-card pl-9 pr-4 text-sm outline-none focus:ring-1 focus:ring-ember-500 shadow-sm"
             value={search}
             onChange={(e) => {
               updateSearchParams({
@@ -234,9 +234,9 @@ function DeploymentHeader({
           <p className="mt-1 text-sm text-muted-foreground">Operate model runtimes, monitor state transitions, and access deployment settings.</p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <button type="button" className="h-9 px-3 inline-flex items-center gap-2 border rounded-md bg-white dark:bg-zinc-900 dark:border-zinc-800 hover:bg-slate-50 transition-colors text-sm font-medium" onClick={onRefresh}><RefreshCw className="w-3.5 h-3.5" /> Refresh</button>
+          <button type="button" className="h-9 px-3 inline-flex items-center gap-2 border rounded-md bg-card dark:border-border hover:bg-muted transition-colors text-sm font-medium" onClick={onRefresh}><RefreshCw className="w-3.5 h-3.5" /> Refresh</button>
           {canCreateDeployment && (
-            <button type="button" onClick={onNew} className="h-9 px-4 bg-emerald-600 text-white rounded-md text-sm font-medium hover:bg-emerald-700 transition-colors shadow-sm inline-flex items-center gap-2"><Plus className="w-4 h-4" /> New Deployment</button>
+            <button type="button" onClick={onNew} className="h-9 px-4 bg-ember-600 text-white rounded-md text-sm font-medium hover:bg-ember-700 transition-colors shadow-sm inline-flex items-center gap-2"><Plus className="w-4 h-4" /> New Deployment</button>
           )}
         </div>
       </div>
@@ -267,7 +267,7 @@ function DeploymentTable({
     return (
       <div className="p-8">
         {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="h-12 w-full bg-slate-100 dark:bg-zinc-800 animate-pulse rounded mb-2" />
+          <div key={i} className="h-12 w-full bg-muted dark:bg-card animate-pulse rounded mb-2" />
         ))}
       </div>
     );
@@ -275,7 +275,7 @@ function DeploymentTable({
 
   if (deployments.length === 0) {
     return (
-      <div className="px-4 py-16 text-center text-slate-500">
+      <div className="px-4 py-16 text-center text-muted-foreground">
         <Activity className="h-8 w-8 mx-auto mb-2 opacity-25" />
         <p className="text-sm">No deployments found.</p>
       </div>
@@ -351,7 +351,7 @@ function DeploymentCard({
   return (
     <article className="space-y-3 p-4">
       <div>
-        <Link to={`/dashboard/deployments/${deployment.id}`} className="font-medium text-foreground hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">
+        <Link to={`/dashboard/deployments/${deployment.id}`} className="font-medium text-foreground hover:text-ember-500 dark:hover:text-ember-400 transition-colors">
           {deployment.name}
         </Link>
         <div className="mt-1 text-xs text-muted-foreground font-mono">{(deployment.id || "").slice(0, 12)}…</div>
@@ -419,7 +419,7 @@ function DeploymentRow({
   return (
     <tr className="bg-background hover:bg-muted/50 dark:hover:bg-muted/10 transition-colors">
       <td className="px-6 py-4">
-        <Link to={`/dashboard/deployments/${d.id}`} className="font-medium text-foreground hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">{d.name}</Link>
+        <Link to={`/dashboard/deployments/${d.id}`} className="font-medium text-foreground hover:text-ember-500 dark:hover:text-ember-400 transition-colors">{d.name}</Link>
         <div className="mt-1 text-xs text-muted-foreground font-mono">{(d.id || "").slice(0, 12)}…</div>
       </td>
       <td className="px-6 py-4 text-muted-foreground font-mono text-xs">{d.modelName}</td>
@@ -478,7 +478,7 @@ function DeploymentActions({
 
   return (
     <div className={cn("flex flex-wrap items-center gap-2", align === "end" ? "justify-end" : "")}>
-      {canUpdateDeployment && canStart && <button type="button" disabled={isMutating} onClick={() => onStart(deployment.id)} className="inline-flex items-center gap-1.5 rounded-md border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1.5 text-xs text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/20 font-medium disabled:opacity-50 transition-colors"><Play className="w-3.5 h-3.5" /> Start</button>}
+      {canUpdateDeployment && canStart && <button type="button" disabled={isMutating} onClick={() => onStart(deployment.id)} className="inline-flex items-center gap-1.5 rounded-md border border-ember-500/20 bg-ember-500/10 px-2.5 py-1.5 text-xs text-ember-600 dark:text-ember-400 hover:bg-ember-500/20 font-medium disabled:opacity-50 transition-colors"><Play className="w-3.5 h-3.5" /> Start</button>}
       {canUpdateDeployment && isRunning && <button type="button" disabled={isMutating} onClick={() => onStop(deployment.id)} className="inline-flex items-center gap-1.5 rounded-md border border-amber-500/20 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-500/20 font-medium disabled:opacity-50 transition-colors"><Square className="w-3.5 h-3.5" /> Stop</button>}
       {canDeleteDeployment && canDelete && <button type="button" disabled={isMutating} onClick={() => onDelete(deployment.id)} className="inline-flex items-center gap-1.5 rounded-md border border-red-500/20 bg-red-500/10 px-2.5 py-1.5 text-xs text-red-600 dark:text-red-400 hover:bg-red-500/20 font-medium disabled:opacity-50 transition-colors"><Trash2 className="w-3.5 h-3.5" /> Delete</button>}
     </div>
@@ -490,7 +490,7 @@ function DeploymentPagination({ totalItems, pageSize, currentPage, totalPages, o
     <div className="bg-muted/10 border-t border-border/50 px-6 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between text-xs text-muted-foreground">
       <span>Showing {totalItems === 0 ? 0 : (currentPage - 1) * pageSize + 1} to {Math.min(currentPage * pageSize, totalItems)} of {totalItems}</span>
       <div className="flex items-center gap-3">
-        <div className="flex items-center gap-2"><span>Rows</span><select className="bg-white dark:bg-zinc-900 border dark:border-zinc-800 rounded px-2 py-1 outline-none" value={pageSize} onChange={(e) => onPageSizeChange(Number(e.target.value))}>{PAGE_SIZE_OPTIONS.map((o) => (<option key={o} value={o}>{o}</option>))}</select></div>
+        <div className="flex items-center gap-2"><span>Rows</span><select className="bg-card border dark:border-border rounded px-2 py-1 outline-none" value={pageSize} onChange={(e) => onPageSizeChange(Number(e.target.value))}>{PAGE_SIZE_OPTIONS.map((o) => (<option key={o} value={o}>{o}</option>))}</select></div>
         <div className="inline-flex items-center gap-2">
           <button type="button" className="rounded border px-2 py-1 disabled:opacity-50" disabled={currentPage <= 1} onClick={() => onPageChange(currentPage - 1)}>Prev</button>
           <span>Page {currentPage} of {totalPages}</span>

--- a/apps/dashboard/src/pages/Insights.tsx
+++ b/apps/dashboard/src/pages/Insights.tsx
@@ -684,7 +684,7 @@ export default function Insights() {
                         </ChartCard>
 
                         <ChartCard title="Request Volume" subtitle={`${granularity === "hour" ? "Hourly" : "Daily"} requests`}>
-                            <ChartLegend items={[{ label: "Requests", colorClass: "bg-emerald-600" }]} />
+                            <ChartLegend items={[{ label: "Requests", colorClass: "bg-ember-600" }]} />
                             <Suspense fallback={<Skeleton className="h-[260px] w-full" />}>
                                 <RequestVolumeChart data={chartData} />
                             </Suspense>
@@ -937,7 +937,7 @@ function MetricCard({
         <div className="rounded-xl border bg-card p-4 shadow-sm">
             <div className="mb-3 flex items-center justify-between">
                 <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{title}</span>
-                <Icon className="h-4 w-4 text-emerald-500" />
+                <Icon className="h-4 w-4 text-ember-500" />
             </div>
             <div className="text-2xl font-bold">{value}</div>
             <div className="mt-1 text-xs text-muted-foreground">{subtitle}</div>

--- a/apps/dashboard/src/pages/KnowledgeBase.tsx
+++ b/apps/dashboard/src/pages/KnowledgeBase.tsx
@@ -150,7 +150,7 @@ export default function KnowledgeBase() {
                             setIsNew(false)
                             setNewCollectionName("")
                         }}
-                        className="px-4 py-2 bg-transparent border text-emerald-500 border-emerald-500/50 hover:bg-emerald-500/10 rounded-md text-sm font-medium flex items-center gap-2 transition-colors"
+                        className="px-4 py-2 bg-transparent border text-ember-500 border-ember-500/50 hover:bg-ember-500/10 rounded-md text-sm font-medium flex items-center gap-2 transition-colors"
                     >
                         Add new knowledge <Plus className="w-4 h-4" />
                     </button>
@@ -227,7 +227,7 @@ export default function KnowledgeBase() {
                                         {canAddKnowledge && (
                                             <button
                                                 onClick={() => setShowUpload(true)}
-                                                className="px-4 py-2 bg-transparent border text-emerald-500 border-emerald-500/50 hover:bg-emerald-500/10 rounded-md text-sm font-medium flex items-center gap-2 transition-colors"
+                                                className="px-4 py-2 bg-transparent border text-ember-500 border-ember-500/50 hover:bg-ember-500/10 rounded-md text-sm font-medium flex items-center gap-2 transition-colors"
                                             >
                                                 Create new knowledge <Plus className="w-4 h-4" />
                                             </button>
@@ -238,7 +238,7 @@ export default function KnowledgeBase() {
                                         {files?.map((file, idx) => (
                                             <div key={idx} className="flex items-center justify-between p-4 bg-transparent border-b border-border/50 hover:bg-muted/10 transition-colors group first:border-t-0">
                                                 <div className="flex items-center gap-4 overflow-hidden">
-                                                    <div className="p-2.5 bg-emerald-500/10 text-emerald-500 dark:text-emerald-400 rounded-lg shrink-0">
+                                                    <div className="p-2.5 bg-ember-500/10 text-ember-500 dark:text-ember-400 rounded-lg shrink-0">
                                                         <FileText className="w-5 h-5" />
                                                     </div>
                                                     <div>

--- a/apps/dashboard/src/pages/Login.tsx
+++ b/apps/dashboard/src/pages/Login.tsx
@@ -62,44 +62,44 @@ export default function Login() {
 
       <div className="overflow-hidden rounded-3xl border border-border/70 bg-card/90 shadow-2xl shadow-black/10 backdrop-blur-xl">
         <div className="grid lg:grid-cols-[1.15fr_0.85fr]">
-          <aside className="relative overflow-hidden border-b border-border/70 bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 p-6 text-slate-100 lg:border-b-0 lg:border-r lg:p-10">
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(36,180,126,0.25),_transparent_45%),radial-gradient(circle_at_bottom_right,_rgba(125,211,252,0.18),_transparent_48%)]" />
+          <aside className="relative overflow-hidden border-b border-border/70 bg-gradient-to-br from-[#0C0C0C] via-[#0C0C0C] to-[#161616] p-6 text-cream lg:border-b-0 lg:border-r lg:p-10">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(201,77,42,0.30),_transparent_45%),radial-gradient(circle_at_bottom_right,_rgba(244,232,224,0.10),_transparent_48%)]" />
             <div className="relative space-y-8">
-              <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em]">
+              <div className="inline-flex items-center gap-2 rounded-full border border-ember-500/40 bg-ember-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-ember-300">
                 <Sparkles className="h-3.5 w-3.5" />
                 Organisation Console
               </div>
 
               <div className="space-y-4">
-                <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
+                <h1 className="font-serif text-3xl leading-tight sm:text-4xl">
                   Build, Ship, and Monitor AI Deployments in One Place
                 </h1>
-                <p className="max-w-md text-sm text-slate-300 sm:text-base">
+                <p className="max-w-md text-sm text-cream/70 sm:text-base">
                   Secure inference operations with policy controls, multi-provider routing, and real-time deployment intelligence.
                 </p>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
-                <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
-                    <Radar className="h-3.5 w-3.5" />
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/60">
+                    <Radar className="h-3.5 w-3.5 text-ember-400" />
                     Live Observability
                   </div>
-                  <p className="text-sm text-slate-200">Latency and throughput tracked per deployment in real time.</p>
+                  <p className="text-sm text-cream/85">Latency and throughput tracked per deployment in real time.</p>
                 </div>
-                <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
-                    <ShieldCheck className="h-3.5 w-3.5" />
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/60">
+                    <ShieldCheck className="h-3.5 w-3.5 text-ember-400" />
                     Trust Layer
                   </div>
-                  <p className="text-sm text-slate-200">Role-gated access with auditable actions across your organization.</p>
+                  <p className="text-sm text-cream/85">Role-gated access with auditable actions across your organization.</p>
                 </div>
-                <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
-                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-slate-300">
-                    <LockKeyhole className="h-3.5 w-3.5" />
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                  <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-cream/60">
+                    <LockKeyhole className="h-3.5 w-3.5 text-ember-400" />
                     Built-in 2FA
                   </div>
-                  <p className="text-sm text-slate-200">Hardware and authenticator-based sign-in hardening by default.</p>
+                  <p className="text-sm text-cream/85">Hardware and authenticator-based sign-in hardening by default.</p>
                 </div>
               </div>
             </div>

--- a/apps/dashboard/src/pages/NewDeployment.tsx
+++ b/apps/dashboard/src/pages/NewDeployment.tsx
@@ -326,10 +326,10 @@ const initialState: State = {
 function StepIndicator({ step, current, label }: { step: number; current: number; label: string }) {
   const isActive = step >= current
   return (
-    <div className={cn("flex items-center gap-2", isActive && "text-emerald-600 dark:text-emerald-400")}>
+    <div className={cn("flex items-center gap-2", isActive && "text-ember-600 dark:text-ember-400")}>
       <div className={cn(
         "w-6 h-6 rounded-full flex items-center justify-center text-xs border transition-colors",
-        isActive ? "bg-emerald-600 text-white border-emerald-600 dark:border-emerald-500 dark:bg-emerald-600" : "border-slate-300 dark:border-zinc-700 bg-white dark:bg-zinc-800"
+        isActive ? "bg-ember-600 text-white border-ember-600 dark:border-ember-500 dark:bg-ember-600" : "border-border bg-card"
       )}>
         {current}
       </div>
@@ -375,7 +375,7 @@ function HuggingFaceModelBrowser({
     return (
       <button
         onClick={() => setShowBrowser(true)}
-        className="w-full px-3 py-2 text-sm border border-dashed border-emerald-300 dark:border-emerald-700 rounded-md hover:bg-emerald-50 dark:hover:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400 flex items-center justify-center gap-2 transition-colors"
+        className="w-full px-3 py-2 text-sm border border-dashed border-ember-300 dark:border-ember-700 rounded-md hover:bg-ember-50 dark:hover:bg-ember-900/20 text-ember-600 dark:text-ember-400 flex items-center justify-center gap-2 transition-colors"
       >
         <Search className="w-4 h-4" />
         Browse Hugging Face Models
@@ -384,9 +384,9 @@ function HuggingFaceModelBrowser({
   }
 
   return (
-    <div className="border rounded-lg overflow-hidden bg-white dark:bg-zinc-900">
-      <div className="p-3 border-b dark:border-zinc-700 flex items-center gap-2">
-        <Search className="w-4 h-4 text-slate-400" />
+    <div className="border rounded-lg overflow-hidden bg-card">
+      <div className="p-3 border-b dark:border-border flex items-center gap-2">
+        <Search className="w-4 h-4 text-muted-foreground" />
         <input
           type="text"
           value={searchQuery}
@@ -396,20 +396,20 @@ function HuggingFaceModelBrowser({
         />
         <button
           onClick={() => setShowBrowser(false)}
-          className="p-1 hover:bg-slate-100 dark:hover:bg-zinc-800 rounded"
+          className="p-1 hover:bg-muted dark:hover:bg-card rounded"
         >
-          <X className="w-4 h-4 text-slate-400" />
+          <X className="w-4 h-4 text-muted-foreground" />
         </button>
       </div>
 
       <div className="max-h-64 overflow-y-auto">
         {isLoading ? (
-          <div className="p-8 text-center text-slate-500">
+          <div className="p-8 text-center text-muted-foreground">
             <Loader2 className="w-6 h-6 animate-spin mx-auto mb-2" />
             Loading models...
           </div>
         ) : modelType === "embedding" ? (
-          <div className="divide-y dark:divide-zinc-700">
+          <div className="divide-y dark:divide-border">
             {embeddingModels.map((model) => (
               <button
                 key={model.id}
@@ -428,15 +428,15 @@ function HuggingFaceModelBrowser({
                   setShowBrowser(false)
                 }}
                 className={cn(
-                  "w-full p-3 text-left hover:bg-slate-50 dark:hover:bg-zinc-800 transition-colors flex items-start gap-3",
-                  selectedModelId === model.id && "bg-emerald-50 dark:bg-emerald-900/20 border-l-2 border-emerald-500"
+                  "w-full p-3 text-left hover:bg-muted dark:hover:bg-card transition-colors flex items-start gap-3",
+                  selectedModelId === model.id && "bg-ember-50 dark:bg-ember-900/20 border-l-2 border-ember-500"
                 )}
               >
-                <Database className="w-5 h-5 text-slate-400 mt-0.5" />
+                <Database className="w-5 h-5 text-muted-foreground mt-0.5" />
                 <div className="flex-1 min-w-0">
                   <div className="font-medium text-sm truncate">{model.name}</div>
-                  <div className="text-xs text-slate-500 mt-0.5">{model.description}</div>
-                  <div className="flex items-center gap-3 mt-1.5 text-xs text-slate-400">
+                  <div className="text-xs text-muted-foreground mt-0.5">{model.description}</div>
+                  <div className="flex items-center gap-3 mt-1.5 text-xs text-muted-foreground">
                     <span>{model.dimensions}d</span>
                     <span>•</span>
                     <span>Max {model.max_sequence_length} tokens</span>
@@ -446,7 +446,7 @@ function HuggingFaceModelBrowser({
             ))}
           </div>
         ) : displayModels?.length ? (
-          <div className="divide-y dark:divide-zinc-700">
+          <div className="divide-y dark:divide-border">
             {displayModels.map((model: HFModel) => (
               <button
                 key={model.id}
@@ -455,14 +455,14 @@ function HuggingFaceModelBrowser({
                   setShowBrowser(false)
                 }}
                 className={cn(
-                  "w-full p-3 text-left hover:bg-slate-50 dark:hover:bg-zinc-800 transition-colors",
-                  selectedModelId === model.id && "bg-emerald-50 dark:bg-emerald-900/20 border-l-2 border-emerald-500"
+                  "w-full p-3 text-left hover:bg-muted dark:hover:bg-card transition-colors",
+                  selectedModelId === model.id && "bg-ember-50 dark:bg-ember-900/20 border-l-2 border-ember-500"
                 )}
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
                     <div className="font-medium text-sm truncate">{model.id}</div>
-                    <div className="flex items-center gap-3 mt-1 text-xs text-slate-400">
+                    <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
                       <span className="flex items-center gap-1">
                         <Download className="w-3 h-3" />
                         {formatDownloads(model.downloads || 0)}
@@ -472,7 +472,7 @@ function HuggingFaceModelBrowser({
                         {model.likes || 0}
                       </span>
                       {model.pipeline_tag && (
-                        <span className="px-1.5 py-0.5 bg-slate-100 dark:bg-zinc-800 rounded text-[10px]">
+                        <span className="px-1.5 py-0.5 bg-muted dark:bg-card rounded text-[10px]">
                           {model.pipeline_tag}
                         </span>
                       )}
@@ -483,7 +483,7 @@ function HuggingFaceModelBrowser({
             ))}
           </div>
         ) : (
-          <div className="p-8 text-center text-slate-500 text-sm">
+          <div className="p-8 text-center text-muted-foreground text-sm">
             {searchQuery.length > 2
               ? "No models found. Try a different search term."
               : "Type to search for models on Hugging Face"
@@ -519,7 +519,7 @@ function OllamaModelBrowser({
     return (
       <button
         onClick={() => setShowBrowser(true)}
-        className="w-full px-3 py-2 text-sm border border-dashed border-emerald-300 dark:border-emerald-700 rounded-md hover:bg-emerald-50 dark:hover:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400 flex items-center justify-center gap-2 transition-colors"
+        className="w-full px-3 py-2 text-sm border border-dashed border-ember-300 dark:border-ember-700 rounded-md hover:bg-ember-50 dark:hover:bg-ember-900/20 text-ember-600 dark:text-ember-400 flex items-center justify-center gap-2 transition-colors"
       >
         <Search className="w-4 h-4" />
         Browse Ollama Models
@@ -528,9 +528,9 @@ function OllamaModelBrowser({
   }
 
   return (
-    <div className="border rounded-lg overflow-hidden bg-white dark:bg-zinc-900">
-      <div className="p-3 border-b dark:border-zinc-700 flex items-center gap-2">
-        <Search className="w-4 h-4 text-slate-400" />
+    <div className="border rounded-lg overflow-hidden bg-card">
+      <div className="p-3 border-b dark:border-border flex items-center gap-2">
+        <Search className="w-4 h-4 text-muted-foreground" />
         <input
           type="text"
           value={searchQuery}
@@ -538,19 +538,19 @@ function OllamaModelBrowser({
           placeholder="Search Ollama models..."
           className="flex-1 text-sm outline-none bg-transparent"
         />
-        <button onClick={() => setShowBrowser(false)} className="p-1 hover:bg-slate-100 dark:hover:bg-zinc-800 rounded">
-          <X className="w-4 h-4 text-slate-400" />
+        <button onClick={() => setShowBrowser(false)} className="p-1 hover:bg-muted dark:hover:bg-card rounded">
+          <X className="w-4 h-4 text-muted-foreground" />
         </button>
       </div>
 
       <div className="max-h-64 overflow-y-auto">
         {isLoading ? (
-          <div className="p-8 text-center text-slate-500">
+          <div className="p-8 text-center text-muted-foreground">
             <Loader2 className="w-6 h-6 animate-spin mx-auto mb-2" />
             Loading Ollama models...
           </div>
         ) : filteredModels.length > 0 ? (
-          <div className="divide-y dark:divide-zinc-700">
+          <div className="divide-y dark:divide-border">
             {filteredModels.map((model: OllamaModel) => (
               <button
                 key={model.name}
@@ -569,17 +569,17 @@ function OllamaModelBrowser({
                   setShowBrowser(false)
                 }}
                 className={cn(
-                  "w-full p-3 text-left hover:bg-slate-50 dark:hover:bg-zinc-800 transition-colors",
-                  selectedModelId === model.name && "bg-emerald-50 dark:bg-emerald-900/20 border-l-2 border-emerald-500"
+                  "w-full p-3 text-left hover:bg-muted dark:hover:bg-card transition-colors",
+                  selectedModelId === model.name && "bg-ember-50 dark:bg-ember-900/20 border-l-2 border-ember-500"
                 )}
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
                     <div className="font-medium text-sm truncate">{model.name}</div>
-                    <div className="flex items-center gap-3 mt-1 text-xs text-slate-400">
+                    <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
                       {model.size > 0 && <span>{formatModelSize(model.size)}</span>}
                       {model.details?.parameter_size && <span>{model.details.parameter_size}</span>}
-                      {model.details?.family && <span className="px-1.5 py-0.5 bg-slate-100 dark:bg-zinc-800 rounded text-[10px]">{model.details.family}</span>}
+                      {model.details?.family && <span className="px-1.5 py-0.5 bg-muted dark:bg-card rounded text-[10px]">{model.details.family}</span>}
                     </div>
                   </div>
                 </div>
@@ -587,7 +587,7 @@ function OllamaModelBrowser({
             ))}
           </div>
         ) : (
-          <div className="p-8 text-center text-slate-500 text-sm">
+          <div className="p-8 text-center text-muted-foreground text-sm">
             {searchQuery ? "No Ollama models found for this search." : "No models available."}
           </div>
         )}
@@ -901,23 +901,23 @@ export default function NewDeployment() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in duration-500 font-sans text-slate-900 dark:text-zinc-50">
+    <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in duration-500 font-sans text-foreground">
       <div>
         <h2 className="text-3xl font-bold tracking-tight">New Deployment</h2>
         <p className="text-muted-foreground mt-2">Deploy your models on managed pools or connect to external AI providers.</p>
       </div>
 
       <div className="flex justify-center">
-        <div className="bg-slate-100 dark:bg-zinc-900 p-1 rounded-lg inline-flex shadow-inner">
+        <div className="bg-muted dark:bg-card p-1 rounded-lg inline-flex shadow-inner">
           <button
             onClick={() => { dispatch({ type: 'SET_MODE', payload: "managed" }); }}
-            className={cn("px-6 py-2.5 rounded-md text-sm font-medium transition-colors flex items-center gap-2", mode === "managed" ? "bg-white dark:bg-zinc-800 shadow-sm text-emerald-600 dark:text-emerald-400 ring-1 ring-black/5 dark:ring-white/5" : "text-slate-500 hover:text-slate-900 dark:text-zinc-400 dark:hover:text-zinc-200")}
+            className={cn("px-6 py-2.5 rounded-md text-sm font-medium transition-colors flex items-center gap-2", mode === "managed" ? "bg-card shadow-sm text-ember-600 dark:text-ember-400 ring-1 ring-black/5 dark:ring-white/5" : "text-muted-foreground hover:text-foreground dark:text-muted-foreground dark:hover:text-cream/85")}
           >
             <Layers className="w-4 h-4" /> Deploy on Compute
           </button>
           <button
             onClick={() => { dispatch({ type: 'SET_MODE', payload: "external" }); }}
-            className={cn("px-6 py-2.5 rounded-md text-sm font-medium transition-colors flex items-center gap-2", mode === "external" ? "bg-white dark:bg-zinc-800 shadow-sm text-emerald-600 dark:text-emerald-400 ring-1 ring-black/5 dark:ring-white/5" : "text-slate-500 hover:text-slate-900 dark:text-zinc-400 dark:hover:text-zinc-200")}
+            className={cn("px-6 py-2.5 rounded-md text-sm font-medium transition-colors flex items-center gap-2", mode === "external" ? "bg-card shadow-sm text-ember-600 dark:text-ember-400 ring-1 ring-black/5 dark:ring-white/5" : "text-muted-foreground hover:text-foreground dark:text-muted-foreground dark:hover:text-cream/85")}
           >
             <Globe className="w-4 h-4" /> External Provider
           </button>
@@ -953,13 +953,13 @@ function ManagedFlow({ state, dispatch, onLaunch, isPending, externalRegistry }:
 
   return (
     <>
-      <div className="flex items-center gap-4 text-sm font-medium text-muted-foreground border-b dark:border-zinc-800 pb-4">
+      <div className="flex items-center gap-4 text-sm font-medium text-muted-foreground border-b dark:border-border pb-4">
         <StepIndicator step={step} current={1} label="Type" />
-        <div className="h-px w-8 bg-slate-200 dark:bg-zinc-800" />
+        <div className="h-px w-8 bg-muted dark:bg-card" />
         <StepIndicator step={step} current={2} label="Engine" />
-        <div className="h-px w-8 bg-slate-200 dark:bg-zinc-800" />
+        <div className="h-px w-8 bg-muted dark:bg-card" />
         <StepIndicator step={step} current={3} label="Pool" />
-        <div className="h-px w-8 bg-slate-200 dark:bg-zinc-800" />
+        <div className="h-px w-8 bg-muted dark:bg-card" />
         <StepIndicator step={step} current={4} label="Config" />
       </div>
 
@@ -984,19 +984,19 @@ function TypeSelection({ selectedId, onSelect }: { selectedId: string; onSelect:
           className={cn(
             "w-full p-5 rounded-xl border relative transition-colors outline-none text-left",
             type.active
-              ? "cursor-pointer bg-white dark:bg-zinc-900 dark:border-zinc-800 hover:border-emerald-300 dark:hover:border-emerald-700 hover:shadow-sm focus:ring-2 focus:ring-emerald-500/40"
-              : "opacity-50 cursor-not-allowed bg-slate-50 dark:bg-zinc-900/50 dark:border-zinc-800",
-            selectedId === type.id && type.active ? "border-emerald-600 dark:border-emerald-500 ring-1 ring-emerald-600 dark:ring-emerald-500 shadow-md" : ""
+              ? "cursor-pointer bg-card dark:border-border hover:border-ember-300 dark:hover:border-ember-700 hover:shadow-sm focus:ring-2 focus:ring-ember-500/40"
+              : "opacity-50 cursor-not-allowed bg-muted dark:bg-card/50 dark:border-border",
+            selectedId === type.id && type.active ? "border-ember-600 dark:border-ember-500 ring-1 ring-ember-600 dark:ring-ember-500 shadow-md" : ""
           )}
         >
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
-              {type.icon && <type.icon className={cn("w-5 h-5", type.active ? "text-slate-700 dark:text-zinc-200" : "text-slate-500")} />}
+              {type.icon && <type.icon className={cn("w-5 h-5", type.active ? "text-fg-secondary dark:text-cream/85" : "text-muted-foreground")} />}
               <h3 className="font-bold">{type.name}</h3>
             </div>
-            {type.badge && <span className="text-[10px] font-bold px-2 py-0.5 bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400 rounded-full uppercase tracking-wide">{type.badge}</span>}
+            {type.badge && <span className="text-[10px] font-bold px-2 py-0.5 bg-muted dark:bg-card text-muted-foreground rounded-full uppercase tracking-wide">{type.badge}</span>}
           </div>
-          <p className="text-sm text-slate-500 dark:text-zinc-400 leading-relaxed">{type.desc}</p>
+          <p className="text-sm text-muted-foreground leading-relaxed">{type.desc}</p>
         </button>
       ))}
     </div>
@@ -1007,21 +1007,21 @@ function EngineSelection({ modelType, selectedEngine, dispatch, setStep }: { mod
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div className="col-span-full">
-        <button type="button" onClick={() => setStep(1)} className="text-sm text-slate-500 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-zinc-200 font-medium mb-4 flex items-center gap-1">← Back to Type</button>
+        <button type="button" onClick={() => setStep(1)} className="text-sm text-muted-foreground hover:text-foreground dark:hover:text-cream/85 font-medium mb-4 flex items-center gap-1">← Back to Type</button>
       </div>
       {computeEngines.filter(e => e.modelTypes.includes(modelType)).map(e => (
-        <button type="button" key={e.id} aria-pressed={selectedEngine === e.id} onClick={() => dispatch({ type: 'SET_FIELD', field: 'selectedEngine', value: e.id })} className={cn("w-full cursor-pointer p-6 rounded-xl border bg-white dark:bg-zinc-900 dark:border-zinc-800 relative transition-colors outline-none text-left focus:ring-2 focus:ring-emerald-500/40", selectedEngine === e.id ? "border-emerald-600 dark:border-emerald-500 ring-1 ring-emerald-600 dark:ring-emerald-500 shadow-md" : "hover:border-emerald-300 dark:hover:border-emerald-700 hover:shadow-sm")}>
+        <button type="button" key={e.id} aria-pressed={selectedEngine === e.id} onClick={() => dispatch({ type: 'SET_FIELD', field: 'selectedEngine', value: e.id })} className={cn("w-full cursor-pointer p-6 rounded-xl border bg-card dark:border-border relative transition-colors outline-none text-left focus:ring-2 focus:ring-ember-500/40", selectedEngine === e.id ? "border-ember-600 dark:border-ember-500 ring-1 ring-ember-600 dark:ring-ember-500 shadow-md" : "hover:border-ember-300 dark:hover:border-ember-700 hover:shadow-sm")}>
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center gap-2">
-              {e.icon && <e.icon className="w-5 h-5 text-slate-700 dark:text-zinc-200" />}
+              {e.icon && <e.icon className="w-5 h-5 text-fg-secondary dark:text-cream/85" />}
               <h3 className="font-bold text-lg">{e.name}</h3>
             </div>
-            {selectedEngine === e.id && <Check className="w-5 h-5 text-emerald-600 dark:text-emerald-500" />}
+            {selectedEngine === e.id && <Check className="w-5 h-5 text-ember-600 dark:text-ember-500" />}
           </div>
-          <p className="text-sm text-slate-500 dark:text-zinc-400 leading-relaxed">{e.desc}</p>
+          <p className="text-sm text-muted-foreground leading-relaxed">{e.desc}</p>
         </button>
       ))}
-      <div className="col-span-full flex justify-end pt-4"><button type="button" onClick={() => setStep(3)} className="px-6 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 transition-colors font-medium">Continue</button></div>
+      <div className="col-span-full flex justify-end pt-4"><button type="button" onClick={() => setStep(3)} className="px-6 py-2 bg-ember-600 text-white rounded-md hover:bg-ember-700 transition-colors font-medium">Continue</button></div>
     </div>
   );
 }
@@ -1032,40 +1032,40 @@ function PoolSelection({ userPools, poolsLoading, selectedPool, dispatch, setSte
       {poolsLoading ? (
         <div className="flex items-center justify-center py-12">
           <div className="flex flex-col items-center gap-3">
-            <div className="w-8 h-8 border-4 border-emerald-500 border-t-transparent rounded-full animate-spin" />
-            <p className="text-sm text-slate-500 dark:text-zinc-400">Loading compute pools...</p>
+            <div className="w-8 h-8 border-4 border-ember-500 border-t-transparent rounded-full animate-spin" />
+            <p className="text-sm text-muted-foreground">Loading compute pools...</p>
           </div>
         </div>
       ) : userPools.length === 0 ? (
-        <div className="text-center py-12 bg-slate-50 dark:bg-zinc-900/50 rounded-xl border border-dashed dark:border-zinc-800 flex flex-col items-center">
-          <Server className="w-12 h-12 text-slate-300 dark:text-zinc-600 mb-4" />
-          <h3 className="text-lg font-medium text-slate-900 dark:text-zinc-100">No Compute Pools Found</h3>
-          <p className="text-slate-500 dark:text-zinc-400 mt-1 mb-6 max-w-sm">You need active compute resources to deploy this model.</p>
-          <Link to="/dashboard/compute/pools/new" className="px-4 py-2 bg-white dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-md text-sm font-medium text-slate-700 dark:text-zinc-300 hover:bg-slate-50 dark:hover:bg-zinc-800 shadow-sm flex items-center gap-2"><Zap className="w-4 h-4 text-amber-500" /> Create New Pool</Link>
+        <div className="text-center py-12 bg-muted dark:bg-card/50 rounded-xl border border-dashed dark:border-border flex flex-col items-center">
+          <Server className="w-12 h-12 text-cream/70 dark:text-muted-foreground mb-4" />
+          <h3 className="text-lg font-medium text-foreground dark:text-cream">No Compute Pools Found</h3>
+          <p className="text-muted-foreground mt-1 mb-6 max-w-sm">You need active compute resources to deploy this model.</p>
+          <Link to="/dashboard/compute/pools/new" className="px-4 py-2 bg-card border border-border rounded-md text-sm font-medium text-fg-secondary dark:text-cream/70 hover:bg-muted dark:hover:bg-card shadow-sm flex items-center gap-2"><Zap className="w-4 h-4 text-amber-500" /> Create New Pool</Link>
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {userPools.filter(pool => pool.lifecycle_state === "running").length === 0 && (
-            <div className="col-span-full text-center py-8 text-slate-500 dark:text-zinc-400">
+            <div className="col-span-full text-center py-8 text-muted-foreground">
               <p className="text-sm">No ready pools available. Pools may still be provisioning.</p>
-              <Link to="/dashboard/compute/pools/new" className="text-emerald-600 text-sm font-medium mt-2 inline-block hover:underline">Create New Pool</Link>
+              <Link to="/dashboard/compute/pools/new" className="text-ember-600 text-sm font-medium mt-2 inline-block hover:underline">Create New Pool</Link>
             </div>
           )}
           {userPools.map(pool => {
             const isReady = pool.lifecycle_state === "running" && pool.is_active;
             const isProvisioning = pool.lifecycle_state === "provisioning" || (!pool.cluster_id && pool.pool_type === "cluster");
             return (
-            <button type="button" key={pool.pool_id} aria-pressed={selectedPool?.pool_id === pool.pool_id} disabled={!isReady} onClick={() => isReady && dispatch({ type: 'SET_FIELD', field: 'selectedPool', value: pool })} className={cn("w-full cursor-pointer p-5 rounded-xl border bg-white dark:bg-zinc-900 dark:border-zinc-800 relative transition-colors outline-none text-left focus:ring-2 focus:ring-emerald-500/40", !isReady && "opacity-50 cursor-not-allowed", selectedPool?.pool_id === pool.pool_id ? "border-emerald-600 dark:border-emerald-500 ring-1 ring-emerald-600 dark:ring-emerald-500 shadow-md" : "hover:border-emerald-300 dark:hover:border-emerald-700")}>
+            <button type="button" key={pool.pool_id} aria-pressed={selectedPool?.pool_id === pool.pool_id} disabled={!isReady} onClick={() => isReady && dispatch({ type: 'SET_FIELD', field: 'selectedPool', value: pool })} className={cn("w-full cursor-pointer p-5 rounded-xl border bg-card dark:border-border relative transition-colors outline-none text-left focus:ring-2 focus:ring-ember-500/40", !isReady && "opacity-50 cursor-not-allowed", selectedPool?.pool_id === pool.pool_id ? "border-ember-600 dark:border-ember-500 ring-1 ring-ember-600 dark:ring-ember-500 shadow-md" : "hover:border-ember-300 dark:hover:border-ember-700")}>
               <div className="flex items-start justify-between">
-                <div><div className="font-bold text-lg">{pool.pool_name}</div><div className="text-sm text-slate-500 dark:text-zinc-400 font-mono mt-1">{pool.provider}{pool.gpu_count > 1 ? ` (${pool.gpu_count}x GPU)` : ''}</div></div>
-                <div className={cn("px-2 py-0.5 rounded text-xs font-medium border", isProvisioning ? "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-900/50" : isReady ? "bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-900/50" : "bg-slate-50 text-slate-500 border-slate-200 dark:bg-zinc-800 dark:text-zinc-400 dark:border-zinc-700")}>{isProvisioning ? "Provisioning..." : isReady ? "Ready" : "Inactive"}</div>
+                <div><div className="font-bold text-lg">{pool.pool_name}</div><div className="text-sm text-muted-foreground font-mono mt-1">{pool.provider}{pool.gpu_count > 1 ? ` (${pool.gpu_count}x GPU)` : ''}</div></div>
+                <div className={cn("px-2 py-0.5 rounded text-xs font-medium border", isProvisioning ? "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-900/50" : isReady ? "bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-900/50" : "bg-muted text-muted-foreground border-border dark:bg-card dark:text-muted-foreground dark:border-border")}>{isProvisioning ? "Provisioning..." : isReady ? "Ready" : "Inactive"}</div>
               </div>
             </button>
             );
           })}
         </div>
       )}
-      <div className="flex justify-between pt-6 border-t dark:border-zinc-800"><button type="button" onClick={() => setStep(2)} className="text-slate-500 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-zinc-200 font-medium">Back</button><button type="button" onClick={() => selectedPool && setStep(4)} disabled={!selectedPool} className="px-6 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50 transition-colors font-medium">Continue</button></div>
+      <div className="flex justify-between pt-6 border-t dark:border-border"><button type="button" onClick={() => setStep(2)} className="text-muted-foreground hover:text-foreground dark:hover:text-cream/85 font-medium">Back</button><button type="button" onClick={() => selectedPool && setStep(4)} disabled={!selectedPool} className="px-6 py-2 bg-ember-600 text-white rounded-md hover:bg-ember-700 disabled:opacity-50 transition-colors font-medium">Continue</button></div>
     </div>
   );
 }
@@ -1134,28 +1134,28 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
 
   const getFitColor = (level: FitLevel) => {
     switch (level) {
-      case "Perfect": return "text-emerald-500 bg-emerald-500/10 border-emerald-500/20";
+      case "Perfect": return "text-ember-500 bg-ember-500/10 border-ember-500/20";
       case "Good": return "text-blue-500 bg-blue-500/10 border-blue-500/20";
       case "Marginal": return "text-amber-500 bg-amber-500/10 border-amber-500/20";
       case "TooTight": return "text-rose-500 bg-rose-500/10 border-rose-500/20";
-      default: return "text-slate-500 bg-slate-500/10 border-slate-500/20";
+      default: return "text-muted-foreground bg-muted-foreground/10 border-muted-foreground/20";
     }
   };
 
   return (
     <div className="max-w-2xl mx-auto space-y-8">
       <div className="space-y-4">
-        <label htmlFor="instanceName" className="block text-sm font-medium text-slate-700 dark:text-zinc-300">Deployment Name</label>
-        <input id="instanceName" value={instanceName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'instanceName', value: e.target.value })} className="w-full px-4 py-2 border dark:border-zinc-700 rounded-md focus:ring-2 focus:ring-emerald-500/20 outline-none transition-colors bg-white dark:bg-zinc-900 dark:text-white" placeholder="e.g. Production Llama 3" />
+        <label htmlFor="instanceName" className="block text-sm font-medium text-fg-secondary dark:text-cream/70">Deployment Name</label>
+        <input id="instanceName" value={instanceName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'instanceName', value: e.target.value })} className="w-full px-4 py-2 border dark:border-border rounded-md focus:ring-2 focus:ring-ember-500/20 outline-none transition-colors bg-card dark:text-white" placeholder="e.g. Production Llama 3" />
       </div>
 
       <div className="space-y-4">
-        <label className="block text-sm font-medium text-slate-700 dark:text-zinc-300">{modelType === "embedding" ? "Embedding Model" : "Model"}</label>
+        <label className="block text-sm font-medium text-fg-secondary dark:text-cream/70">{modelType === "embedding" ? "Embedding Model" : "Model"}</label>
         {selectedHFModel ? (
-          <div className="p-4 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 rounded-lg">
+          <div className="p-4 bg-ember-50 dark:bg-ember-900/20 border border-ember-200 dark:border-ember-800 rounded-lg">
             <div className="flex items-start justify-between">
-              <div><div className="font-medium text-emerald-900 dark:text-emerald-100">{selectedHFModel.id}</div><div className="text-sm text-emerald-600 dark:text-emerald-400 mt-1">{selectedHFModel.pipeline_tag || "feature-extraction"} • {formatDownloads(selectedHFModel.downloads || 0)} downloads</div></div>
-              <button type="button" onClick={() => { dispatch({ type: 'SET_FIELD', field: 'selectedHFModel', value: null }); dispatch({ type: 'SET_FIELD', field: 'modelId', value: "" }); }} className="p-1 hover:bg-emerald-100 dark:hover:bg-emerald-800 rounded"><X className="w-4 h-4 text-emerald-600 dark:text-emerald-400" /></button>
+              <div><div className="font-medium text-ember-900 dark:text-ember-100">{selectedHFModel.id}</div><div className="text-sm text-ember-600 dark:text-ember-400 mt-1">{selectedHFModel.pipeline_tag || "feature-extraction"} • {formatDownloads(selectedHFModel.downloads || 0)} downloads</div></div>
+              <button type="button" onClick={() => { dispatch({ type: 'SET_FIELD', field: 'selectedHFModel', value: null }); dispatch({ type: 'SET_FIELD', field: 'modelId', value: "" }); }} className="p-1 hover:bg-ember-100 dark:hover:bg-ember-800 rounded"><X className="w-4 h-4 text-ember-600 dark:text-ember-400" /></button>
             </div>
           </div>
         ) : selectedEngine === "ollama" ? (
@@ -1163,7 +1163,7 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
         ) : (
           <HuggingFaceModelBrowser modelType={modelType} onSelect={(m) => { dispatch({ type: 'SET_FIELD', field: 'selectedHFModel', value: m }); dispatch({ type: 'SET_FIELD', field: 'modelId', value: m.id }); }} selectedModelId={modelId} />
         )}
-        <input id="modelId" value={modelId} onChange={e => dispatch({ type: 'SET_FIELD', field: 'modelId', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md focus:ring-2 focus:ring-emerald-500/20 outline-none bg-white dark:bg-zinc-900 dark:text-white" placeholder={selectedEngine === "ollama" ? "e.g. llama3:8b, mistral, qwen2" : modelType === "embedding" ? "e.g. sentence-transformers/all-MiniLM-L6-v2" : "e.g. meta-llama/Meta-Llama-3-8B-Instruct"} />
+        <input id="modelId" value={modelId} onChange={e => dispatch({ type: 'SET_FIELD', field: 'modelId', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md focus:ring-2 focus:ring-ember-500/20 outline-none bg-card dark:text-white" placeholder={selectedEngine === "ollama" ? "e.g. llama3:8b, mistral, qwen2" : modelType === "embedding" ? "e.g. sentence-transformers/all-MiniLM-L6-v2" : "e.g. meta-llama/Meta-Llama-3-8B-Instruct"} />
       </div>
 
       {compatibility && (
@@ -1267,12 +1267,12 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
       {selectedEngine === "vllm" && (
         <div className="space-y-4 p-4 bg-muted/50 rounded-lg border">
           <div className="flex items-center gap-2 mb-2"><Cpu className="w-4 h-4 text-primary" /><h4 className="font-medium text-sm">vLLM Configuration</h4></div>
-          <div><label htmlFor="vllmImage" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">vLLM Image</label><input id="vllmImage" value={vllmImage} onChange={e => dispatch({ type: 'SET_FIELD', field: 'vllmImage', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" /></div>
+          <div><label htmlFor="vllmImage" className="block text-xs font-medium text-muted-foreground mb-1.5">vLLM Image</label><input id="vllmImage" value={vllmImage} onChange={e => dispatch({ type: 'SET_FIELD', field: 'vllmImage', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Required CUDA Versions</label>
+            <label className="block text-xs font-medium text-muted-foreground mb-1.5">Required CUDA Versions</label>
             <div className="flex flex-wrap gap-2">
               {["12.0", "12.1", "12.2", "12.3", "12.4", "12.5", "12.6", "12.7", "12.8", "12.9", "13.0", "13.1", "13.2"].map(v => (
-                <label key={v} className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium cursor-pointer transition-colors", cudaVersions.includes(v) ? "bg-emerald-50 border-emerald-300 text-emerald-700 dark:bg-emerald-900/20 dark:border-emerald-700 dark:text-emerald-400" : "bg-white border-slate-200 text-slate-500 dark:bg-zinc-900 dark:border-zinc-700 dark:text-zinc-400 hover:border-slate-300 dark:hover:border-zinc-600")}>
+                <label key={v} className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium cursor-pointer transition-colors", cudaVersions.includes(v) ? "bg-ember-50 border-ember-300 text-ember-700 dark:bg-ember-900/20 dark:border-ember-700 dark:text-ember-400" : "bg-card border-border text-muted-foreground dark:bg-card dark:border-border dark:text-muted-foreground hover:border-border dark:hover:border-border")}>
                   <input
                     type="checkbox"
                     checked={cudaVersions.includes(v)}
@@ -1290,19 +1290,19 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
             </div>
           </div>
           <div className="grid grid-cols-2 gap-4">
-            <div><label htmlFor="maxModelLen" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Max Model Length</label><input id="maxModelLen" value={maxModelLen} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxModelLen', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" /></div>
-            <div><label htmlFor="gpuUtil" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">GPU Memory Util</label><input id="gpuUtil" value={gpuUtil} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gpuUtil', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" /></div>
+            <div><label htmlFor="maxModelLen" className="block text-xs font-medium text-muted-foreground mb-1.5">Max Model Length</label><input id="maxModelLen" value={maxModelLen} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxModelLen', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
+            <div><label htmlFor="gpuUtil" className="block text-xs font-medium text-muted-foreground mb-1.5">GPU Memory Util</label><input id="gpuUtil" value={gpuUtil} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gpuUtil', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
           </div>
-          <div><label htmlFor="hfTokenVllm" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">HF Token</label><input id="hfTokenVllm" type="password" value={hfToken} onChange={e => dispatch({ type: 'SET_FIELD', field: 'hfToken', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" placeholder="hf_..." /></div>
+          <div><label htmlFor="hfTokenVllm" className="block text-xs font-medium text-muted-foreground mb-1.5">HF Token</label><input id="hfTokenVllm" type="password" value={hfToken} onChange={e => dispatch({ type: 'SET_FIELD', field: 'hfToken', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" placeholder="hf_..." /></div>
 
 
 
           {/* Advanced Configuration */}
-          <div className="border-t border-slate-200 dark:border-zinc-700 pt-4 mt-4">
+          <div className="border-t border-border pt-4 mt-4">
             <button
               type="button"
               onClick={() => dispatch({ type: 'SET_FIELD', field: 'isAdvancedOpen', value: !isAdvancedOpen })}
-              className="flex items-center gap-2 text-xs font-medium text-slate-500 dark:text-zinc-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+              className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-ember-600 dark:hover:text-ember-400 transition-colors"
             >
               {isAdvancedOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
               Advanced Configuration
@@ -1311,8 +1311,8 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
             {isAdvancedOpen && (
               <div className="mt-4 grid grid-cols-2 gap-4">
                 <div>
-                  <label htmlFor="dtype" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Data Type (dtype)</label>
-                  <select id="dtype" value={dtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'dtype', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white">
+                  <label htmlFor="dtype" className="block text-xs font-medium text-muted-foreground mb-1.5">Data Type (dtype)</label>
+                  <select id="dtype" value={dtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'dtype', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white">
                     <option value="auto">auto</option>
                     <option value="float16">float16</option>
                     <option value="bfloat16">bfloat16</option>
@@ -1320,8 +1320,8 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                   </select>
                 </div>
                 <div>
-                  <label htmlFor="kvCacheDtype" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">KV Cache dtype</label>
-                  <select id="kvCacheDtype" value={kvCacheDtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'kvCacheDtype', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white">
+                  <label htmlFor="kvCacheDtype" className="block text-xs font-medium text-muted-foreground mb-1.5">KV Cache dtype</label>
+                  <select id="kvCacheDtype" value={kvCacheDtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'kvCacheDtype', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white">
                     <option value="auto">auto</option>
                     <option value="fp8">fp8</option>
                     <option value="fp8_e4m3">fp8_e4m3</option>
@@ -1329,12 +1329,12 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                   </select>
                 </div>
                 <div>
-                  <label htmlFor="maxNumSeqs" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Max Num Sequences</label>
-                  <input id="maxNumSeqs" type="number" min="1" value={maxNumSeqs} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxNumSeqs', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" />
+                  <label htmlFor="maxNumSeqs" className="block text-xs font-medium text-muted-foreground mb-1.5">Max Num Sequences</label>
+                  <input id="maxNumSeqs" type="number" min="1" value={maxNumSeqs} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxNumSeqs', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" />
                 </div>
                 <div>
-                  <label htmlFor="quantization" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Quantization</label>
-                  <select id="quantization" value={quantization} onChange={e => dispatch({ type: 'SET_FIELD', field: 'quantization', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white">
+                  <label htmlFor="quantization" className="block text-xs font-medium text-muted-foreground mb-1.5">Quantization</label>
+                  <select id="quantization" value={quantization} onChange={e => dispatch({ type: 'SET_FIELD', field: 'quantization', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white">
                     <option value="">None</option>
                     <option value="awq">AWQ</option>
                     <option value="awq_marlin">AWQ Marlin</option>
@@ -1359,9 +1359,9 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                     type="checkbox"
                     checked={trustRemoteCode}
                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'trustRemoteCode', value: e.target.checked })}
-                    className="w-4 h-4 rounded border-slate-300 dark:border-zinc-600"
+                    className="w-4 h-4 rounded border-border"
                   />
-                  <label htmlFor="trustRemoteCode" className="text-xs font-medium text-slate-600 dark:text-zinc-400">Trust Remote Code</label>
+                  <label htmlFor="trustRemoteCode" className="text-xs font-medium text-muted-foreground">Trust Remote Code</label>
                 </div>
                 <div className="flex items-center gap-2">
                   <input
@@ -1369,9 +1369,9 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                     type="checkbox"
                     checked={enforceEager}
                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'enforceEager', value: e.target.checked })}
-                    className="w-4 h-4 rounded border-slate-300 dark:border-zinc-600"
+                    className="w-4 h-4 rounded border-border"
                   />
-                  <label htmlFor="enforceEager" className="text-xs font-medium text-slate-600 dark:text-zinc-400">Enforce Eager Mode</label>
+                  <label htmlFor="enforceEager" className="text-xs font-medium text-muted-foreground">Enforce Eager Mode</label>
                 </div>
                 <div className="flex items-center gap-2">
                   <input
@@ -1379,9 +1379,9 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                     type="checkbox"
                     checked={!!cudaModuleLoading}
                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'cudaModuleLoading', value: e.target.checked ? "LAZY" : "" })}
-                    className="w-4 h-4 rounded border-slate-300 dark:border-zinc-600"
+                    className="w-4 h-4 rounded border-border"
                   />
-                  <label htmlFor="cudaModuleLoading" className="text-xs font-medium text-slate-600 dark:text-zinc-400">CUDA Module Loading: LAZY</label>
+                  <label htmlFor="cudaModuleLoading" className="text-xs font-medium text-muted-foreground">CUDA Module Loading: LAZY</label>
                 </div>
                 <div className="flex items-center gap-2">
                   <input
@@ -1389,9 +1389,9 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                     type="checkbox"
                     checked={!!nvidiaDisableCudaCompat}
                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'nvidiaDisableCudaCompat', value: e.target.checked ? "1" : "" })}
-                    className="w-4 h-4 rounded border-slate-300 dark:border-zinc-600"
+                    className="w-4 h-4 rounded border-border"
                   />
-                  <label htmlFor="nvidiaDisableCudaCompat" className="text-xs font-medium text-slate-600 dark:text-zinc-400">NVIDIA Disable CUDA Compat</label>
+                  <label htmlFor="nvidiaDisableCudaCompat" className="text-xs font-medium text-muted-foreground">NVIDIA Disable CUDA Compat</label>
                 </div>
               </div>
             )}
@@ -1404,10 +1404,10 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
           <div className="flex items-center gap-2 mb-2"><Database className="w-4 h-4 text-primary" /><h4 className="font-medium text-sm">Embedding Configuration</h4></div>
           <div className="grid grid-cols-2 gap-4">
             {selectedEngine === "infinity" && (
-              <div><label htmlFor="batchSize" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Batch Size</label><input id="batchSize" type="number" value={batchSize} onChange={e => dispatch({ type: 'SET_FIELD', field: 'batchSize', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" /></div>
+              <div><label htmlFor="batchSize" className="block text-xs font-medium text-muted-foreground mb-1.5">Batch Size</label><input id="batchSize" type="number" value={batchSize} onChange={e => dispatch({ type: 'SET_FIELD', field: 'batchSize', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
             )}
             {selectedEngine === "tei" && (
-              <div><label htmlFor="maxBatchTokens" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Max Batch Tokens</label><input id="maxBatchTokens" type="number" value={maxBatchTokens} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxBatchTokens', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" /></div>
+              <div><label htmlFor="maxBatchTokens" className="block text-xs font-medium text-muted-foreground mb-1.5">Max Batch Tokens</label><input id="maxBatchTokens" type="number" value={maxBatchTokens} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxBatchTokens', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
             )}
             <div className="flex items-center gap-2 pt-6">
               <input
@@ -1415,17 +1415,17 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                 type="checkbox"
                 checked={gpuEnabled}
                 onChange={e => dispatch({ type: 'SET_FIELD', field: 'gpuEnabled', value: e.target.checked })}
-                className="w-4 h-4 rounded border-slate-300 dark:border-zinc-600"
+                className="w-4 h-4 rounded border-border"
               />
-              <label htmlFor="gpuEnabled" className="text-xs font-medium text-slate-600 dark:text-zinc-400">Enable GPU Acceleration</label>
+              <label htmlFor="gpuEnabled" className="text-xs font-medium text-muted-foreground">Enable GPU Acceleration</label>
             </div>
           </div>
 
-          <div className="border-t border-slate-200 dark:border-zinc-700 pt-4 mt-4">
+          <div className="border-t border-border pt-4 mt-4">
             <button
               type="button"
               onClick={() => dispatch({ type: 'SET_FIELD', field: 'isAdvancedOpen', value: !isAdvancedOpen })}
-              className="flex items-center gap-2 text-xs font-medium text-slate-500 dark:text-zinc-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+              className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-ember-600 dark:hover:text-ember-400 transition-colors"
             >
               {isAdvancedOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
               Advanced Hardware Configuration
@@ -1434,17 +1434,17 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
             {isAdvancedOpen && (
               <div className="mt-4 grid grid-cols-2 gap-4">
                 <div>
-                  <label htmlFor="requiredCpu" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Required CPU Cores</label>
-                  <input id="requiredCpu" type="number" min="1" value={requiredCpu} onChange={e => dispatch({ type: 'SET_FIELD', field: 'requiredCpu', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" />
+                  <label htmlFor="requiredCpu" className="block text-xs font-medium text-muted-foreground mb-1.5">Required CPU Cores</label>
+                  <input id="requiredCpu" type="number" min="1" value={requiredCpu} onChange={e => dispatch({ type: 'SET_FIELD', field: 'requiredCpu', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" />
                 </div>
                 <div>
-                  <label htmlFor="requiredRam" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Required RAM (MB)</label>
-                  <input id="requiredRam" type="number" min="1024" step="1024" value={requiredRam} onChange={e => dispatch({ type: 'SET_FIELD', field: 'requiredRam', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" />
+                  <label htmlFor="requiredRam" className="block text-xs font-medium text-muted-foreground mb-1.5">Required RAM (MB)</label>
+                  <input id="requiredRam" type="number" min="1024" step="1024" value={requiredRam} onChange={e => dispatch({ type: 'SET_FIELD', field: 'requiredRam', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" />
                 </div>
                 {selectedEngine === "tei" && (
                   <div>
-                    <label htmlFor="pooling" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Pooling Strategy</label>
-                    <select id="pooling" value={pooling} onChange={e => dispatch({ type: 'SET_FIELD', field: 'pooling', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white">
+                    <label htmlFor="pooling" className="block text-xs font-medium text-muted-foreground mb-1.5">Pooling Strategy</label>
+                    <select id="pooling" value={pooling} onChange={e => dispatch({ type: 'SET_FIELD', field: 'pooling', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white">
                       <option value="cls">CLS</option>
                       <option value="mean">Mean</option>
                       <option value="last_token">Last Token</option>
@@ -1469,8 +1469,8 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
             Model type is automatically set based on your deployment type. API key is configured automatically by the system.
           </div>
           <div>
-            <label htmlFor="hfTokenLocalai" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">HuggingFace Token (for private/gated models)</label>
-            <input id="hfTokenLocalai" type="password" value={hfToken} onChange={e => dispatch({ type: 'SET_FIELD', field: 'hfToken', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" placeholder="hf_xxxxx (optional)" />
+            <label htmlFor="hfTokenLocalai" className="block text-xs font-medium text-muted-foreground mb-1.5">HuggingFace Token (for private/gated models)</label>
+            <input id="hfTokenLocalai" type="password" value={hfToken} onChange={e => dispatch({ type: 'SET_FIELD', field: 'hfToken', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" placeholder="hf_xxxxx (optional)" />
             <p className="text-xs text-muted-foreground mt-1">Required only for gated models like SDXL, FLUX, etc.</p>
           </div>
           <div className="grid grid-cols-3 gap-4">
@@ -1480,9 +1480,9 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                 type="checkbox"
                 checked={state.trustRemoteCode || false}
                 onChange={e => dispatch({ type: 'SET_FIELD', field: 'trustRemoteCode', value: e.target.checked })}
-                className="w-4 h-4 rounded border-gray-300 dark:border-zinc-700 text-emerald-600 focus:ring-emerald-500"
+                className="w-4 h-4 rounded border-border text-ember-600 focus:ring-ember-500"
               />
-              <label htmlFor="trustRemoteCode" className="text-xs font-medium text-slate-600 dark:text-zinc-400">Trust Remote Code</label>
+              <label htmlFor="trustRemoteCode" className="text-xs font-medium text-muted-foreground">Trust Remote Code</label>
             </div>
             <div className="flex items-center gap-2">
               <input
@@ -1490,9 +1490,9 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                 type="checkbox"
                 checked={state.modelOffload || false}
                 onChange={e => dispatch({ type: 'SET_FIELD', field: 'modelOffload', value: e.target.checked })}
-                className="w-4 h-4 rounded border-gray-300 dark:border-zinc-700 text-emerald-600 focus:ring-emerald-500"
+                className="w-4 h-4 rounded border-border text-ember-600 focus:ring-ember-500"
               />
-              <label htmlFor="modelOffload" className="text-xs font-medium text-slate-600 dark:text-zinc-400">Model Offload</label>
+              <label htmlFor="modelOffload" className="text-xs font-medium text-muted-foreground">Model Offload</label>
             </div>
             <div className="flex items-center gap-2">
               <input
@@ -1500,9 +1500,9 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
                 type="checkbox"
                 checked={state.groupOffload || false}
                 onChange={e => dispatch({ type: 'SET_FIELD', field: 'groupOffload', value: e.target.checked })}
-                className="w-4 h-4 rounded border-gray-300 dark:border-zinc-700 text-emerald-600 focus:ring-emerald-500"
+                className="w-4 h-4 rounded border-border text-ember-600 focus:ring-ember-500"
               />
-              <label htmlFor="groupOffload" className="text-xs font-medium text-slate-600 dark:text-zinc-400">Group Offload</label>
+              <label htmlFor="groupOffload" className="text-xs font-medium text-muted-foreground">Group Offload</label>
             </div>
           </div>
         </div>
@@ -1511,9 +1511,9 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
       {deploymentType === "training" && (
         <div className="space-y-4 p-4 bg-muted/50 rounded-lg border">
           <div className="flex items-center gap-2 mb-2"><Layers className="w-4 h-4 text-primary" /><h4 className="font-medium text-sm">Training Configuration</h4></div>
-          <div><label htmlFor="gitRepo" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Git Repository URL</label><input id="gitRepo" value={gitRepo} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gitRepo', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" /></div>
-          <div><label htmlFor="trainingScript" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Training Script</label><input id="trainingScript" value={trainingScript} onChange={e => dispatch({ type: 'SET_FIELD', field: 'trainingScript', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md font-mono bg-white dark:bg-zinc-900 dark:text-white" /></div>
-          <div><label htmlFor="datasetUrl" className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1.5">Dataset URL</label><input id="datasetUrl" value={datasetUrl} onChange={e => dispatch({ type: 'SET_FIELD', field: 'datasetUrl', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-zinc-700 rounded-md bg-white dark:bg-zinc-900 dark:text-white" /></div>
+          <div><label htmlFor="gitRepo" className="block text-xs font-medium text-muted-foreground mb-1.5">Git Repository URL</label><input id="gitRepo" value={gitRepo} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gitRepo', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
+          <div><label htmlFor="trainingScript" className="block text-xs font-medium text-muted-foreground mb-1.5">Training Script</label><input id="trainingScript" value={trainingScript} onChange={e => dispatch({ type: 'SET_FIELD', field: 'trainingScript', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md font-mono bg-card dark:text-white" /></div>
+          <div><label htmlFor="datasetUrl" className="block text-xs font-medium text-muted-foreground mb-1.5">Dataset URL</label><input id="datasetUrl" value={datasetUrl} onChange={e => dispatch({ type: 'SET_FIELD', field: 'datasetUrl', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
         </div>
       )}
 
@@ -1537,7 +1537,7 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
           ))}
         </div>
       )}
-      <div className="flex gap-4 pt-6 border-t dark:border-zinc-800"><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 3 })} className="flex-1 py-2.5 border rounded-md hover:bg-slate-50 dark:hover:bg-zinc-800 font-medium transition-colors text-slate-700 dark:text-zinc-300">Back</button><button type="button" onClick={onLaunch} disabled={isPending} className="flex-[2] py-2.5 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-70 font-medium shadow-sm transition-colors flex justify-center items-center gap-2">{isPending ? "Deploying..." : <><Rocket className="w-4 h-4" /> Launch Deployment</>}</button></div>
+      <div className="flex gap-4 pt-6 border-t dark:border-border"><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 3 })} className="flex-1 py-2.5 border rounded-md hover:bg-muted dark:hover:bg-card font-medium transition-colors text-fg-secondary dark:text-cream/70">Back</button><button type="button" onClick={onLaunch} disabled={isPending} className="flex-[2] py-2.5 bg-ember-600 text-white rounded-md hover:bg-ember-700 disabled:opacity-70 font-medium shadow-sm transition-colors flex justify-center items-center gap-2">{isPending ? "Deploying..." : <><Rocket className="w-4 h-4" /> Launch Deployment</>}</button></div>
     </div>
   );
 }
@@ -1550,24 +1550,24 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
 
   return (
     <>
-      <div className="flex items-center gap-4 text-sm font-medium text-muted-foreground border-b dark:border-zinc-800 pb-4">
+      <div className="flex items-center gap-4 text-sm font-medium text-muted-foreground border-b dark:border-border pb-4">
         <StepIndicator step={step} current={1} label="Type & Provider" />
-        <div className="h-px w-8 bg-slate-200 dark:bg-zinc-800" />
+        <div className="h-px w-8 bg-muted dark:bg-card" />
         <StepIndicator step={step} current={2} label="API Configuration" />
-        <div className="h-px w-8 bg-slate-200 dark:bg-zinc-800" />
+        <div className="h-px w-8 bg-muted dark:bg-card" />
         <StepIndicator step={step} current={3} label="Review & Launch" />
       </div>
 
       {step === 1 && (
         <div className="space-y-6">
-          <div className="flex justify-center"><div className="bg-slate-100 dark:bg-zinc-900 p-1 rounded-lg inline-flex shadow-inner"><button type="button" onClick={() => dispatch({ type: 'SET_FIELD', field: 'modelType', value: 'inference' })} className={cn("px-5 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2", externalModelType === "inference" ? "bg-white dark:bg-zinc-800 shadow-sm text-emerald-600 dark:text-emerald-400" : "text-slate-500")}><MessageSquare className="w-4 h-4" /> Inference</button><button type="button" onClick={() => dispatch({ type: 'SET_FIELD', field: 'modelType', value: 'embedding' })} className={cn("px-5 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2", externalModelType === "embedding" ? "bg-white dark:bg-zinc-800 shadow-sm text-emerald-600 dark:text-emerald-400" : "text-slate-500")}><Database className="w-4 h-4" /> Embeddings</button><button type="button" onClick={() => dispatch({ type: 'SET_FIELD', field: 'modelType', value: 'image_generation' })} className={cn("px-5 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2", externalModelType === "image_generation" ? "bg-white dark:bg-zinc-800 shadow-sm text-emerald-600 dark:text-emerald-400" : "text-slate-500")}><Image className="w-4 h-4" /> Image Generation</button></div></div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">{filteredProviders.map(p => (<button type="button" key={p.id} aria-pressed={selectedProvider === p.id} onClick={() => dispatch({ type: 'SET_FIELD', field: 'selectedProvider', value: p.id })} className={cn("w-full cursor-pointer p-6 rounded-xl border bg-white dark:bg-zinc-900 dark:border-zinc-800 flex items-center gap-4 transition-colors outline-none text-left", selectedProvider === p.id ? "border-emerald-600 dark:border-emerald-500 ring-2 ring-emerald-600/20 dark:ring-emerald-500/20 bg-emerald-50 dark:bg-emerald-900/20 shadow-md" : "hover:border-emerald-300 dark:hover:border-emerald-700")}><div className="p-3 bg-slate-50 dark:bg-zinc-800 rounded-lg"><p.icon className="w-6 h-6 text-slate-700 dark:text-zinc-200" /></div><div><h3 className="font-bold text-lg">{p.name}</h3><p className="text-sm text-slate-500 dark:text-zinc-400">{p.desc}</p></div></button>))}</div>
-          <div className="col-span-full flex justify-end pt-4"><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 2 })} disabled={!selectedProvider} className="px-6 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50 transition-colors font-medium">Continue</button></div>
+          <div className="flex justify-center"><div className="bg-muted dark:bg-card p-1 rounded-lg inline-flex shadow-inner"><button type="button" onClick={() => dispatch({ type: 'SET_FIELD', field: 'modelType', value: 'inference' })} className={cn("px-5 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2", externalModelType === "inference" ? "bg-card shadow-sm text-ember-600 dark:text-ember-400" : "text-muted-foreground")}><MessageSquare className="w-4 h-4" /> Inference</button><button type="button" onClick={() => dispatch({ type: 'SET_FIELD', field: 'modelType', value: 'embedding' })} className={cn("px-5 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2", externalModelType === "embedding" ? "bg-card shadow-sm text-ember-600 dark:text-ember-400" : "text-muted-foreground")}><Database className="w-4 h-4" /> Embeddings</button><button type="button" onClick={() => dispatch({ type: 'SET_FIELD', field: 'modelType', value: 'image_generation' })} className={cn("px-5 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-2", externalModelType === "image_generation" ? "bg-card shadow-sm text-ember-600 dark:text-ember-400" : "text-muted-foreground")}><Image className="w-4 h-4" /> Image Generation</button></div></div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">{filteredProviders.map(p => (<button type="button" key={p.id} aria-pressed={selectedProvider === p.id} onClick={() => dispatch({ type: 'SET_FIELD', field: 'selectedProvider', value: p.id })} className={cn("w-full cursor-pointer p-6 rounded-xl border bg-card dark:border-border flex items-center gap-4 transition-colors outline-none text-left", selectedProvider === p.id ? "border-ember-600 dark:border-ember-500 ring-2 ring-ember-600/20 dark:ring-ember-500/20 bg-ember-50 dark:bg-ember-900/20 shadow-md" : "hover:border-ember-300 dark:hover:border-ember-700")}><div className="p-3 bg-muted dark:bg-card rounded-lg"><p.icon className="w-6 h-6 text-fg-secondary dark:text-cream/85" /></div><div><h3 className="font-bold text-lg">{p.name}</h3><p className="text-sm text-muted-foreground">{p.desc}</p></div></button>))}</div>
+          <div className="col-span-full flex justify-end pt-4"><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 2 })} disabled={!selectedProvider} className="px-6 py-2 bg-ember-600 text-white rounded-md hover:bg-ember-700 disabled:opacity-50 transition-colors font-medium">Continue</button></div>
         </div>
       )}
 
       {step === 2 && externalModelType === 'image_generation' && (
-        <div className="max-w-2xl mx-auto space-y-6 bg-white dark:bg-zinc-900 p-8 rounded-xl border dark:border-zinc-800 shadow-sm">
+        <div className="max-w-2xl mx-auto space-y-6 bg-card p-8 rounded-xl border dark:border-border shadow-sm">
           {/* Gemini image model catalog */}
           {selectedProvider === 'gemini' && (
             <div className="space-y-4">
@@ -1581,8 +1581,8 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
                     className={cn(
                       "w-full text-left px-4 py-3 rounded-lg border transition-all flex items-center justify-between gap-3",
                       externalModelName === m.id && !geminiCustomMode
-                        ? "border-emerald-600 dark:border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 ring-2 ring-emerald-600/20 dark:ring-emerald-500/20"
-                        : "border-slate-200 dark:border-zinc-700 hover:border-emerald-300 dark:hover:border-emerald-700 bg-white dark:bg-zinc-800/50"
+                        ? "border-ember-600 dark:border-ember-500 bg-ember-50 dark:bg-ember-900/20 ring-2 ring-ember-600/20 dark:ring-ember-500/20"
+                        : "border-border hover:border-ember-300 dark:hover:border-ember-700 bg-card/80"
                     )}
                   >
                     <div className="min-w-0 flex items-center gap-3">
@@ -1592,17 +1592,17 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
                       <div>
                         <div className="flex items-center gap-2">
                           <span className="font-medium text-sm">{m.name}</span>
-                          <span className="text-xs text-slate-400 dark:text-zinc-500 font-mono">{m.id}</span>
+                          <span className="text-xs text-muted-foreground font-mono">{m.id}</span>
                           {'badge' in m && m.badge && <span className="px-1.5 py-0.5 text-[10px] font-bold uppercase rounded bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-400">{m.badge}</span>}
                         </div>
-                        <p className="text-xs text-slate-500 dark:text-zinc-400 mt-0.5">{m.desc}</p>
+                        <p className="text-xs text-muted-foreground mt-0.5">{m.desc}</p>
                       </div>
                     </div>
                     <div className="flex-shrink-0">
                       {externalModelName === m.id && !geminiCustomMode ? (
-                        <div className="w-5 h-5 rounded-full bg-emerald-600 flex items-center justify-center"><Check className="w-3 h-3 text-white" /></div>
+                        <div className="w-5 h-5 rounded-full bg-ember-600 flex items-center justify-center"><Check className="w-3 h-3 text-white" /></div>
                       ) : (
-                        <div className="w-5 h-5 rounded-full border-2 border-slate-300 dark:border-zinc-600" />
+                        <div className="w-5 h-5 rounded-full border-2 border-border" />
                       )}
                     </div>
                   </button>
@@ -1614,19 +1614,19 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
                   className={cn(
                     "w-full text-left px-4 py-3 rounded-lg border transition-all flex items-center justify-between gap-3",
                     geminiCustomMode
-                      ? "border-emerald-600 dark:border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 ring-2 ring-emerald-600/20 dark:ring-emerald-500/20"
-                      : "border-dashed border-slate-300 dark:border-zinc-700 hover:border-emerald-300 dark:hover:border-emerald-700 bg-white dark:bg-zinc-800/50"
+                      ? "border-ember-600 dark:border-ember-500 bg-ember-50 dark:bg-ember-900/20 ring-2 ring-ember-600/20 dark:ring-ember-500/20"
+                      : "border-dashed border-border hover:border-ember-300 dark:hover:border-ember-700 bg-card/80"
                   )}
                 >
                   <div className="min-w-0 flex-1">
                     <span className="font-medium text-sm">Other Model</span>
-                    <p className="text-xs text-slate-500 dark:text-zinc-400 mt-0.5">Enter a custom image model ID</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">Enter a custom image model ID</p>
                   </div>
                   <div className="flex-shrink-0">
                     {geminiCustomMode ? (
-                      <div className="w-5 h-5 rounded-full bg-emerald-600 flex items-center justify-center"><Check className="w-3 h-3 text-white" /></div>
+                      <div className="w-5 h-5 rounded-full bg-ember-600 flex items-center justify-center"><Check className="w-3 h-3 text-white" /></div>
                     ) : (
-                      <div className="w-5 h-5 rounded-full border-2 border-dashed border-slate-300 dark:border-zinc-600" />
+                      <div className="w-5 h-5 rounded-full border-2 border-dashed border-border" />
                     )}
                   </div>
                 </button>
@@ -1635,7 +1635,7 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
                     autoFocus
                     value={externalModelName}
                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'externalModelName', value: e.target.value })}
-                    className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white border-slate-200 dark:border-zinc-700 text-sm"
+                    className="w-full px-4 py-2 border rounded-md bg-card dark:text-white border-border text-sm"
                     placeholder="e.g. imagen-3.0-generate-001"
                   />
                 )}
@@ -1647,32 +1647,32 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
           {selectedProvider !== 'gemini' && (
             <div className="space-y-4">
               <label htmlFor="externalImageModel" className="block text-sm font-medium">Model Name</label>
-              <input id="externalImageModel" value={externalModelName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'externalModelName', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white" placeholder="e.g. dall-e-3, stabilityai/stable-diffusion-2-1" />
+              <input id="externalImageModel" value={externalModelName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'externalModelName', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-card dark:text-white" placeholder="e.g. dall-e-3, stabilityai/stable-diffusion-2-1" />
             </div>
           )}
 
           <div className="space-y-4">
             <label htmlFor="apiKeyImg" className="block text-sm font-medium">API Key</label>
-            <input id="apiKeyImg" type="password" value={apiKey} onChange={e => dispatch({ type: 'SET_FIELD', field: 'apiKey', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white font-mono" placeholder="sk-..." />
+            <input id="apiKeyImg" type="password" value={apiKey} onChange={e => dispatch({ type: 'SET_FIELD', field: 'apiKey', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-card dark:text-white font-mono" placeholder="sk-..." />
           </div>
 
           {selectedProvider === 'custom' && (
             <div className="space-y-4">
               <label htmlFor="endpointUrlImg" className="block text-sm font-medium">Endpoint URL</label>
-              <input id="endpointUrlImg" value={endpointUrl} onChange={e => dispatch({ type: 'SET_FIELD', field: 'endpointUrl', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white" placeholder="https://..." />
+              <input id="endpointUrlImg" value={endpointUrl} onChange={e => dispatch({ type: 'SET_FIELD', field: 'endpointUrl', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-card dark:text-white" placeholder="https://..." />
             </div>
           )}
 
-          <div className="flex justify-between pt-6 border-t dark:border-zinc-800 mt-6">
-            <button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 1 })} className="text-slate-500 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-zinc-200 font-medium">Back</button>
-            <button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 3 })} disabled={!externalModelName || !apiKey || (selectedProvider === 'custom' && !endpointUrl)} className="px-6 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50 transition-colors font-medium">Continue</button>
+          <div className="flex justify-between pt-6 border-t dark:border-border mt-6">
+            <button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 1 })} className="text-muted-foreground hover:text-foreground dark:hover:text-cream/85 font-medium">Back</button>
+            <button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 3 })} disabled={!externalModelName || !apiKey || (selectedProvider === 'custom' && !endpointUrl)} className="px-6 py-2 bg-ember-600 text-white rounded-md hover:bg-ember-700 disabled:opacity-50 transition-colors font-medium">Continue</button>
           </div>
         </div>
       )}
 
       {step === 2 && externalModelType !== 'image_generation' && (
-        <div className="max-w-2xl mx-auto space-y-6 bg-white dark:bg-zinc-900 p-8 rounded-xl border dark:border-zinc-800 shadow-sm">
-          {selectedProvider === 'custom' && (<div className="space-y-4"><label htmlFor="customProviderName" className="block text-sm font-medium">Provider Name</label><input id="customProviderName" value={customProviderName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'customProviderName', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white" placeholder="e.g. My Custom Provider" /></div>)}
+        <div className="max-w-2xl mx-auto space-y-6 bg-card p-8 rounded-xl border dark:border-border shadow-sm">
+          {selectedProvider === 'custom' && (<div className="space-y-4"><label htmlFor="customProviderName" className="block text-sm font-medium">Provider Name</label><input id="customProviderName" value={customProviderName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'customProviderName', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-card dark:text-white" placeholder="e.g. My Custom Provider" /></div>)}
 
           {/* Gemini model catalog */}
           {selectedProvider === 'gemini' ? (
@@ -1687,23 +1687,23 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
                     className={cn(
                       "w-full text-left px-4 py-3 rounded-lg border transition-all flex items-center justify-between gap-3",
                       externalModelName === m.id && !geminiCustomMode
-                        ? "border-emerald-600 dark:border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 ring-2 ring-emerald-600/20 dark:ring-emerald-500/20"
-                        : "border-slate-200 dark:border-zinc-700 hover:border-emerald-300 dark:hover:border-emerald-700 bg-white dark:bg-zinc-800/50"
+                        ? "border-ember-600 dark:border-ember-500 bg-ember-50 dark:bg-ember-900/20 ring-2 ring-ember-600/20 dark:ring-ember-500/20"
+                        : "border-border hover:border-ember-300 dark:hover:border-ember-700 bg-card/80"
                     )}
                   >
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <span className="font-medium text-sm">{m.name}</span>
-                        <span className="text-xs text-slate-400 dark:text-zinc-500 font-mono">{m.id}</span>
-                        {'badge' in m && m.badge && <span className="px-1.5 py-0.5 text-[10px] font-bold uppercase rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">{m.badge}</span>}
+                        <span className="text-xs text-muted-foreground font-mono">{m.id}</span>
+                        {'badge' in m && m.badge && <span className="px-1.5 py-0.5 text-[10px] font-bold uppercase rounded bg-ember-100 dark:bg-ember-900/40 text-ember-700 dark:text-ember-400">{m.badge}</span>}
                       </div>
-                      <p className="text-xs text-slate-500 dark:text-zinc-400 mt-0.5">{m.desc}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">{m.desc}</p>
                     </div>
                     <div className="flex-shrink-0">
                       {externalModelName === m.id && !geminiCustomMode ? (
-                        <div className="w-5 h-5 rounded-full bg-emerald-600 flex items-center justify-center"><Check className="w-3 h-3 text-white" /></div>
+                        <div className="w-5 h-5 rounded-full bg-ember-600 flex items-center justify-center"><Check className="w-3 h-3 text-white" /></div>
                       ) : (
-                        <div className="w-5 h-5 rounded-full border-2 border-slate-300 dark:border-zinc-600" />
+                        <div className="w-5 h-5 rounded-full border-2 border-border" />
                       )}
                     </div>
                   </button>
@@ -1715,19 +1715,19 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
                   className={cn(
                     "w-full text-left px-4 py-3 rounded-lg border transition-all flex items-center justify-between gap-3",
                     geminiCustomMode
-                      ? "border-emerald-600 dark:border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 ring-2 ring-emerald-600/20 dark:ring-emerald-500/20"
-                      : "border-dashed border-slate-300 dark:border-zinc-700 hover:border-emerald-300 dark:hover:border-emerald-700 bg-white dark:bg-zinc-800/50"
+                      ? "border-ember-600 dark:border-ember-500 bg-ember-50 dark:bg-ember-900/20 ring-2 ring-ember-600/20 dark:ring-ember-500/20"
+                      : "border-dashed border-border hover:border-ember-300 dark:hover:border-ember-700 bg-card/80"
                   )}
                 >
                   <div className="min-w-0 flex-1">
                     <span className="font-medium text-sm">Other Model</span>
-                    <p className="text-xs text-slate-500 dark:text-zinc-400 mt-0.5">Enter a custom Gemini model ID</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">Enter a custom Gemini model ID</p>
                   </div>
                   <div className="flex-shrink-0">
                     {geminiCustomMode ? (
-                      <div className="w-5 h-5 rounded-full bg-emerald-600 flex items-center justify-center"><Check className="w-3 h-3 text-white" /></div>
+                      <div className="w-5 h-5 rounded-full bg-ember-600 flex items-center justify-center"><Check className="w-3 h-3 text-white" /></div>
                     ) : (
-                      <div className="w-5 h-5 rounded-full border-2 border-dashed border-slate-300 dark:border-zinc-600" />
+                      <div className="w-5 h-5 rounded-full border-2 border-dashed border-border" />
                     )}
                   </div>
                 </button>
@@ -1736,29 +1736,29 @@ function ExternalFlow({ state, dispatch, onLaunch, isPending, filteredProviders,
                     autoFocus
                     value={externalModelName}
                     onChange={e => dispatch({ type: 'SET_FIELD', field: 'externalModelName', value: e.target.value })}
-                    className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white border-slate-200 dark:border-zinc-700 text-sm"
+                    className="w-full px-4 py-2 border rounded-md bg-card dark:text-white border-border text-sm"
                     placeholder="e.g. gemini-2.0-flash"
                   />
                 )}
               </div>
             </div>
           ) : (
-            <div className="space-y-4"><label htmlFor="externalModelName" className="block text-sm font-medium">Model Name</label><input id="externalModelName" value={externalModelName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'externalModelName', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white" placeholder={externalModelType === "embedding" ? "e.g. text-embedding-3" : "e.g. gpt-4o"} /></div>
+            <div className="space-y-4"><label htmlFor="externalModelName" className="block text-sm font-medium">Model Name</label><input id="externalModelName" value={externalModelName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'externalModelName', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-card dark:text-white" placeholder={externalModelType === "embedding" ? "e.g. text-embedding-3" : "e.g. gpt-4o"} /></div>
           )}
 
-          <div className="space-y-4"><label htmlFor="apiKey" className="block text-sm font-medium">API Key</label><input id="apiKey" type="password" value={apiKey} onChange={e => dispatch({ type: 'SET_FIELD', field: 'apiKey', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white font-mono" placeholder="sk-..." /></div>
-          {selectedProvider === 'custom' && (<div className="space-y-4"><label htmlFor="endpointUrl" className="block text-sm font-medium">Endpoint URL</label><input id="endpointUrl" value={endpointUrl} onChange={e => dispatch({ type: 'SET_FIELD', field: 'endpointUrl', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white" placeholder="https://..." /></div>)}
-          <div className="flex justify-between pt-6 border-t dark:border-zinc-800 mt-6"><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 1 })} className="text-slate-500 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-zinc-200 font-medium">Back</button><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 3 })} disabled={!externalModelName || !apiKey || (selectedProvider === 'custom' && (!customProviderName || !endpointUrl))} className="px-6 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50 transition-colors font-medium">Continue</button></div>
+          <div className="space-y-4"><label htmlFor="apiKey" className="block text-sm font-medium">API Key</label><input id="apiKey" type="password" value={apiKey} onChange={e => dispatch({ type: 'SET_FIELD', field: 'apiKey', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-card dark:text-white font-mono" placeholder="sk-..." /></div>
+          {selectedProvider === 'custom' && (<div className="space-y-4"><label htmlFor="endpointUrl" className="block text-sm font-medium">Endpoint URL</label><input id="endpointUrl" value={endpointUrl} onChange={e => dispatch({ type: 'SET_FIELD', field: 'endpointUrl', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-card dark:text-white" placeholder="https://..." /></div>)}
+          <div className="flex justify-between pt-6 border-t dark:border-border mt-6"><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 1 })} className="text-muted-foreground hover:text-foreground dark:hover:text-cream/85 font-medium">Back</button><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 3 })} disabled={!externalModelName || !apiKey || (selectedProvider === 'custom' && (!customProviderName || !endpointUrl))} className="px-6 py-2 bg-ember-600 text-white rounded-md hover:bg-ember-700 disabled:opacity-50 transition-colors font-medium">Continue</button></div>
         </div>
       )}
 
       {step === 3 && (
         <div className="max-w-xl mx-auto space-y-6">
-          <div className="p-6 rounded-xl border dark:border-zinc-800 bg-slate-50/50 dark:bg-zinc-900/50 space-y-4">
-            <div className="space-y-2"><label htmlFor="externalInstanceName" className="text-sm font-medium">Name your Deployment</label><input id="externalInstanceName" value={instanceName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'instanceName', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-white dark:bg-zinc-900 dark:text-white border-slate-200 dark:border-zinc-700" placeholder="My External Model" /></div>
-            <div className="pt-4 border-t dark:border-zinc-800 space-y-2 text-sm"><div className="flex justify-between"><span className="text-slate-500">Type</span> <span className="font-medium capitalize">{externalModelType}</span></div><div className="flex justify-between"><span className="text-slate-500">Provider</span> <span className="font-medium capitalize">{selectedProvider}</span></div><div className="flex justify-between"><span className="text-slate-500">Model</span> <span className="font-medium">{externalModelName}</span></div></div>
+          <div className="p-6 rounded-xl border dark:border-border bg-muted/50 dark:bg-card/50 space-y-4">
+            <div className="space-y-2"><label htmlFor="externalInstanceName" className="text-sm font-medium">Name your Deployment</label><input id="externalInstanceName" value={instanceName} onChange={e => dispatch({ type: 'SET_FIELD', field: 'instanceName', value: e.target.value })} className="w-full px-4 py-2 border rounded-md bg-card dark:text-white border-border" placeholder="My External Model" /></div>
+            <div className="pt-4 border-t dark:border-border space-y-2 text-sm"><div className="flex justify-between"><span className="text-muted-foreground">Type</span> <span className="font-medium capitalize">{externalModelType}</span></div><div className="flex justify-between"><span className="text-muted-foreground">Provider</span> <span className="font-medium capitalize">{selectedProvider}</span></div><div className="flex justify-between"><span className="text-muted-foreground">Model</span> <span className="font-medium">{externalModelName}</span></div></div>
           </div>
-          <div className="flex gap-4"><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 2 })} className="flex-1 py-2 border rounded-md font-medium text-slate-700 dark:text-zinc-300">Back</button><button type="button" onClick={onLaunch} disabled={isPending} className="flex-[2] py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-70 font-medium shadow-sm flex items-center justify-center gap-2">{isPending ? "Deploying..." : "Launch Deployment"}</button></div>
+          <div className="flex gap-4"><button type="button" onClick={() => dispatch({ type: 'SET_STEP', payload: 2 })} className="flex-1 py-2 border rounded-md font-medium text-fg-secondary dark:text-cream/70">Back</button><button type="button" onClick={onLaunch} disabled={isPending} className="flex-[2] py-2 bg-ember-600 text-white rounded-md hover:bg-ember-700 disabled:opacity-70 font-medium shadow-sm flex items-center justify-center gap-2">{isPending ? "Deploying..." : "Launch Deployment"}</button></div>
         </div>
       )}
     </>

--- a/apps/dashboard/src/pages/Overview.tsx
+++ b/apps/dashboard/src/pages/Overview.tsx
@@ -94,9 +94,9 @@ function getStatToneConfig(tone: StatTone) {
   switch (tone) {
     case "positive":
       return {
-        iconWrap: "bg-emerald-500/12",
-        iconColor: "text-emerald-600 dark:text-emerald-400",
-        statusColor: "text-emerald-700 dark:text-emerald-400",
+        iconWrap: "bg-ember-500/12",
+        iconColor: "text-ember-600 dark:text-ember-400",
+        statusColor: "text-ember-700 dark:text-ember-400",
         statusIcon: CheckCircle2,
       };
     case "warning":
@@ -115,16 +115,16 @@ function getStatToneConfig(tone: StatTone) {
       };
     case "locked":
       return {
-        iconWrap: "bg-slate-500/12",
-        iconColor: "text-slate-600 dark:text-slate-300",
-        statusColor: "text-slate-600 dark:text-slate-300",
+        iconWrap: "bg-muted-foreground/10",
+        iconColor: "text-muted-foreground",
+        statusColor: "text-muted-foreground",
         statusIcon: Lock,
       };
     case "neutral":
     default:
       return {
-        iconWrap: "bg-slate-500/10",
-        iconColor: "text-slate-600 dark:text-slate-300",
+        iconWrap: "bg-muted-foreground/10",
+        iconColor: "text-muted-foreground",
         statusColor: "text-muted-foreground",
         statusIcon: Circle,
       };
@@ -157,8 +157,8 @@ function QuickAction({
   description,
   href,
   icon: Icon,
-  colorClass = "text-emerald-600 dark:text-emerald-400",
-  bgClass = "bg-emerald-500/10",
+  colorClass = "text-ember-600 dark:text-ember-400",
+  bgClass = "bg-ember-500/10",
 }: QuickActionProps) {
   return (
     <Link
@@ -409,8 +409,8 @@ export default function Overview() {
                 description="Launch an inference or embedding workload."
                 href="/dashboard/deployments/new"
                 icon={Rocket}
-                colorClass="text-emerald-600 dark:text-emerald-400"
-                bgClass="bg-emerald-500/10"
+                colorClass="text-ember-600 dark:text-ember-400"
+                bgClass="bg-ember-500/10"
               />
               <QuickAction
                 title="Add Compute Pool"
@@ -486,7 +486,7 @@ export default function Overview() {
                       to={`/dashboard/deployments/${job.deployment_id}`}
                       className={cn(
                         "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                        tone === "positive" && "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+                        tone === "positive" && "bg-ember-500/10 text-ember-700 dark:text-ember-400",
                         tone === "warning" && "bg-amber-500/10 text-amber-700 dark:text-amber-400",
                         tone === "danger" && "bg-red-500/10 text-red-700 dark:text-red-400",
                         tone === "neutral" && "bg-muted text-muted-foreground",
@@ -539,7 +539,7 @@ export default function Overview() {
                     className={cn(
                       "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold",
                       isPoolHealthy(pool)
-                        ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                        ? "bg-ember-500/10 text-ember-700 dark:text-ember-400"
                         : ["terminated", "terminating"].includes((pool.lifecycle_state || "").toLowerCase())
                           ? "bg-red-500/10 text-red-700 dark:text-red-400"
                           : "bg-muted text-muted-foreground"
@@ -612,7 +612,7 @@ export default function Overview() {
                           className={cn(
                             "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold",
                             isSuccess
-                              ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                              ? "bg-ember-500/10 text-ember-700 dark:text-ember-400"
                               : "bg-red-500/10 text-red-700 dark:text-red-400"
                           )}
                         >

--- a/apps/dashboard/src/pages/Sandbox.tsx
+++ b/apps/dashboard/src/pages/Sandbox.tsx
@@ -204,7 +204,7 @@ export default function Sandbox() {
                     const dep = deployments.find((d) => d.id === e.target.value);
                     if (dep) handleDeploymentChange(dep);
                   }}
-                  className="w-full px-3 py-2 rounded-lg border bg-background text-sm focus:ring-1 focus:ring-emerald-500 outline-none"
+                  className="w-full px-3 py-2 rounded-lg border bg-background text-sm focus:ring-1 focus:ring-ember-500 outline-none"
                 >
                   {deployments.map((dep) => (
                     <option key={dep.id} value={dep.id}>
@@ -340,10 +340,10 @@ function ChatParamsPanel() {
             onClick={() => updateParam("stream", !params.stream)}
             className={cn(
               "w-10 h-5 rounded-full transition-colors relative",
-              params.stream ? "bg-emerald-500" : "bg-muted"
+              params.stream ? "bg-ember-500" : "bg-muted"
             )}
           >
-            <span className={cn("absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform", params.stream ? "left-5" : "left-0.5")} />
+            <span className={cn("absolute top-0.5 w-4 h-4 rounded-full bg-card transition-transform", params.stream ? "left-5" : "left-0.5")} />
           </button>
         </div>
       </div>
@@ -532,7 +532,7 @@ function InferencePanel({ deployment }: { deployment: Deployment }) {
             onClick={() => setActiveTab("chat")}
             className={cn(
               "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === "chat" ? "border-emerald-500 text-emerald-600" : "border-transparent text-muted-foreground hover:text-foreground"
+              activeTab === "chat" ? "border-ember-500 text-ember-600" : "border-transparent text-muted-foreground hover:text-foreground"
             )}
           >
             <MessageSquare className="w-4 h-4 inline-block mr-2" />
@@ -542,7 +542,7 @@ function InferencePanel({ deployment }: { deployment: Deployment }) {
             onClick={() => setActiveTab("completions")}
             className={cn(
               "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === "completions" ? "border-emerald-500 text-emerald-600" : "border-transparent text-muted-foreground hover:text-foreground"
+              activeTab === "completions" ? "border-ember-500 text-ember-600" : "border-transparent text-muted-foreground hover:text-foreground"
             )}
           >
             <Bot className="w-4 h-4 inline-block mr-2" />
@@ -577,7 +577,7 @@ function ImagePanel({ deployment }: { deployment: Deployment }) {
             onClick={() => setActiveTab("generate")}
             className={cn(
               "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === "generate" ? "border-emerald-500 text-emerald-600" : "border-transparent text-muted-foreground hover:text-foreground"
+              activeTab === "generate" ? "border-ember-500 text-ember-600" : "border-transparent text-muted-foreground hover:text-foreground"
             )}
           >
             <Sparkles className="w-4 h-4 inline-block mr-2" />
@@ -587,7 +587,7 @@ function ImagePanel({ deployment }: { deployment: Deployment }) {
             onClick={() => setActiveTab("edit")}
             className={cn(
               "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === "edit" ? "border-emerald-500 text-emerald-600" : "border-transparent text-muted-foreground hover:text-foreground"
+              activeTab === "edit" ? "border-ember-500 text-ember-600" : "border-transparent text-muted-foreground hover:text-foreground"
             )}
           >
             <Wand2 className="w-4 h-4 inline-block mr-2" />
@@ -597,7 +597,7 @@ function ImagePanel({ deployment }: { deployment: Deployment }) {
             onClick={() => setActiveTab("variations")}
             className={cn(
               "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === "variations" ? "border-emerald-500 text-emerald-600" : "border-transparent text-muted-foreground hover:text-foreground"
+              activeTab === "variations" ? "border-ember-500 text-ember-600" : "border-transparent text-muted-foreground hover:text-foreground"
             )}
           >
             <Layers className="w-4 h-4 inline-block mr-2" />
@@ -625,7 +625,7 @@ function VideoPanel({ deployment }: { deployment: Deployment }) {
             onClick={() => setActiveTab("generate")}
             className={cn(
               "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === "generate" ? "border-emerald-500 text-emerald-600" : "border-transparent text-muted-foreground hover:text-foreground"
+              activeTab === "generate" ? "border-ember-500 text-ember-600" : "border-transparent text-muted-foreground hover:text-foreground"
             )}
           >
             <Sparkles className="w-4 h-4 inline-block mr-2" />
@@ -635,7 +635,7 @@ function VideoPanel({ deployment }: { deployment: Deployment }) {
             onClick={() => setActiveTab("edit")}
             className={cn(
               "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === "edit" ? "border-emerald-500 text-emerald-600" : "border-transparent text-muted-foreground hover:text-foreground"
+              activeTab === "edit" ? "border-ember-500 text-ember-600" : "border-transparent text-muted-foreground hover:text-foreground"
             )}
           >
             <Wand2 className="w-4 h-4 inline-block mr-2" />
@@ -645,7 +645,7 @@ function VideoPanel({ deployment }: { deployment: Deployment }) {
             onClick={() => setActiveTab("extend")}
             className={cn(
               "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === "extend" ? "border-emerald-500 text-emerald-600" : "border-transparent text-muted-foreground hover:text-foreground"
+              activeTab === "extend" ? "border-ember-500 text-ember-600" : "border-transparent text-muted-foreground hover:text-foreground"
             )}
           >
             <RefreshCw className="w-4 h-4 inline-block mr-2" />
@@ -781,13 +781,13 @@ function ChatInterface({ deployment }: { deployment: Deployment }) {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Type your message..."
-            className="flex-1 px-4 py-2 rounded-lg border bg-background focus:ring-1 focus:ring-emerald-500 outline-none"
+            className="flex-1 px-4 py-2 rounded-lg border bg-background focus:ring-1 focus:ring-ember-500 outline-none"
             disabled={isLoading}
           />
           <button
             type="submit"
             disabled={!input.trim() || isLoading}
-            className="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50 transition-colors"
+            className="px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50 transition-colors"
           >
             {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
           </button>
@@ -843,7 +843,7 @@ function CompletionsInterface({ deployment }: { deployment: Deployment }) {
         <button
           onClick={handleSubmit}
           disabled={!prompt.trim() || isLoading}
-          className="w-full px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50 transition-colors"
+          className="w-full px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50 transition-colors"
         >
           {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Generate"}
         </button>
@@ -866,14 +866,14 @@ function ChatMessageItem({ message }: { message: ChatMessage }) {
   };
   return (
     <div className={cn("flex gap-3", message.role === "user" ? "flex-row-reverse" : "flex-row")}>
-      <div className={cn("w-8 h-8 rounded-full flex items-center justify-center shrink-0", message.role === "user" ? "bg-emerald-100 dark:bg-emerald-900/30" : "bg-slate-100 dark:bg-slate-800")}>
-        {message.role === "user" ? <User className="w-4 h-4 text-emerald-600" /> : <Bot className="w-4 h-4 text-slate-600" />}
+      <div className={cn("w-8 h-8 rounded-full flex items-center justify-center shrink-0", message.role === "user" ? "bg-ember-100 dark:bg-ember-900/30" : "bg-muted dark:bg-card")}>
+        {message.role === "user" ? <User className="w-4 h-4 text-ember-600" /> : <Bot className="w-4 h-4 text-muted-foreground" />}
       </div>
-      <div className={cn("flex-1 max-w-[85%] rounded-lg p-3", message.role === "user" ? "bg-emerald-500/10 border border-emerald-500/20" : "bg-muted border border-border")}>
+      <div className={cn("flex-1 max-w-[85%] rounded-lg p-3", message.role === "user" ? "bg-ember-500/10 border border-ember-500/20" : "bg-muted border border-border")}>
         <p className="text-sm whitespace-pre-wrap">{message.content}</p>
         <div className="flex justify-end mt-2">
           <button onClick={handleCopy} className="p-1 hover:bg-accent rounded">
-            {copied ? <Check className="w-3 h-3 text-emerald-500" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
+            {copied ? <Check className="w-3 h-3 text-ember-500" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
           </button>
         </div>
       </div>
@@ -923,7 +923,7 @@ function EmbeddingInterface({ deployment }: { deployment: Deployment }) {
       <div className="p-4 border-b space-y-3">
         <textarea value={input} onChange={(e) => setInput(e.target.value)} placeholder="Enter text to embed..." className="w-full h-24 px-3 py-2 rounded-lg border bg-background text-sm resize-none" disabled={isLoading} />
         <div className="flex justify-between items-center">
-          <button onClick={handleGenerate} disabled={!input.trim() || isLoading} className="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50">
+          <button onClick={handleGenerate} disabled={!input.trim() || isLoading} className="px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50">
             {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Compute"} Embeddings
           </button>
           {embeddings && <span className="text-xs text-muted-foreground">Dimensions: {embeddings.length}</span>}
@@ -992,7 +992,7 @@ function ImageGenerationInterface({ deployment }: { deployment: Deployment }) {
       <div className="p-4 border-b space-y-3">
         <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Describe the image you want to generate..." className="w-full h-20 px-3 py-2 rounded-lg border bg-background text-sm resize-none" disabled={isLoading} />
         <textarea value={negativePrompt} onChange={(e) => setNegativePrompt(e.target.value)} placeholder="Negative prompt (what to avoid)..." className="w-full h-16 px-3 py-2 rounded-lg border bg-background text-sm resize-none" disabled={isLoading} />
-        <button onClick={handleGenerate} disabled={!prompt.trim() || isLoading} className="w-full px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50 flex items-center justify-center gap-2">
+        <button onClick={handleGenerate} disabled={!prompt.trim() || isLoading} className="w-full px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50 flex items-center justify-center gap-2">
           {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />} Generate
         </button>
       </div>
@@ -1049,7 +1049,7 @@ function ImageEditInterface({ deployment }: { deployment: Deployment }) {
           <label htmlFor="img-edit" className="cursor-pointer"><Upload className="w-8 h-8 mx-auto mb-2 text-muted-foreground" /><p className="text-xs text-muted-foreground">{image ? "Image loaded" : "Upload image"}</p></label>
         </div>
         <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Describe the edit..." className="w-full h-16 px-3 py-2 rounded-lg border bg-background text-sm resize-none" disabled={isLoading} />
-        <button onClick={handleGenerate} disabled={!image || !prompt.trim() || isLoading} className="w-full px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50">
+        <button onClick={handleGenerate} disabled={!image || !prompt.trim() || isLoading} className="w-full px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50">
           {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Edit Image"}
         </button>
       </div>
@@ -1099,7 +1099,7 @@ function ImageVariationInterface({ deployment }: { deployment: Deployment }) {
           <input type="file" accept="image/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) { const r = new FileReader(); r.onload = () => setImage((r.result as string).split(",")[1]); r.readAsDataURL(f); } }} className="hidden" id="img-var" />
           <label htmlFor="img-var" className="cursor-pointer"><Upload className="w-8 h-8 mx-auto mb-2 text-muted-foreground" /><p className="text-xs text-muted-foreground">{image ? "Image loaded" : "Upload image"}</p></label>
         </div>
-        <button onClick={handleGenerate} disabled={!image || isLoading} className="w-full px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50">
+        <button onClick={handleGenerate} disabled={!image || isLoading} className="w-full px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50">
           {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Create Variation"}
         </button>
       </div>
@@ -1196,7 +1196,7 @@ function VideoGenerationInterface({ deployment }: { deployment: Deployment }) {
       <div className="p-4 border-b space-y-3">
         <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Describe the video you want to generate..." className="w-full h-20 px-3 py-2 rounded-lg border bg-background text-sm resize-none" disabled={isLoading} />
         <input value={imageRef} onChange={(e) => setImageRef(e.target.value)} placeholder="Image URL for image-to-video (optional)..." className="w-full px-3 py-2 rounded-lg border bg-background text-sm" disabled={isLoading} />
-        <button onClick={handleGenerate} disabled={!prompt.trim() || isLoading} className="w-full px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50">
+        <button onClick={handleGenerate} disabled={!prompt.trim() || isLoading} className="w-full px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50">
           {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Generate Video"}
         </button>
         {progress && <p className="text-xs text-center text-muted-foreground">{progress}</p>}
@@ -1293,7 +1293,7 @@ function VideoEditInterface({ deployment }: { deployment: Deployment }) {
           <label htmlFor="vid-edit" className="cursor-pointer"><Upload className="w-8 h-8 mx-auto mb-2 text-muted-foreground" /><p className="text-xs text-muted-foreground">{video ? "Video loaded" : "Upload video"}</p></label>
         </div>
         <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Describe the edit (optional)..." className="w-full h-16 px-3 py-2 rounded-lg border bg-background text-sm resize-none" disabled={isLoading} />
-        <button onClick={handleGenerate} disabled={!video || isLoading} className="w-full px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50">
+        <button onClick={handleGenerate} disabled={!video || isLoading} className="w-full px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50">
           {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Edit Video"}
         </button>
         {progress && <p className="text-xs text-center text-muted-foreground">{progress}</p>}
@@ -1390,7 +1390,7 @@ function VideoExtensionInterface({ deployment }: { deployment: Deployment }) {
           <label htmlFor="vid-ext" className="cursor-pointer"><Upload className="w-8 h-8 mx-auto mb-2 text-muted-foreground" /><p className="text-xs text-muted-foreground">{video ? "Video loaded" : "Upload video to extend"}</p></label>
         </div>
         <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Describe how to extend (optional)..." className="w-full h-16 px-3 py-2 rounded-lg border bg-background text-sm resize-none" disabled={isLoading} />
-        <button onClick={handleGenerate} disabled={!video || isLoading} className="w-full px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50">
+        <button onClick={handleGenerate} disabled={!video || isLoading} className="w-full px-4 py-2 bg-ember-600 text-white rounded-lg hover:bg-ember-700 disabled:opacity-50">
           {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Extend Video"}
         </button>
         {progress && <p className="text-xs text-center text-muted-foreground">{progress}</p>}

--- a/apps/dashboard/src/pages/Settings/AuditLogs.tsx
+++ b/apps/dashboard/src/pages/Settings/AuditLogs.tsx
@@ -205,7 +205,7 @@ export default function AuditLogs() {
                                     {log.details && (
                                         <div>
                                             <div className="text-xs text-muted-foreground mb-2 font-medium uppercase tracking-tight">Event Details</div>
-                                            <pre className="p-3 bg-slate-950 text-slate-300 rounded-md text-[11px] overflow-x-auto font-mono whitespace-pre-wrap break-all max-h-96 overflow-y-auto">
+                                            <pre className="p-3 bg-background text-cream/70 rounded-md text-[11px] overflow-x-auto font-mono whitespace-pre-wrap break-all max-h-96 overflow-y-auto">
                                                 {JSON.stringify(log.details, null, 2)}
                                             </pre>
                                         </div>

--- a/apps/dashboard/src/pages/Settings/Providers/ProviderCategories.tsx
+++ b/apps/dashboard/src/pages/Settings/Providers/ProviderCategories.tsx
@@ -8,8 +8,8 @@ export default function ProviderCategories() {
             title: "Infrastructure & Compute",
             description: "Manage Cloud (AWS, GCP) and DePIN (Nosana, Akash) credentials",
             icon: Cloud,
-            color: "text-emerald-500",
-            bg: "bg-emerald-50 dark:bg-emerald-900/20",
+            color: "text-ember-500",
+            bg: "bg-ember-50 dark:bg-ember-900/20",
         },
         {
             id: "vector-db",

--- a/apps/dashboard/src/pages/Settings/Providers/ProviderConfig.tsx
+++ b/apps/dashboard/src/pages/Settings/Providers/ProviderConfig.tsx
@@ -603,7 +603,7 @@ function NosanaFields({
                     <Key className="w-4 h-4" />
                     Wallet Configuration
                 </h3>
-                <div className="p-3 bg-emerald-50 border border-emerald-100 rounded-lg text-xs text-emerald-700">
+                <div className="p-3 bg-ember-50 border border-ember-100 rounded-lg text-xs text-ember-700">
                     Nosana supports both Wallet-based (on-chain) and API-based (credit) deployments. Enter a Private Key for on-chain deployments.
                 </div>
                 <div className="space-y-2">
@@ -722,7 +722,7 @@ function AkashFields({ config, updateField, handleAddKey }: { config: ProvidersC
                     <Key className="w-4 h-4" />
                     Legacy Mnemonic
                 </h3>
-                <div className="p-3 bg-emerald-50 border border-emerald-100 rounded-lg text-xs text-emerald-700">
+                <div className="p-3 bg-ember-50 border border-ember-100 rounded-lg text-xs text-ember-700">
                     Akash uses a mnemonic phrase for wallet authentication. You can use the legacy field below or set up multiple wallets using the credential management system.
                 </div>
                 <div className="space-y-2">

--- a/apps/dashboard/src/pages/Settings/Roles.tsx
+++ b/apps/dashboard/src/pages/Settings/Roles.tsx
@@ -229,7 +229,7 @@ export default function Roles() {
               <tr key={role.name} className="hover:bg-muted/50 dark:hover:bg-muted/10 transition-colors">
                 <td className="px-6 py-4 font-medium">
                   <div className="inline-flex items-center gap-2">
-                    <ShieldCheck className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
+                    <ShieldCheck className="w-4 h-4 text-ember-600 dark:text-ember-400" />
                     <span>{role.name}</span>
                   </div>
                 </td>
@@ -239,7 +239,7 @@ export default function Roles() {
                     {role.permissions.map((permission) => (
                       <span
                         key={permission}
-                        className="px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300 text-xs border border-emerald-200 dark:border-emerald-800"
+                        className="px-2 py-0.5 rounded-full bg-ember-100 text-ember-700 dark:bg-ember-900/30 dark:text-ember-300 text-xs border border-ember-200 dark:border-ember-800"
                       >
                         {permission}
                       </span>

--- a/apps/dashboard/src/pages/Settings/Security.tsx
+++ b/apps/dashboard/src/pages/Settings/Security.tsx
@@ -142,7 +142,7 @@ export default function Security() {
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p className="text-sm font-medium inline-flex items-center gap-2 mb-1">
-              {userInfo?.totp_enabled ? <ShieldCheck className="w-4 h-4 text-emerald-500" /> : <KeyRound className="w-4 h-4 text-amber-500" />}
+              {userInfo?.totp_enabled ? <ShieldCheck className="w-4 h-4 text-ember-500" /> : <KeyRound className="w-4 h-4 text-amber-500" />}
               Status: {userInfo?.totp_enabled ? "Enabled" : "Disabled"}
             </p>
             <p className="text-sm text-muted-foreground max-w-xl">
@@ -177,7 +177,7 @@ export default function Security() {
 
             {setupData && (
               <div className="flex flex-col items-center gap-4 py-2">
-                <div className="bg-white p-2 rounded-lg border">
+                <div className="bg-card p-2 rounded-lg border">
                   {setupData.qr_code.startsWith("data:image/") ? (
                     <img src={setupData.qr_code} alt="2FA QR Code" className="w-48 h-48" />
                   ) : (
@@ -204,7 +204,7 @@ export default function Security() {
             )}
 
             <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-              <button type="button" onClick={closeModal} className="mt-2 sm:mt-0 px-4 py-2 border rounded-md hover:bg-slate-100 transition-colors">
+              <button type="button" onClick={closeModal} className="mt-2 sm:mt-0 px-4 py-2 border rounded-md hover:bg-muted transition-colors">
                 Cancel
               </button>
               <button

--- a/apps/dashboard/src/pages/Settings/Users.tsx
+++ b/apps/dashboard/src/pages/Settings/Users.tsx
@@ -220,7 +220,7 @@ export default function Users() {
             <button
               type="button"
               onClick={() => dispatch({ type: 'SET_SHOW_MODAL', payload: true })}
-              className="inline-flex items-center gap-2 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+              className="inline-flex items-center gap-2 rounded-md bg-ember-600 px-4 py-2 text-sm font-medium text-white hover:bg-ember-700"
             >
               <UserPlus className="w-4 h-4" />
               Invite Member
@@ -232,7 +232,7 @@ export default function Users() {
       <section className="space-y-4">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-medium inline-flex items-center gap-2">
-            <UsersIcon className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
+            <UsersIcon className="w-4 h-4 text-ember-600 dark:text-ember-400" />
             Active Users
           </h2>
           <span className="text-xs text-muted-foreground">{totalUsers} total</span>

--- a/apps/dashboard/src/pages/Status.tsx
+++ b/apps/dashboard/src/pages/Status.tsx
@@ -308,7 +308,7 @@ export default function Status() {
             {/* Service Endpoints Reference */}
             <div className="bg-card rounded-xl border p-6">
                 <h3 className="font-semibold mb-4 flex items-center gap-2">
-                    <Database className="w-4 h-4 text-emerald-500" />
+                    <Database className="w-4 h-4 text-ember-500" />
                     Service Endpoints
                 </h3>
                 <div className="grid gap-2 text-sm font-mono">

--- a/apps/dashboard/src/services/auditService.ts
+++ b/apps/dashboard/src/services/auditService.ts
@@ -45,12 +45,12 @@ export const AUDIT_CATEGORIES = [
 export const CATEGORY_COLORS: Record<string, string> = {
     auth: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
     security: "bg-red-500/10 text-red-600 dark:text-red-400",
-    deployment: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    deployment: "bg-ember-500/10 text-ember-600 dark:text-ember-400",
     api_key: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
     organization: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
     user_management: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400",
     credential: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
-    configuration: "bg-slate-500/10 text-slate-600 dark:text-slate-400",
+    configuration: "bg-muted-foreground/10 text-muted-foreground",
     knowledge_base: "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400",
 };
 

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -22,6 +22,29 @@ export default {
                 ring: "hsl(var(--ring))",
                 background: "hsl(var(--background))",
                 foreground: "hsl(var(--foreground))",
+                // Editorial palette (matches InferiaAI/new-website)
+                cream: {
+                    DEFAULT: "#FAF7F2",
+                    deep: "#F2EDE4",
+                },
+                ember: {
+                    50:  "#FDF5F0",
+                    100: "#F4E8E0",
+                    200: "#ECC9B2",
+                    300: "#E3AA85",
+                    400: "#D98057",
+                    500: "#C94D2A",
+                    600: "#B84525",
+                    700: "#A33D20",
+                    800: "#82321A",
+                    900: "#5F2616",
+                    950: "#3A1710",
+                },
+                fg: {
+                    DEFAULT: "#0C0C0C",
+                    secondary: "#3D3D3D",
+                    muted: "#8A8A8A",
+                },
                 primary: {
                     DEFAULT: "hsl(var(--primary))",
                     foreground: "hsl(var(--primary-foreground))",
@@ -58,6 +81,7 @@ export default {
             },
             fontFamily: {
                 sans: ["Inter", "sans-serif"],
+                serif: ["'DM Serif Display'", "Georgia", "serif"],
                 mono: ["JetBrains Mono", "monospace"],
             },
         },


### PR DESCRIPTION
## Summary
Unify the dashboard's visual identity with the main marketing site [`InferiaAI/new-website`](https://github.com/InferiaAI/new-website) by replacing the Supabase-green palette with the warm cream + ember editorial palette.

## Palette (sourced from `new-website/src/styles/global.css`)

| Role | Light | Dark |
|---|---|---|
| Background (cream) | `#FAF7F2` | `#0F0F0F` |
| Surface / card (cream-deep) | `#F2EDE4` | `#1A1A1A` |
| Primary (ember) | `#C94D2A` | `#E06640` |
| Primary-hover | `#A33D20` | `#C94D2A` |
| Foreground | `#0C0C0C` | `#E8E4DE` |
| Border | `#E6E1D8` | `rgba(255,255,255,0.10)` |
| Muted text | `#8A8A8A` | `#666666` |

## Changes

**Tokens & theme infra**
- `src/index.css` — rewrite CSS variables for `:root` and `.dark`, add DM Serif Display font + `::selection` + `:focus-visible` styling
- `tailwind.config.js` — add `cream` / `cream.deep` / `ember-{50..950}` / `fg` / `fg.secondary` / `fg.muted` color tokens and `font-serif: DM Serif Display`

**Codebase sweeps**
- Global `emerald-*` → `ember-*` across 26 files (205 references, Supabase-green → ember)
- Hardcoded slate / zinc / gray neutrals → semantic shadcn tokens in 38 files (~347 references):
  - `bg-white dark:bg-zinc-900` → `bg-card`
  - `bg-slate-{50,100,200}` → `bg-muted`
  - `text-slate-900 dark:text-white` → `text-foreground`
  - `text-slate-{500,600,700}` → `text-muted-foreground` / `text-fg-secondary`
  - `border-slate-*` → `border-border`
  - `hover:bg-slate-100 dark:hover:bg-slate-800` → `hover:bg-muted`
  - …and siblings for `zinc`, `gray`, `ring-*`, `focus:ring-*`, `placeholder:text-*`, `divide-*`

**Auth / dark panels retuned**
- `Login.tsx`, `AcceptInvite.tsx`, `Setup2FA.tsx` — aside panels now use `from-[#0C0C0C] via-[#0C0C0C] to-[#161616]` (website's dark block treatment) with ember accents and `font-serif` headlines, replacing the previous slate-900 gradient + slate-100 text.

**Sidebar**
- `DashboardLayout.tsx` — nav items use `text-fg-secondary` / `text-fg-muted` instead of `text-slate-500/600` so they track the warm palette.

## Intentionally preserved
- `components/deployment/TerminalLogs.tsx` — intentional black/zinc terminal aesthetic
- Semantic status colors (`green-*` online/success, `red-*`/`rose-*` error, `amber-*`/`yellow-*` warning, `blue-*` info) — untouched across the codebase

## Verification
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm run build` → success (1.38 MB JS / 376 KB gzip, 72.94 KB CSS / 12.16 KB gzip)
- [x] `grep -rn 'bg-slate-\|bg-zinc-\|bg-gray-\|text-slate-\|text-zinc-\|border-slate-\|border-zinc-' src | grep -v TerminalLogs.tsx` → 0 lines
- [x] `grep -rn 'emerald-' src` → 0 lines

## Test plan
- [ ] Login page — aside panel reads as dark block on cream body, ember accents visible, DM Serif Display headline renders
- [ ] Dashboard sidebar — active nav item shows ember highlight + left rail
- [ ] Deployments / Sandbox / Settings pages — surfaces render on cream background, cards are cream-deep, primary CTAs are ember
- [ ] Dark mode — toggle, verify all surfaces flip to `#0F0F0F`/`#1A1A1A` with ember `#E06640` primary
- [ ] Terminal logs — still render with the intentional dark-terminal look
- [ ] Status indicators (deployment online/offline, error states) — still green/red/amber as expected