### PR TITLE
feat(#243): migrate inference, guardrail, data, orchestration to UnifiedBaseSettings

### DIFF
--- a/inferia.yaml.example
+++ b/inferia.yaml.example
@@ -82,11 +82,91 @@ services:
       orchestration: http://localhost:8080
       inference:     http://localhost:8001
 
-  # Phase 2+ — full schemas land in follow-up PRs.
-  inference:     { enabled: true }
-  guardrail:     { enabled: true }
-  data:          { enabled: true }
-  orchestration: { enabled: true }
+  inference:
+    enabled: true
+    host: 0.0.0.0
+    port: 8001
+    workers: 1
+    reload: false
+    api_gateway_url: ${API_GATEWAY_URL:-http://localhost:8000}
+    external_proxy_url: ${EXTERNAL_PROXY_URL:-}
+    request_timeout: 30
+    verify_ssl: true
+    upstream:
+      http_timeout_seconds: 60.0
+      http_connect_timeout_seconds: 10.0
+      video_timeout_seconds: 300.0
+      http_max_connections: 500
+      http_max_keepalive_connections: 100
+      global_max_in_flight: 0
+      per_deployment_max_in_flight: 100
+      slot_acquire_timeout_seconds: 20.0
+      allowed_internal_hosts: ""
+      max_response_bytes: 52428800
+    gateway_client:
+      http_max_connections: 1000
+      http_max_keepalive_connections: 100
+    context_cache:
+      ttl: 30
+      maxsize: 1000
+    quota_cache:
+      ttl_seconds: 1.0
+      maxsize: 10000
+
+  guardrail:
+    enabled: true
+    host: 0.0.0.0
+    port: 8002
+    reload: false
+    api_gateway_url: ${API_GATEWAY_URL:-http://localhost:8000}
+    default_engine: llm-guard
+    llama_guard_model_id: meta-llama/llama-guard-4-12b
+    banned_substrings: ""
+    controls:
+      enable_guardrails: true
+      enable_toxicity: false
+      enable_prompt_injection: false
+      enable_secrets: false
+      enable_code_scanning: false
+      enable_sensitive_info: false
+      enable_no_refusal: false
+      enable_bias: false
+      enable_relevance: false
+    thresholds:
+      toxicity_threshold: 0.7
+      prompt_injection_threshold: 0.8
+      bias_threshold: 0.75
+      relevance_threshold: 0.5
+    pii:
+      detection_enabled: true
+      anonymize: true
+      entity_types: []
+      max_scan_time_seconds: 5.0
+
+  data:
+    enabled: true
+    host: 0.0.0.0
+    port: 8003
+    reload: false
+    api_gateway_url: ${API_GATEWAY_URL:-http://localhost:8000}
+    redis_url: ${REDIS_URL:-redis://localhost:6379/0}
+    max_ingest_documents: 500
+    max_document_size_bytes: 1000000
+
+  orchestration:
+    enabled: true
+    host: 0.0.0.0
+    http_port: 8080
+    grpc_port: 50051
+    nosana_sidecar_url: ${NOSANA_SIDECAR_URL:-http://localhost:3000}
+    readiness:
+      default_readiness_timeout: 300
+      default_polling_interval: 20
+      ephemeral_failure_threshold_minutes: 10
+    deployment_logs:
+      elasticsearch_url: ${ELASTICSEARCH_URL:-}
+      deployment_log_buffer_size: 10000
+      deployment_log_flush_interval: 10
 
 # ─── Providers ──────────────────────────────────────────────────────────
 # Phase 1 accepts arbitrary keys here (Phase 2 will tighten).

--- a/package/src/inferia/common/tests/unified_config/test_phase_2_services.py
+++ b/package/src/inferia/common/tests/unified_config/test_phase_2_services.py
@@ -1,0 +1,161 @@
+"""Integration tests: each Phase-2 service Settings loads correctly from
+inferia.yaml.example via INFERIA_CONFIG.
+
+These tests assert that the yaml → YamlConfigSettingsSource → service Settings
+pipeline works end to end for each migrated service. They do NOT test every
+field — just enough representative fields to catch schema mismatches and
+flatten-mapping errors.
+"""
+import os
+from pathlib import Path
+import pytest
+
+REPO_ROOT = Path(__file__).parents[6]  # …/InferiaLLM
+EXAMPLE_YAML = REPO_ROOT / "inferia.yaml.example"
+
+# Secrets long enough to pass the schema validator's >=32-char check.
+_JWT = "dev-jwt-secret-thirty-two-bytes-min"
+_IAK = "dev-internal-api-key-thirty-two-bytes"
+
+
+@pytest.fixture(autouse=True)
+def _yaml_env(monkeypatch, tmp_path):
+    """Point INFERIA_CONFIG at a copy of inferia.yaml.example with secrets interpolated."""
+    from inferia.common.unified_config.loader import _clear_cache
+
+    # Write a version of the example yaml with secrets filled in.
+    content = EXAMPLE_YAML.read_text()
+    yaml_copy = tmp_path / "inferia.yaml"
+    yaml_copy.write_text(content)
+
+    monkeypatch.setenv("INFERIA_CONFIG", str(yaml_copy))
+    monkeypatch.setenv("JWT_SECRET_KEY", _JWT)
+    monkeypatch.setenv("INTERNAL_API_KEY", _IAK)
+    _clear_cache()
+    yield
+    _clear_cache()
+
+
+# ─── inference ───────────────────────────────────────────────────────────────
+
+class TestInferenceSettingsFromYaml:
+    def test_port_read_from_yaml(self):
+        from inferia.services.inference.config import Settings
+        s = Settings(_env_file=None)
+        assert s.port == 8001
+
+    def test_upstream_timeout_read_from_yaml(self):
+        from inferia.services.inference.config import Settings
+        s = Settings(_env_file=None)
+        # upstream.http_timeout_seconds → flattened to upstream_http_timeout_seconds
+        assert s.upstream_http_timeout_seconds == 60.0
+
+    def test_context_cache_ttl_read_from_yaml(self):
+        from inferia.services.inference.config import Settings
+        s = Settings(_env_file=None)
+        assert s.context_cache_ttl == 30
+
+    def test_allowed_origins_coerced_from_list(self, monkeypatch):
+        """security.allowed_origins is a list in yaml; field must be a str."""
+        from inferia.services.inference.config import Settings
+        monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+        s = Settings(_env_file=None)
+        # allowed_origins comes from shared security subtree as a list; must be str
+        assert isinstance(s.allowed_origins, str)
+
+    def test_env_overrides_yaml_port(self, monkeypatch):
+        from inferia.common.unified_config.loader import _clear_cache
+        monkeypatch.setenv("INFERENCE_WORKERS", "4")
+        _clear_cache()
+        from inferia.services.inference.config import Settings
+        s = Settings(_env_file=None)
+        assert s.workers == 4
+
+
+# ─── guardrail ───────────────────────────────────────────────────────────────
+
+class TestGuardrailSettingsFromYaml:
+    def test_port_read_from_yaml(self):
+        from inferia.services.guardrail.config import Settings
+        s = Settings(_env_file=None)
+        assert s.port == 8002
+
+    def test_enable_guardrails_read_from_yaml(self):
+        from inferia.services.guardrail.config import Settings
+        s = Settings(_env_file=None)
+        assert s.enable_guardrails is True
+
+    def test_toxicity_threshold_read_from_yaml(self):
+        from inferia.services.guardrail.config import Settings
+        s = Settings(_env_file=None)
+        assert s.toxicity_threshold == pytest.approx(0.7)
+
+    def test_pii_detection_enabled_from_yaml(self):
+        from inferia.services.guardrail.config import Settings
+        s = Settings(_env_file=None)
+        assert s.pii_detection_enabled is True
+
+    def test_allowed_origins_coerced_from_list(self, monkeypatch):
+        from inferia.services.guardrail.config import Settings
+        monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+        s = Settings(_env_file=None)
+        assert isinstance(s.allowed_origins, str)
+
+
+# ─── data ─────────────────────────────────────────────────────────────────────
+
+class TestDataSettingsFromYaml:
+    def test_port_read_from_yaml(self):
+        from inferia.services.data.config import Settings
+        s = Settings(_env_file=None)
+        assert s.port == 8003
+
+    def test_max_ingest_documents_from_yaml(self):
+        from inferia.services.data.config import Settings
+        s = Settings(_env_file=None)
+        assert s.max_ingest_documents == 500
+
+    def test_max_document_size_bytes_from_yaml(self):
+        from inferia.services.data.config import Settings
+        s = Settings(_env_file=None)
+        assert s.max_document_size_bytes == 1_000_000
+
+    def test_allowed_origins_coerced_from_list(self, monkeypatch):
+        from inferia.services.data.config import Settings
+        monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+        s = Settings(_env_file=None)
+        assert isinstance(s.allowed_origins, str)
+
+    def test_api_gateway_url_from_yaml(self):
+        from inferia.services.data.config import Settings
+        s = Settings(_env_file=None)
+        assert s.api_gateway_url == "http://localhost:8000"
+
+
+# ─── orchestration ───────────────────────────────────────────────────────────
+
+class TestOrchestrationSettingsFromYaml:
+    def test_http_port_read_from_yaml(self):
+        from inferia.services.orchestration.config import Settings
+        s = Settings(_env_file=None)
+        assert s.http_port == 8080
+
+    def test_grpc_port_read_from_yaml(self):
+        from inferia.services.orchestration.config import Settings
+        s = Settings(_env_file=None)
+        assert s.grpc_port == 50051
+
+    def test_readiness_timeout_from_yaml(self):
+        from inferia.services.orchestration.config import Settings
+        s = Settings(_env_file=None)
+        assert s.default_readiness_timeout == 300
+
+    def test_deployment_log_buffer_size_from_yaml(self):
+        from inferia.services.orchestration.config import Settings
+        s = Settings(_env_file=None)
+        assert s.deployment_log_buffer_size == 10000
+
+    def test_ephemeral_failure_threshold_from_yaml(self):
+        from inferia.services.orchestration.config import Settings
+        s = Settings(_env_file=None)
+        assert s.ephemeral_failure_threshold_minutes == 10

--- a/package/src/inferia/common/unified_config/schema.py
+++ b/package/src/inferia/common/unified_config/schema.py
@@ -141,19 +141,158 @@ class ApiGatewayService(BaseModel):
     service_urls: ServiceUrlsSection = Field(default_factory=ServiceUrlsSection)
 
 
-class PlaceholderService(BaseModel):
-    """Phase-2 services — only the `enabled` toggle is validated for now."""
-    model_config = ConfigDict(extra="allow")
+# ─── inference ────────────────────────────────────────────────────────────
+
+class UpstreamSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    http_timeout_seconds: float = 60.0
+    http_connect_timeout_seconds: float = 10.0
+    video_timeout_seconds: float = 300.0
+    http_max_connections: int = Field(default=500, gt=0)
+    http_max_keepalive_connections: int = Field(default=100, gt=0)
+    global_max_in_flight: int = Field(default=0, ge=0)
+    per_deployment_max_in_flight: int = Field(default=100, ge=0)
+    slot_acquire_timeout_seconds: float = 20.0
+    allowed_internal_hosts: str = ""
+    max_response_bytes: int = Field(default=52_428_800, gt=0)
+
+
+class GatewayClientSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    http_max_connections: int = Field(default=1000, gt=0)
+    http_max_keepalive_connections: int = Field(default=100, gt=0)
+
+
+class ContextCacheSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    ttl: int = Field(default=30, ge=0)
+    maxsize: int = Field(default=1000, ge=1)
+
+
+class QuotaCacheSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    ttl_seconds: float = Field(default=1.0, ge=0)
+    maxsize: int = Field(default=10000, ge=1)
+
+
+class InferenceService(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     enabled: bool = True
+    host: str = "0.0.0.0"
+    port: int = Field(default=8001, gt=0, le=65535)
+    workers: int = Field(default=1, gt=0)
+    reload: bool = False
+    api_gateway_url: str = "http://localhost:8000"
+    external_proxy_url: Optional[str] = None
+    request_timeout: int = Field(default=30, gt=0)
+    verify_ssl: bool = True
+    upstream: UpstreamSection = Field(default_factory=UpstreamSection)
+    gateway_client: GatewayClientSection = Field(default_factory=GatewayClientSection)
+    context_cache: ContextCacheSection = Field(default_factory=ContextCacheSection)
+    quota_cache: QuotaCacheSection = Field(default_factory=QuotaCacheSection)
+
+
+# ─── guardrail ────────────────────────────────────────────────────────────
+
+class GuardrailControlsSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    enable_guardrails: bool = True
+    enable_toxicity: bool = False
+    enable_prompt_injection: bool = False
+    enable_secrets: bool = False
+    enable_code_scanning: bool = False
+    enable_sensitive_info: bool = False
+    enable_no_refusal: bool = False
+    enable_bias: bool = False
+    enable_relevance: bool = False
+
+
+class GuardrailThresholdsSection(BaseModel):
+    # NOTE: leaf names match the service Settings field names exactly so the
+    # flatten logic in source.py maps them correctly without a prefix collision.
+    model_config = ConfigDict(extra="forbid")
+    toxicity_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
+    prompt_injection_threshold: float = Field(default=0.8, ge=0.0, le=1.0)
+    bias_threshold: float = Field(default=0.75, ge=0.0, le=1.0)
+    relevance_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
+class GuardrailPiiSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    detection_enabled: bool = True
+    anonymize: bool = True
+    entity_types: list[str] = Field(default_factory=list)
+    max_scan_time_seconds: float = Field(default=5.0, gt=0)
+
+
+class GuardrailService(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    enabled: bool = True
+    host: str = "0.0.0.0"
+    port: int = Field(default=8002, gt=0, le=65535)
+    reload: bool = False
+    api_gateway_url: str = "http://localhost:8000"
+    default_engine: str = "llm-guard"
+    llama_guard_model_id: str = "meta-llama/llama-guard-4-12b"
+    banned_substrings: str = ""
+    controls: GuardrailControlsSection = Field(default_factory=GuardrailControlsSection)
+    thresholds: GuardrailThresholdsSection = Field(default_factory=GuardrailThresholdsSection)
+    pii: GuardrailPiiSection = Field(default_factory=GuardrailPiiSection)
+
+
+# ─── data ─────────────────────────────────────────────────────────────────
+
+class DataService(BaseModel):
+    # NOTE: max_ingest_documents and max_document_size_bytes are top-level
+    # (no sub-section wrapper) so the flatten produces the exact field names
+    # declared in data/config.py Settings.
+    model_config = ConfigDict(extra="forbid")
+    enabled: bool = True
+    host: str = "0.0.0.0"
+    port: int = Field(default=8003, gt=0, le=65535)
+    reload: bool = False
+    api_gateway_url: str = "http://localhost:8000"
+    redis_url: str = "redis://localhost:6379/0"
+    max_ingest_documents: int = Field(default=500, gt=0)
+    max_document_size_bytes: int = Field(default=1_000_000, gt=0)
+
+
+# ─── orchestration ────────────────────────────────────────────────────────
+
+class OrchestrationReadinessSection(BaseModel):
+    # NOTE: leaf names match orchestration/config.py Settings field names.
+    model_config = ConfigDict(extra="forbid")
+    default_readiness_timeout: int = Field(default=300, gt=0)
+    default_polling_interval: int = Field(default=20, gt=0)
+    ephemeral_failure_threshold_minutes: int = Field(default=10, gt=0)
+
+
+class OrchestrationDeploymentLogsSection(BaseModel):
+    # NOTE: leaf names match orchestration/config.py Settings field names.
+    model_config = ConfigDict(extra="forbid")
+    elasticsearch_url: Optional[str] = None
+    deployment_log_buffer_size: int = Field(default=10000, gt=0)
+    deployment_log_flush_interval: int = Field(default=10, gt=0)
+
+
+class OrchestrationService(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    enabled: bool = True
+    host: str = "0.0.0.0"
+    http_port: int = Field(default=8080, gt=0, le=65535)
+    grpc_port: int = Field(default=50051, gt=0, le=65535)
+    nosana_sidecar_url: str = "http://localhost:3000"
+    readiness: OrchestrationReadinessSection = Field(default_factory=OrchestrationReadinessSection)
+    deployment_logs: OrchestrationDeploymentLogsSection = Field(default_factory=OrchestrationDeploymentLogsSection)
 
 
 class ServicesConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     api_gateway: ApiGatewayService = Field(default_factory=ApiGatewayService)
-    inference: PlaceholderService = Field(default_factory=PlaceholderService)
-    guardrail: PlaceholderService = Field(default_factory=PlaceholderService)
-    data: PlaceholderService = Field(default_factory=PlaceholderService)
-    orchestration: PlaceholderService = Field(default_factory=PlaceholderService)
+    inference: InferenceService = Field(default_factory=InferenceService)
+    guardrail: GuardrailService = Field(default_factory=GuardrailService)
+    data: DataService = Field(default_factory=DataService)
+    orchestration: OrchestrationService = Field(default_factory=OrchestrationService)
 
 
 # ─── providers (Phase 2 will tighten; for now accept-all) ─────────────────

--- a/package/src/inferia/services/data/config.py
+++ b/package/src/inferia/services/data/config.py
@@ -2,9 +2,9 @@
 Data Service Configuration.
 """
 
-from typing import Optional
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import Any, ClassVar, Optional
+from pydantic import BaseModel, Field, field_validator
+from inferia.common.unified_config import UnifiedBaseSettings
 
 
 class ChromaConfig(BaseModel):
@@ -23,8 +23,21 @@ class ProvidersConfig(BaseModel):
     vectordb: VectorDBConfig = Field(default_factory=VectorDBConfig)
 
 
-class Settings(BaseSettings):
-    """Data Service Settings."""
+class Settings(UnifiedBaseSettings):
+    """Data Service Settings.
+
+    Source precedence (highest → lowest): init/CLI > env > .env > yaml > pydantic defaults.
+    See docs/superpowers/specs/2026-05-12-unified-config-design.md.
+    """
+
+    _yaml_path: ClassVar[str] = "services.data"
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def _coerce_allowed_origins(cls, v: Any) -> Any:
+        if isinstance(v, list):
+            return ",".join(str(item).strip() for item in v if str(item).strip())
+        return v
 
     # Application Settings
     app_name: str = "InferiaLLM Data Service"
@@ -75,13 +88,6 @@ class Settings(BaseSettings):
     @property
     def is_production(self) -> bool:
         return self.environment == "production"
-
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        case_sensitive=False,
-        extra="ignore",
-    )
 
 
 settings = Settings()

--- a/package/src/inferia/services/guardrail/config.py
+++ b/package/src/inferia/services/guardrail/config.py
@@ -3,15 +3,28 @@ Guardrail Service Configuration.
 """
 
 import logging
-from typing import List, Optional
-from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import Any, ClassVar, List, Optional
+from pydantic import Field, field_validator
+from inferia.common.unified_config import UnifiedBaseSettings
 
 logger = logging.getLogger(__name__)
 
 
-class Settings(BaseSettings):
-    """Guardrail Service Settings."""
+class Settings(UnifiedBaseSettings):
+    """Guardrail Service Settings.
+
+    Source precedence (highest → lowest): init/CLI > env > .env > yaml > pydantic defaults.
+    See docs/superpowers/specs/2026-05-12-unified-config-design.md.
+    """
+
+    _yaml_path: ClassVar[str] = "services.guardrail"
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def _coerce_allowed_origins(cls, v: Any) -> Any:
+        if isinstance(v, list):
+            return ",".join(str(item).strip() for item in v if str(item).strip())
+        return v
 
     # Application Settings
     app_name: str = "InferiaLLM Guardrail Service"
@@ -86,13 +99,6 @@ class Settings(BaseSettings):
         if not self.banned_substrings:
             return []
         return [s.strip() for s in self.banned_substrings.split(",") if s.strip()]
-
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        case_sensitive=False,
-        extra="ignore",
-    )
 
 
 settings = Settings()

--- a/package/src/inferia/services/inference/config.py
+++ b/package/src/inferia/services/inference/config.py
@@ -2,13 +2,26 @@
 Configuration for Inference Gateway.
 """
 
-from typing import Any, Optional
-from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import Any, ClassVar, Optional
+from pydantic import Field, field_validator
+from inferia.common.unified_config import UnifiedBaseSettings
 
 
-class Settings(BaseSettings):
-    """Inference Gateway settings."""
+class Settings(UnifiedBaseSettings):
+    """Inference Gateway settings.
+
+    Source precedence (highest → lowest): init/CLI > env > .env > yaml > pydantic defaults.
+    See docs/superpowers/specs/2026-05-12-unified-config-design.md.
+    """
+
+    _yaml_path: ClassVar[str] = "services.inference"
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def _coerce_allowed_origins(cls, v: Any) -> Any:
+        if isinstance(v, list):
+            return ",".join(str(item).strip() for item in v if str(item).strip())
+        return v
 
     # Application Settings
     app_name: str = "InferiaLLM Inference Gateway"
@@ -208,12 +221,6 @@ class Settings(BaseSettings):
         """Check if running in development environment."""
         return self.environment == "development"
 
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        case_sensitive=False,
-        extra="ignore",  # Ignore extra env vars from shared .env file
-    )
 
 
 settings = Settings()

--- a/package/src/inferia/services/orchestration/config.py
+++ b/package/src/inferia/services/orchestration/config.py
@@ -3,9 +3,10 @@ Orchestration Service Configuration
 """
 
 import os
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings
+from inferia.common.unified_config import UnifiedBaseSettings
 
 
 class ProviderSettings(BaseSettings):
@@ -55,8 +56,14 @@ class ProviderSettings(BaseSettings):
     )
 
 
-class Settings(BaseSettings):
-    """Application settings."""
+class Settings(UnifiedBaseSettings):
+    """Application settings.
+
+    Source precedence (highest → lowest): init/CLI > env > .env > yaml > pydantic defaults.
+    See docs/superpowers/specs/2026-05-12-unified-config-design.md.
+    """
+
+    _yaml_path: ClassVar[str] = "services.orchestration"
 
     # App info
     app_name: str = "Orchestration Service"
@@ -179,10 +186,6 @@ class Settings(BaseSettings):
     def is_production(self) -> bool:
         """Check if running in production environment."""
         return getattr(self, "environment", "development") == "production"
-
-    model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
-    )
 
 
 settings = Settings()


### PR DESCRIPTION
Stacks on top of #246.

## Summary
- Expands the unified yaml schema with full models for the 4 remaining services: `InferenceService`, `GuardrailService`, `DataService`, `OrchestrationService`. Each uses `extra="forbid"` for typo protection. `PlaceholderService` is removed.
- Migrates `inference`, `guardrail`, `data`, and `orchestration` Settings classes to inherit `UnifiedBaseSettings` with their `_yaml_path` set. Same 12-line diff pattern as api_gateway in #246.
- Adds the list→str coercion validator on each service's `allowed_origins` field (yaml `list[str]` → comma-joined `str` for legacy `setup_cors()` consumers).
- Expands `inferia.yaml.example` with documented per-service blocks for the most-frequently-customized fields. Defaults handle the rest.
- New integration test file `test_phase_2_services.py` (20 tests) loads each service's `Settings` from the yaml example and asserts representative fields.

## Test plan
- [x] 447 tests pass across `common.tests.unified_config` + all 5 services
- [x] `pytest --cov=inferia.common.unified_config --cov-fail-under=95` → **100% coverage**
- [x] Per-service test deltas: no regressions
  - inference: 111 pass
  - guardrail: 32 pass
  - data: 45 pass
  - api_gateway: 164 pass

## Commit chain (6 commits)
1. `fd9df7a` feat(common): expand schema for 4 services
2. `f5c49d0` feat(inference): migrate Settings
3. `0ebc8a9` feat(guardrail): migrate Settings
4. `46647db` feat(data): migrate Settings
5. `d3f2207` feat(orchestration): migrate Settings
6. `a7f738d` docs: expand inferia.yaml.example + integration test

All SSH-signed, authored by \`ankitprasad2005\`.

## Notes
- \`extra="forbid"\` on each service's full model means yaml typos under \`services.<name>\` are caught at load time.
- \`services.orchestration.ProviderSettings\` (the nested gRPC/cloud provider config) is **NOT** migrated in this PR — it lives separately from \`services.orchestration.Settings\` and is handled in #248 (provider seeding) where the yaml \`providers.*\` tree becomes the source of truth.