### PR TITLE
Enforce append-only behaviour for audit logs

### DIFF
--- a/package/src/inferia/services/api_gateway/db/models/audit_log.py
+++ b/package/src/inferia/services/api_gateway/db/models/audit_log.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, JSON, ForeignKey
+from sqlalchemy import Column, String, DateTime, JSON, ForeignKey, event
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 import uuid
@@ -6,6 +6,10 @@ from ..database import Base
 
 def utcnow_naive():
     return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class ImmutableAuditLogError(ValueError):
+    """Raised when application code attempts to mutate an existing audit log."""
 
 class AuditLog(Base):
     __tablename__ = "audit_logs"
@@ -25,3 +29,19 @@ class AuditLog(Base):
 
     # Relationships
     user = relationship("User", backref="audit_logs")
+
+
+def _reject_audit_log_mutation(operation: str) -> None:
+    raise ImmutableAuditLogError(
+        f"Audit logs are immutable and cannot be {operation}."
+    )
+
+
+@event.listens_for(AuditLog, "before_update")
+def _prevent_audit_log_update(mapper, connection, target):
+    _reject_audit_log_mutation("updated")
+
+
+@event.listens_for(AuditLog, "before_delete")
+def _prevent_audit_log_delete(mapper, connection, target):
+    _reject_audit_log_mutation("deleted")

--- a/package/src/inferia/services/api_gateway/tests/test_audit_immutability.py
+++ b/package/src/inferia/services/api_gateway/tests/test_audit_immutability.py
@@ -1,0 +1,69 @@
+"""Tests for append-only audit log behavior."""
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from inferia.services.api_gateway.db.database import Base
+from inferia.services.api_gateway.db.models.audit_log import AuditLog
+from inferia.services.api_gateway.db.models.user import User
+
+
+@pytest.fixture
+def audit_session():
+    """Provide a minimal in-memory session for audit log model tests."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__, AuditLog.__table__])
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    session = session_factory()
+
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine, tables=[AuditLog.__table__, User.__table__])
+        engine.dispose()
+
+
+def make_audit_log() -> AuditLog:
+    return AuditLog(
+        action="user.login",
+        resource_type="user",
+        resource_id="user-123",
+        details={"source": "test"},
+        status="success",
+        category="auth",
+    )
+
+
+def test_audit_log_insert_remains_allowed(audit_session):
+    audit_log = make_audit_log()
+
+    audit_session.add(audit_log)
+    audit_session.commit()
+
+    stored_logs = audit_session.execute(select(AuditLog)).scalars().all()
+    assert len(stored_logs) == 1
+    assert stored_logs[0].action == "user.login"
+
+
+def test_audit_log_update_is_rejected(audit_session):
+    audit_log = make_audit_log()
+    audit_session.add(audit_log)
+    audit_session.commit()
+
+    audit_log.action = "user.logout"
+
+    with pytest.raises(ValueError, match="immutable"):
+        audit_session.commit()
+
+
+def test_audit_log_delete_is_rejected(audit_session):
+    audit_log = make_audit_log()
+    audit_session.add(audit_log)
+    audit_session.commit()
+
+    audit_session.delete(audit_log)
+
+    with pytest.raises(ValueError, match="immutable"):
+        audit_session.commit()


### PR DESCRIPTION
## Summary

Enforce append-only behavior for API gateway audit logs

## What Changed

- added model-level immutability guards on `AuditLog` using SQLAlchemy `before_update` and `before_delete` listeners
- added focused tests covering:
  - insert remains allowed
  - update is rejected
  - delete is rejected

## Rationale

The repo already treats audit logs as immutable in docs and product behavior, but the mapped model still allowed ordinary ORM updates and deletes. This change closes that gap at the runtime model boundary with minimal scope and low regression risk

## Test Plan

- added and ran:
  - `PYTHONPATH=InferiaLLM/package/src .venv312/bin/python -m pytest --noconftest package/src/inferia/services/api_gateway/tests/test_audit_immutability.py`

## Retention / Cleanup Notes

This change does not alter the explicit SQL retention cleanup function for old audit logs. Normal application ORM code is now append-only, while the existing controlled cleanup path remains intact.