### PR TITLE
feat: three auth modes (local|oidc|inferiaauth) + InferiaLLM-owned permission catalog

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -38,6 +38,7 @@ import { AuthProvider, useAuth } from "@/context/AuthContext";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "sonner";
 import { PermissionGuard } from "@/components/PermissionGuard";
+import { ExternalIdentityGuard } from "@/components/ExternalIdentityGuard";
 import { useTokenFragmentConsumer } from "@/hooks/useTokenFragmentConsumer";
 
 function RequireAuth() {
@@ -180,17 +181,17 @@ const router = createBrowserRouter([
           {
             path: "settings/roles",
             element: <PermissionGuard permission="role:list" />,
-            children: [{ index: true, element: <Roles /> }]
+            children: [{ index: true, element: <ExternalIdentityGuard><Roles /></ExternalIdentityGuard> }]
           },
           {
             path: "settings/users",
             element: <PermissionGuard permission="member:list" />,
-            children: [{ index: true, element: <Users /> }]
+            children: [{ index: true, element: <ExternalIdentityGuard><Users /></ExternalIdentityGuard> }]
           },
           {
             path: "settings/organization",
             element: <PermissionGuard permission="organization:view" />,
-            children: [{ index: true, element: <Organization /> }]
+            children: [{ index: true, element: <ExternalIdentityGuard><Organization /></ExternalIdentityGuard> }]
           },
           {
             path: "settings/audit-logs",

--- a/apps/dashboard/src/components/ExternalIdentityGuard.tsx
+++ b/apps/dashboard/src/components/ExternalIdentityGuard.tsx
@@ -1,0 +1,17 @@
+import { isExternalAuthMode } from "@/lib/authMode";
+import { type ReactNode } from "react";
+
+export function ExternalIdentityGuard({ children }: { children: ReactNode }) {
+  if (isExternalAuthMode()) {
+    return (
+      <div className="p-8 max-w-xl">
+        <h2 className="text-lg font-semibold">Managed by your identity provider</h2>
+        <p className="text-sm text-muted-foreground mt-2">
+          Organizations, users, teams, and roles are managed centrally by your
+          identity provider in this deployment. There's nothing to configure here.
+        </p>
+      </div>
+    );
+  }
+  return <>{children}</>;
+}

--- a/apps/dashboard/src/components/__tests__/ExternalIdentityGuard.test.tsx
+++ b/apps/dashboard/src/components/__tests__/ExternalIdentityGuard.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExternalIdentityGuard } from "@/components/ExternalIdentityGuard";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+const NOTICE_HEADING = /managed by your identity provider/i;
+const CHILD_TEXT = "Child content";
+
+function ChildContent() {
+  return <div>{CHILD_TEXT}</div>;
+}
+
+describe("ExternalIdentityGuard — external auth modes", () => {
+  it("shows the IdP notice and hides children when VITE_AUTH_PROVIDER=inferiaauth", async () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "inferiaauth");
+    // Re-import so the module picks up the stubbed env value
+    const { ExternalIdentityGuard: Guard } = await import("@/components/ExternalIdentityGuard");
+    render(
+      <Guard>
+        <ChildContent />
+      </Guard>
+    );
+    expect(screen.getByRole("heading", { name: NOTICE_HEADING })).toBeInTheDocument();
+    expect(screen.queryByText(CHILD_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("shows the IdP notice and hides children when VITE_AUTH_PROVIDER=oidc", async () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "oidc");
+    const { ExternalIdentityGuard: Guard } = await import("@/components/ExternalIdentityGuard");
+    render(
+      <Guard>
+        <ChildContent />
+      </Guard>
+    );
+    expect(screen.getByRole("heading", { name: NOTICE_HEADING })).toBeInTheDocument();
+    expect(screen.queryByText(CHILD_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("shows the IdP notice for the legacy 'external' alias", async () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "external");
+    const { ExternalIdentityGuard: Guard } = await import("@/components/ExternalIdentityGuard");
+    render(
+      <Guard>
+        <ChildContent />
+      </Guard>
+    );
+    expect(screen.getByRole("heading", { name: NOTICE_HEADING })).toBeInTheDocument();
+    expect(screen.queryByText(CHILD_TEXT)).not.toBeInTheDocument();
+  });
+});
+
+describe("ExternalIdentityGuard — local mode", () => {
+  it("renders children when VITE_AUTH_PROVIDER=local", async () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "local");
+    const { ExternalIdentityGuard: Guard } = await import("@/components/ExternalIdentityGuard");
+    render(
+      <Guard>
+        <ChildContent />
+      </Guard>
+    );
+    expect(screen.getByText(CHILD_TEXT)).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: NOTICE_HEADING })).not.toBeInTheDocument();
+  });
+
+  it("renders children when VITE_AUTH_PROVIDER is unset (defaults to local)", async () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "");
+    const { ExternalIdentityGuard: Guard } = await import("@/components/ExternalIdentityGuard");
+    render(
+      <Guard>
+        <ChildContent />
+      </Guard>
+    );
+    expect(screen.getByText(CHILD_TEXT)).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: NOTICE_HEADING })).not.toBeInTheDocument();
+  });
+});

--- a/apps/dashboard/src/layouts/DashboardLayout.tsx
+++ b/apps/dashboard/src/layouts/DashboardLayout.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils";
 import { useMemo, useState } from "react";
 import { useTheme } from "@/components/theme-provider";
 import { SpotlightSearch, useSpotlight } from "@/components/SpotlightSearch";
+import { isExternalAuthMode } from "@/lib/authMode";
 
 const navItems: (NavItem & { permission?: string })[] = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard, exact: true, permission: "organization:view" },
@@ -173,9 +174,21 @@ export default function DashboardLayout() {
     [hasPermission]
   );
 
+  const externalAuth = isExternalAuthMode();
+
   const filteredSettingsItems = useMemo(
-    () => settingsItems.filter((item) => !item.permission || hasPermission(item.permission)),
-    [hasPermission]
+    () =>
+      settingsItems.filter((item) => {
+        if (externalAuth && [
+          "/dashboard/settings/organization",
+          "/dashboard/settings/users",
+          "/dashboard/settings/roles",
+        ].includes(item.href)) {
+          return false;
+        }
+        return !item.permission || hasPermission(item.permission);
+      }),
+    [hasPermission, externalAuth]
   );
 
   const breadcrumbItems = useMemo(() => {

--- a/apps/dashboard/src/lib/__tests__/authMode.test.ts
+++ b/apps/dashboard/src/lib/__tests__/authMode.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { authProvider, isExternalAuthMode } from "@/lib/authMode";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("authProvider", () => {
+  it("returns the VITE_AUTH_PROVIDER value when set", () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "inferiaauth");
+    expect(authProvider()).toBe("inferiaauth");
+  });
+
+  it("returns 'local' when VITE_AUTH_PROVIDER is empty/unset", () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "");
+    // Empty string is falsy so the || "local" fallback fires.
+    expect(authProvider()).toBe("local");
+  });
+});
+
+describe("isExternalAuthMode", () => {
+  it("returns true for 'inferiaauth'", () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "inferiaauth");
+    expect(isExternalAuthMode()).toBe(true);
+  });
+
+  it("returns true for 'oidc'", () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "oidc");
+    expect(isExternalAuthMode()).toBe(true);
+  });
+
+  it("returns true for the legacy 'external' alias", () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "external");
+    expect(isExternalAuthMode()).toBe(true);
+  });
+
+  it("returns false for 'local'", () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "local");
+    expect(isExternalAuthMode()).toBe(false);
+  });
+
+  it("returns false when VITE_AUTH_PROVIDER is unset (empty string)", () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "");
+    expect(isExternalAuthMode()).toBe(false);
+  });
+
+  it("returns false for an unrecognised/garbage value", () => {
+    vi.stubEnv("VITE_AUTH_PROVIDER", "saml");
+    expect(isExternalAuthMode()).toBe(false);
+  });
+});

--- a/apps/dashboard/src/lib/authMode.ts
+++ b/apps/dashboard/src/lib/authMode.ts
@@ -1,0 +1,14 @@
+// Auth mode is baked in at build time via VITE_AUTH_PROVIDER.
+// "local" = built-in user/password; "oidc"/"inferiaauth" = redirect to an
+// external IdP. "external" is a deprecated alias for "inferiaauth".
+export type AuthMode = "local" | "oidc" | "inferiaauth";
+
+export function authProvider(): string {
+  return (import.meta.env.VITE_AUTH_PROVIDER as string) || "local";
+}
+
+/** True when login is delegated to an external IdP (oidc or inferiaauth). */
+export function isExternalAuthMode(): boolean {
+  const p = authProvider();
+  return p === "oidc" || p === "inferiaauth" || p === "external";
+}

--- a/apps/dashboard/src/pages/Login.tsx
+++ b/apps/dashboard/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { LockKeyhole, Radar, ShieldCheck, Sparkles } from "lucide-react";
 
 import { startExternalLogin } from "@/services/authService";
+import { isExternalAuthMode } from "@/lib/authMode";
 
 /**
  * The legacy email/password form. Always available locally; surfaced as an
@@ -143,10 +144,10 @@ function LocalCredentialForm() {
 }
 
 export default function Login() {
-  // VITE_AUTH_PROVIDER is baked in at build time. Only the exact literal
-  // "external" enables the redirect flow; anything else (unset, "local",
-  // typos, garbage) falls back to the legacy email/password form.
-  const isExternal = import.meta.env.VITE_AUTH_PROVIDER === "external";
+  // VITE_AUTH_PROVIDER is baked in at build time. "oidc", "inferiaauth", and
+  // the legacy "external" all enable the redirect flow; anything else (unset,
+  // "local", typos, garbage) falls back to the legacy email/password form.
+  const isExternal = isExternalAuthMode();
 
   return (
     <div className="relative w-full max-w-5xl px-4 py-6 sm:px-8">

--- a/apps/dashboard/src/services/authService.ts
+++ b/apps/dashboard/src/services/authService.ts
@@ -1,5 +1,6 @@
 import api from "@/lib/api";
 import * as tokenStore from "@/lib/tokenStore";
+import { isExternalAuthMode } from "@/lib/authMode";
 
 const { setToken } = tokenStore;
 
@@ -71,7 +72,7 @@ export async function logout(): Promise<void> {
     // Network failure on the audit POST must not block the redirect.
   }
 
-  const isExternal = import.meta.env.VITE_AUTH_PROVIDER === "external";
+  const isExternal = isExternalAuthMode();
   const externalUrl = import.meta.env.VITE_EXTERNAL_AUTH_URL as
     | string
     | undefined;

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     css: false,
     coverage: {
       provider: "v8",
-      include: ["src/services/authService.ts", "src/lib/tokenStore.ts", "src/App.tsx", "src/pages/Login.tsx"],
+      include: ["src/lib/authMode.ts", "src/services/authService.ts", "src/lib/tokenStore.ts", "src/App.tsx", "src/pages/Login.tsx"],
       exclude: ["src/main.tsx", "src/setupTests.ts", "**/*.test.{ts,tsx}", "**/__tests__/**"],
       reporter: ["text", "html"],
     },

--- a/deploy/docker-compose.sso.yml
+++ b/deploy/docker-compose.sso.yml
@@ -116,9 +116,12 @@ services:
       JWT_REFRESH_TTL: "168h"
       ENCRYPTION_KEY: "x9tZfrL6OCoGDLg26VKE3F4djdjoPQK989p9lmCt8UY="
       # The in-process OAuth seed (cmd/server/seed.go) inserts the
-      # inferiallm-dashboard oauth_clients row and seeds the FGA permission
-      # tree. OAUTH_SEED_REDIRECT_URI overrides the default so the registered
-      # redirect_uri matches what the Caddy-fronted dashboard advertises.
+      # inferiallm-dashboard oauth_clients row. The inferiallm FGA permission
+      # tree is NO LONGER seeded here — InferiaLLM self-declares its catalog at
+      # boot via PUT /api/v1/services/inferiallm/catalog (see inferia-app's
+      # CATALOG_ADMIN_TOKEN below). OAUTH_SEED_REDIRECT_URI overrides the default
+      # so the registered redirect_uri matches what the Caddy-fronted dashboard
+      # advertises.
       OAUTH_SEED_REDIRECT_URI: "https://inferia.local/auth/callback"
       COOKIE_SECURE: "true"
       RATE_LIMIT_MAX: "60"
@@ -156,20 +159,26 @@ services:
       ENVIRONMENT: "development"
       LOG_LEVEL: "INFO"
 
-      # --- Auth provider — external mode, pointed at inferia-auth via Caddy.
-      AUTH_PROVIDER: "external"
+      # --- Auth provider — inferiaauth (SaaS) mode, pointed at inferia-auth via Caddy.
+      AUTH_PROVIDER: "inferiaauth"
       EXTERNAL_AUTH_URL: "https://auth.inferia.local"
       EXTERNAL_AUTH_ISSUER: "https://auth.inferia.local"
       APP_NAMESPACE: "inferiallm"
       OAUTH_CLIENT_ID: "inferiallm-dashboard"
       OAUTH_REDIRECT_URI: "https://inferia.local/auth/callback"
       OAUTH_JWKS_CACHE_TTL_SECONDS: "3600"
+      # Catalog self-declaration: InferiaLLM PUTs its permission/role catalog to
+      # inferia-auth at boot. The token must be a USER JWT carrying the
+      # `services_manage` permission (e.g. minted for the superuser). Empty =
+      # declare is skipped (non-fatal) — provision a real token for a full
+      # end-to-end FGA-backed run (see docs/operations/auth.md).
+      CATALOG_ADMIN_TOKEN: "${CATALOG_ADMIN_TOKEN:-}"
 
       # --- Vite build-time vars. The unified Dockerfile builds the dashboard
       # in stage 2 of the multi-stage build, so these must be set as build
       # args, not runtime env vars, in production. For local dev we set them
       # here so a rebuild picks them up via `make docker-up-sso` (--build).
-      VITE_AUTH_PROVIDER: "external"
+      VITE_AUTH_PROVIDER: "inferiaauth"
       VITE_EXTERNAL_AUTH_URL: "https://auth.inferia.local"
 
       # --- Local superadmin (recovery path). Always works even in external

--- a/docs/plans/2026-06-09-inferiallm-auth-modes-and-catalog.md
+++ b/docs/plans/2026-06-09-inferiallm-auth-modes-and-catalog.md
@@ -1,0 +1,204 @@
+# InferiaLLM Three Auth Modes + Catalog Self-Declaration — Implementation Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development or superpowers:executing-plans to implement task-by-task. Steps use `- [ ]` checkboxes.
+
+**Goal:** Make InferiaLLM auth mirror InferiaGate — three modes (`local | oidc | inferiaauth`) — and have InferiaLLM self-declare its permission/role catalog to InferiaAuth instead of InferiaAuth hardcoding it.
+
+**Architecture:** Generalize the existing `AUTH_PROVIDER=external` InferiaAuth integration into three explicit modes; add an InferiaLLM-owned catalog declared to InferiaAuth at boot; hide local org/user/team management in the two external modes; keep everything for `local` (open-source). Cross-repo: InferiaLLM (Python/FastAPI) + InferiaAuth (Go).
+
+**Tech Stack:** Python 3.10–3.12, FastAPI, SQLAlchemy/asyncpg, pytest+pytest-asyncio, httpx, python-jose; React 19 + Vite + TanStack Query (dashboard); Go (InferiaAuth).
+
+**Spec:** `docs/specs/2026-06-09-inferiallm-auth-modes-and-catalog.md`
+
+**Commit convention:** Conventional commits. **Never** include Claude / Co-Authored-By footers.
+
+---
+
+## Phase 0 — Verify the existing SaaS SSO (gate before refactor)
+
+Confirm the already-built `external` integration round-trips before changing it.
+
+### Task 0.1: Bring up + smoke-test the SSO topology
+**Files:** none (ops).
+- [ ] **Step 1:** Add hosts entries: `127.0.0.1 inferia.local` and `127.0.0.1 auth.inferia.local` (`/etc/hosts`).
+- [ ] **Step 2:** `make docker-up-sso` (builds inferia-auth + inferia-app images; brings up postgres/redis/caddy). Expected: all 4 services healthy (`make docker-logs-sso`).
+- [ ] **Step 3:** Run the existing smoke script `scripts/sso_smoke.sh`. Expected: exits 0 (full redirect → login → callback → authenticated `/me` round-trip).
+- [ ] **Step 4:** Manually: open `https://inferia.local`, confirm redirect to `https://auth.inferia.local`, log in (`admin@example.com` / `change-me-immediately-1234`), confirm redirect back + dashboard loads authenticated.
+- [ ] **Step 5:** Record the baseline (what works) in the plan's "Phase 0 results" note. **No commit** (ops-only). If the smoke fails, fix the existing scaffold first and re-run before Phase 1.
+
+---
+
+## Phase 1 — Catalog self-declaration
+
+InferiaLLM owns its catalog; InferiaAuth stops hardcoding it.
+
+### Task 1.1: Define InferiaLLM's permission/role catalog
+**Files:**
+- Create: `package/src/inferia/services/api_gateway/rbac/catalog.py`
+- Test: `package/src/inferia/services/api_gateway/rbac/tests/test_catalog.py`
+
+- [ ] **Step 1: Write the failing test** (`test_catalog.py`):
+```python
+from inferia.services.api_gateway.rbac.catalog import CATALOG, to_declare_request
+
+def test_every_role_permission_is_declared():
+    keys = {p.key for p in CATALOG.permissions}
+    for role in CATALOG.roles:
+        for k in role.permissions:
+            assert k in keys, f"role {role.name} references undeclared {k}"
+
+def test_admin_has_all_permissions():
+    admin = next(r for r in CATALOG.roles if r.name == "admin")
+    assert set(admin.permissions) == {p.key for p in CATALOG.permissions}
+
+def test_to_declare_request_shape():
+    body = to_declare_request(CATALOG)
+    assert set(body) == {"roles", "permissions"}
+    assert all({"key", "display_name", "description"} <= set(p) for p in body["permissions"])
+    assert all({"name", "permissions"} <= set(r) for r in body["roles"])
+    # keys are colon-form inferiallm:<resource>:<action>
+    assert all(p["key"].startswith("inferiallm:") for p in body["permissions"])
+```
+- [ ] **Step 2: Run, expect FAIL** — `pytest package/src/inferia/services/api_gateway/rbac/tests/test_catalog.py -v` → ImportError.
+- [ ] **Step 3: Implement `catalog.py`** — `@dataclass Permission(key, display_name, description)`, `@dataclass Role(name, permissions: list[str])`, `@dataclass Catalog(permissions, roles)`. Define the v1 permission list (deployment/provider/user/org/audit/apikey/model × read/write/delete as in spec), roles `admin`/`operator`/`viewer`, and `to_declare_request(catalog) -> dict` projecting to the InferiaAuth `PUT /services/:id/catalog` body. Add a module-load assertion that every role permission is declared (raise at import if not).
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** — `feat(rbac): define InferiaLLM permission/role catalog`.
+
+### Task 1.2: Catalog declare client (boot-time PUT to InferiaAuth)
+**Files:**
+- Create: `package/src/inferia/services/api_gateway/rbac/catalog_declare.py`
+- Test: `.../rbac/tests/test_catalog_declare.py`
+
+- [ ] **Step 1: Write failing test** — using `httpx.MockTransport`, assert `declare_catalog(base_url, token)` issues `PUT {base}/api/v1/services/inferiallm/catalog` with the `to_declare_request(CATALOG)` body + `Authorization: Bearer <token>`, returns True on 200, returns False (no raise) on 5xx/network error.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** `async def declare_catalog(base_url, admin_token, *, client=None) -> bool` — httpx PUT, 30s timeout, length-guard inputs, swallow errors → return False + log warning (non-fatal, mirrors InferiaGate).
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** — `feat(rbac): catalog declare client for InferiaAuth`.
+
+### Task 1.3: Call declare on boot (inferiaauth mode only)
+**Files:**
+- Modify: `package/src/inferia/services/api_gateway/app.py` (startup)
+- Modify: `config.py` (add `catalog_admin_token` setting, alias `CATALOG_ADMIN_TOKEN`)
+- Test: `.../tests/test_app_startup_catalog.py`
+
+- [ ] **Step 1: Write failing test** — with `auth_provider="inferiaauth"` + a mocked `declare_catalog`, assert app startup awaits `declare_catalog(external_auth_url, catalog_admin_token)`; with `auth_provider="local"`, assert it is NOT called.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** — in the FastAPI startup handler, `if settings.auth_provider == "inferiaauth" and settings.catalog_admin_token: await declare_catalog(settings.external_auth_url, settings.catalog_admin_token)`. Log success/failure; never raise.
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** — `feat(app): declare catalog to InferiaAuth on boot (inferiaauth mode)`.
+
+### Task 1.4: Remove the hardcoded inferiallm seed from InferiaAuth
+**Files (InferiaAuth repo `../inferiaauth`):**
+- Modify: `cmd/server/seed.go` (delete `inferiallmPermissions` + its FGA seed call; keep the `inferiallm-dashboard` OAuth client seed)
+- Test: `cmd/server/seed_test.go` (or the relevant seed test)
+
+- [ ] **Step 1:** Read `cmd/server/seed.go`; identify (a) the `inferiallmPermissions` map + the `SeedApp`/`SeedTemplates` call that seeds the inferiallm FGA tree, and (b) the `inferiallm-dashboard` OAuth client insert. Confirm the catalog handler (`internal/transport/rest/handler/catalog.go`) seeds FGA via the same `Seeder` path on declare.
+- [ ] **Step 2: Update the seed test** — assert boot seed still inserts the `inferiallm-dashboard` client, and assert it NO LONGER seeds the inferiallm permission tree (that now arrives via the catalog API). Run, expect FAIL.
+- [ ] **Step 3: Implement** — delete `inferiallmPermissions` + the FGA seed for inferiallm; keep the client seed. Build: `go build ./...`.
+- [ ] **Step 4: Run** the auth test suite for the touched packages — expect PASS. Verify a fresh boot + an InferiaLLM catalog-declare produces the same FGA tuples as before (integration check against the SSO topology).
+- [ ] **Step 5: Commit (InferiaAuth)** — `refactor(seed): let InferiaLLM self-declare its catalog; drop hardcoded perms`.
+
+---
+
+## Phase 2 — Three explicit modes (`local | oidc | inferiaauth`)
+
+### Task 2.1: Config — 3-mode enum + per-mode validation + back-compat
+**Files:**
+- Modify: `config.py:160` (`auth_provider` Literal) + the model validator (`config.py:304`)
+- Test: `.../tests/test_config_modes.py`
+
+- [ ] **Step 1: Write failing tests** — (a) `AUTH_PROVIDER=inferiaauth` without the 4 external fields → validation error; (b) `AUTH_PROVIDER=oidc` requires issuer+client+redirect; (c) `AUTH_PROVIDER=external` (legacy) loads as `inferiaauth` with a deprecation warning; (d) `AUTH_PROVIDER=local` needs nothing.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** — `Literal["local","oidc","inferiaauth"]`; a `field_validator`/`model_validator` that normalizes `external`→`inferiaauth` (warn), and enforces required fields per mode. Add a `is_external_mode` helper property (`mode in {oidc, inferiaauth}`).
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** — `feat(config): three auth modes (local|oidc|inferiaauth) with back-compat`.
+
+### Task 2.2: Middleware — branch per mode
+**Files:**
+- Modify: `rbac/middleware.py` (the `use_external` branch + add `_resolve_oidc_token`)
+- Test: `.../rbac/tests/test_middleware_modes.py`
+
+- [ ] **Step 1: Write failing tests** — with a stubbed JWKS verifier: (a) `inferiaauth` mode → `_resolve_external_token` reads `permissions`/`roles` from claims; (b) `oidc` mode → `_resolve_oidc_token` builds UserContext with the interim "authenticated ⇒ admin" role + shadow org, no catalog claim required; (c) `local` mode → external paths never invoked.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** — replace `use_external = settings.auth_provider == "external" …` with a 3-way branch keyed on `settings.auth_provider`; add `_resolve_oidc_token(db, token)` (JWKS verify against the enterprise issuer → shadow user → role from `OIDC_GROUPS_CLAIM` map if set, else `["admin"]` interim). Reuse `_get_verifier()` (parameterized by issuer/audience already).
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** — `feat(rbac): per-mode request auth (local|oidc|inferiaauth)`.
+
+### Task 2.3: Redirect-SSO router covers both external modes
+**Files:**
+- Modify: `rbac/oauth_router.py` (`_require_external_mode` → `_require_redirect_sso_mode`)
+- Test: `.../rbac/tests/test_oauth_router_modes.py`
+
+- [ ] **Step 1: Write failing test** — `/auth/start` returns 302 in both `oidc` and `inferiaauth` modes; returns 503 in `local` mode.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** — gate on `settings.is_external_mode` (oidc|inferiaauth) instead of the old `external` string.
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** — `feat(rbac): redirect-SSO available in oidc and inferiaauth modes`.
+
+### Task 2.4: Update the SSO compose to the new mode value
+**Files:**
+- Modify: `deploy/docker-compose.sso.yml` (`AUTH_PROVIDER: external` → `inferiaauth`; `VITE_AUTH_PROVIDER: external` → `inferiaauth`; add `CATALOG_ADMIN_TOKEN`)
+- [ ] **Step 1:** Set `AUTH_PROVIDER: inferiaauth`, `VITE_AUTH_PROVIDER: inferiaauth`, and a dev `CATALOG_ADMIN_TOKEN`.
+- [ ] **Step 2:** `make docker-up-sso` + `scripts/sso_smoke.sh` → expect 0 (regression check that the rename + catalog-declare didn't break the round-trip).
+- [ ] **Step 3: Commit** — `chore(sso): use inferiaauth mode + catalog-admin token in SSO compose`.
+
+---
+
+## Phase 3 — Hide local org/user/team in external modes
+
+### Task 3.1: Backend gate — `require_local_identity`
+**Files:**
+- Create: `package/src/inferia/services/api_gateway/rbac/local_identity_guard.py`
+- Modify: `management/organizations.py`, `management/users.py`, `rbac/users_router.py`, the role-management routes, and the local password-login routes in `rbac/oauth_router.py`/auth router
+- Test: `.../tests/test_local_identity_guard.py`
+
+- [ ] **Step 1: Write failing tests** — in `inferiaauth`/`oidc` mode, `GET/POST/PUT/DELETE` on `/organizations`, `/users`, `/roles`, `/auth/login`, `/auth/register` → `409` with a "managed by your identity provider" body; in `local` mode → normal behavior.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** — `def require_local_identity():` FastAPI dependency raising `HTTPException(409, …)` when `settings.is_external_mode`; add it to each local-identity router (`dependencies=[Depends(require_local_identity)]`). Keep the superadmin recovery login path exempt.
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** — `feat(rbac): gate local org/user/team/login in external modes`.
+
+### Task 3.2: Dashboard — hide identity surfaces in external modes
+**Files:**
+- Modify: `apps/dashboard/src/**` — the nav + Settings (Organization / Users & Teams / Roles) using `VITE_AUTH_PROVIDER`
+- Test: the dashboard test(s) for nav/settings visibility
+
+- [ ] **Step 1: Write failing test** — when `VITE_AUTH_PROVIDER` ∈ {oidc, inferiaauth}, the Settings → Organization/Users/Teams/Roles entries are not rendered (and routes redirect to a "managed by your IdP" notice); when `local`, they render.
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** — a `useAuthMode()`/env read + a `hideIdentityInExternal` filter on the nav, plus a route guard notice (mirror InferiaGate's `hideInTiers` + the ConfigView per-org redirect).
+- [ ] **Step 4: Run, expect PASS** (`cd apps/dashboard && npm test`).
+- [ ] **Step 5: Commit** — `feat(dashboard): hide org/user/team/roles in external auth modes`.
+
+---
+
+## Phase 4 — Generic enterprise OIDC mode polish
+
+### Task 4.1: `OIDC_GROUPS_CLAIM` → role mapping (optional, behind config)
+**Files:**
+- Modify: `config.py` (`oidc_groups_claim`, `oidc_role_map`), `rbac/middleware.py` `_resolve_oidc_token`
+- Test: `.../rbac/tests/test_oidc_role_mapping.py`
+
+- [ ] **Step 1: Write failing test** — a token with `groups: ["llm-admins"]` + `OIDC_ROLE_MAP={"llm-admins":"admin"}` → role `admin`; no matching group → `viewer` (configurable default).
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** the mapping (default behavior unchanged when unset: interim `["admin"]`).
+- [ ] **Step 4: Run, expect PASS.**
+- [ ] **Step 5: Commit** — `feat(rbac): optional OIDC group→role mapping for enterprise mode`.
+
+---
+
+## Phase 5 — End-to-end verification (all three modes)
+
+### Task 5.1: Mode matrix verification
+- [ ] **Step 1: `local`** — `AUTH_PROVIDER=local`: register/login locally, org/user/team management works, no redirect to any IdP.
+- [ ] **Step 2: `inferiaauth`** — `make docker-up-sso`: redirect to InferiaAuth → login → back; catalog visible in InferiaAuth (`GET /api/v1/services/inferiallm/catalog`); permissions claim enforced; local org/user/team hidden + 409.
+- [ ] **Step 3: `oidc`** — point `EXTERNAL_AUTH_*` at a generic OIDC IdP (or InferiaAuth acting as plain OIDC); authenticated ⇒ admin of shadow org; local org/user/team hidden; no catalog declare.
+- [ ] **Step 4:** Run the full suite — `make test` (Python) + `cd apps/dashboard && npm test` + InferiaAuth `go test ./...` (touched pkgs). Expect green.
+- [ ] **Step 5: Update docs** — `docs/operations/auth.md` (the three modes), `CLAUDE.md` (mode table + catalog self-declaration). Commit.
+
+---
+
+## Self-review checklist (run before execution)
+- [ ] Spec coverage: each spec section maps to a task above (3 modes ✓ T2.x, catalog ✓ T1.x, hide identity ✓ T3.x, oidc ✓ T4.1, verify ✓ T0/T5).
+- [ ] No placeholders: every code/test step shows concrete content or a precise file+behavior.
+- [ ] Type consistency: `CATALOG`, `to_declare_request`, `declare_catalog`, `require_local_identity`, `is_external_mode`, `_resolve_oidc_token` used consistently across tasks.
+- [ ] Cross-repo: InferiaAuth change (T1.4) is the only Go task; everything else is InferiaLLM Python/React.

--- a/docs/specs/2026-06-09-inferiallm-auth-modes-and-catalog.md
+++ b/docs/specs/2026-06-09-inferiallm-auth-modes-and-catalog.md
@@ -1,0 +1,143 @@
+# InferiaLLM — Three Auth Modes + Catalog Self-Declaration (Design Spec)
+
+**Date:** 2026-06-09
+**Status:** Approved for planning
+**Owners:** platform
+
+## Goal
+
+Make InferiaLLM's authentication mirror **InferiaGate** exactly: three deployment
+modes, and have InferiaLLM **self-declare its own permission/role catalog** to
+InferiaAuth instead of InferiaAuth hardcoding it.
+
+## Background — the three ways InferiaLLM ships
+
+| Mode (`AUTH_PROVIDER`) | InferiaGate equiv | Identity authority | Local org/user/team |
+|---|---|---|---|
+| `local` (open-source) | `primitive` | InferiaLLM's own user/password (basic auth) | **active** |
+| `oidc` (enterprise self-hosted) | `oidc` | the enterprise's **own** OIDC IdP | hidden (IdP owns it) |
+| `inferiaauth` (SaaS) | `inferiaauth` | **InferiaAuth** (`auth.inferia.ai`) | hidden (InferiaAuth owns it) |
+
+A user hits InferiaLLM, is redirected to the IdP's hosted login (InferiaAuth in
+SaaS), signs in, and is redirected back with a session. In `oidc`/`inferiaauth`
+modes, **Organization / User / Team management is owned by the IdP**, not by
+InferiaLLM.
+
+## Current state (what already exists)
+
+InferiaLLM already has a substantial InferiaAuth integration under a single
+`AUTH_PROVIDER=external` value (built per `docs/specs|plans/2026-05-23-inferia-auth-sso-integration.md`):
+
+- **Redirect-SSO**: `rbac/oauth_router.py` (`/auth/start` PKCE → `inferia-auth/oauth/authorize`; `/auth/callback` → exchange code → hand token to dashboard via `/#access_token=`).
+- **Token verification**: `rbac/jwks_verifier.py` (verify InferiaAuth EdDSA JWTs via cached JWKS).
+- **Request auth**: `rbac/middleware.py` (`AUTH_PROVIDER=external` → try local JWT, fall back to JWKS-verify → shadow user → **roles/permissions straight from the token claims**).
+- **Shadow users**: `rbac/shadow_user.py` (provision a local FK-anchor user on first external login).
+- **Dashboard**: `apps/dashboard/src/services/authService.ts`, `hooks/useTokenFragmentConsumer.ts`, `pages/Login.tsx`.
+- **Topology**: `deploy/docker-compose.sso.yml` (`make docker-up-sso`) — InferiaLLM + InferiaAuth + Caddy.
+- **Permissions are HARDCODED in InferiaAuth**: `inferia-auth/cmd/server/seed.go` `inferiallmPermissions` map (the "v1 source of truth") + the `inferiallm-dashboard` OAuth client.
+
+So `local` and (one) `external` mode exist; the gaps are: (1) `external` conflates
+the two external modes, (2) the catalog is hardcoded in InferiaAuth, (3) local
+org/user/team is not hidden in external modes.
+
+## Target architecture
+
+### 1. Three explicit modes (`AUTH_PROVIDER: local | oidc | inferiaauth`)
+
+`config.py`: change `auth_provider: Literal["local","external"]` →
+`Literal["local","oidc","inferiaauth"]`. Backward-compat: accept `external` as a
+deprecated alias mapping to `inferiaauth` (log a deprecation warning) so the
+existing `docker-compose.sso.yml` keeps working until updated.
+
+Validation (`config.py` model validator):
+- `inferiaauth` requires `EXTERNAL_AUTH_URL`, `EXTERNAL_AUTH_ISSUER`, `OAUTH_CLIENT_ID`, `OAUTH_REDIRECT_URI` (today's "external" rule).
+- `oidc` requires the same OIDC discovery inputs (issuer, client id, redirect) but **no** InferiaAuth-specific catalog/gRPC.
+- `local` requires none.
+
+`rbac/middleware.py` — branch the request-auth path on mode:
+- `local`: `_resolve_local_token` only (today's behavior).
+- `inferiaauth`: try local (superadmin recovery) → `_resolve_external_token` (JWKS verify; **permissions/roles from the `permissions`/`roles` claims** — InferiaAuth-issued, catalog-backed).
+- `oidc`: try local (superadmin) → `_resolve_oidc_token` (JWKS verify against the enterprise IdP; **no catalog claim** — derive role from a configurable group/role claim mapping; default "authenticated ⇒ admin of the shadow org", matching InferiaGate's documented `oidc` posture, with `OIDC_GROUPS_CLAIM` → role map as a follow-up).
+
+`rbac/oauth_router.py`/`config.py`: `_require_external_mode()` → `_require_redirect_sso_mode()` (true for `oidc` **or** `inferiaauth`); the `/auth/start` + `/auth/callback` flow is identical for both (standard OIDC code+PKCE).
+
+### 2. Catalog self-declaration (InferiaLLM owns its permission/role catalog)
+
+**InferiaLLM defines the catalog** (new module `rbac/catalog.py`) — the contract
+of every `inferiallm:<resource>:<action>` permission + the roles that bundle
+them, mirroring InferiaGate's `internal/identity/catalog/catalog.go`:
+
+- Permissions (the v1 set, taken from InferiaAuth's current hardcoded map):
+  `inferiallm:deployment:{read,write,delete}`, `inferiallm:provider:{read,write}`,
+  `inferiallm:user:{read,write}`, `inferiallm:org:{read,write}`,
+  `inferiallm:audit:read`, `inferiallm:apikey:{read,write}`,
+  `inferiallm:model:{read,write}`.
+- Roles: `admin` (all), `operator` (writes for deployment/provider/model + reads), `viewer` (all `:read`). Each role validated to reference only declared permission keys.
+- Each permission has `key`, `display_name`, `description` (the InferiaAuth `PUT /api/v1/services/:id/catalog` body shape — see `inferia-auth/internal/transport/rest/handler/catalog.go`).
+
+**InferiaLLM declares it at boot** (new `rbac/catalog_declare.py`, called from
+`app.py` startup when `auth_provider == "inferiaauth"`): `PUT
+{EXTERNAL_AUTH_URL}/api/v1/services/inferiallm/catalog` with a short-lived
+catalog-admin token (same mechanism InferiaGate uses — `CATALOG_ADMIN_TOKEN` /
+the catalog declare flow). Idempotent; performs shrink reconciliation on the
+InferiaAuth side. A `catalog declare failed` boot warning is non-fatal (the
+catalog persists in InferiaAuth across restarts).
+
+**InferiaAuth stops hardcoding** (`inferia-auth/cmd/server/seed.go`): remove the
+`inferiallmPermissions` map + its FGA seed. Keep seeding the `inferiallm-dashboard`
+OAuth **client** row (client registration is still InferiaAuth's job, like
+`svc_inferiagate`). The FGA permission tree for `inferiallm` is now created by
+the catalog declare call (the same `SeedApp`/`SeedTemplates` path the catalog
+handler already uses for InferiaGate).
+
+> The local `PermissionEnum` (`member:list`, `role:update`, …) governs **local
+> mode** RBAC and stays. The declared `inferiallm:*` catalog is what InferiaAuth
+> issues in the `permissions` claim and what the middleware enforces in
+> `inferiaauth` mode. A small mapping (`rbac/permissions.py`) bridges the two
+> where a route is gated in both modes.
+
+### 3. Hide local org/user/team in external modes (mirror InferiaGate SaaS)
+
+When `auth_provider in {oidc, inferiaauth}`, the IdP owns identity, so:
+- **Backend**: gate the local management routes — `management/organizations.py`,
+  `management/users.py`, `rbac/users_router.py`, and the role-management routes —
+  to return `409 Conflict` / a redirect-to-IdP message (a `require_local_identity`
+  dependency that 409s in external modes). The `auth_service.create_access_token`
+  password-login path (`/auth/login`, `/auth/register`) is also gated off in
+  external modes (superadmin recovery login stays).
+- **Dashboard**: hide the Settings → Organization / Users & Teams / Roles
+  surfaces when `VITE_AUTH_PROVIDER` ∈ {oidc, inferiaauth}; mirror InferiaGate's
+  `hideInTiers`/runtime-mode detection. Shadow users + org-scoping FK anchors stay.
+- **Local mode**: everything stays fully active (open-source self-serve).
+
+## Cross-repo change summary
+
+**InferiaLLM** (`package/src/inferia/services/api_gateway/`):
+- `config.py` — 3-mode enum + per-mode validation + `external` back-compat alias.
+- `rbac/catalog.py` (new) — the permission/role catalog.
+- `rbac/catalog_declare.py` (new) — boot-time `PUT …/services/inferiallm/catalog`.
+- `app.py` — call catalog-declare on startup (inferiaauth mode); branch middleware/router wiring per mode.
+- `rbac/middleware.py` — 3-way branch; add `_resolve_oidc_token`.
+- `rbac/oauth_router.py` — `_require_redirect_sso_mode` (oidc|inferiaauth).
+- `management/*.py`, `rbac/users_router.py` — `require_local_identity` gate.
+- `apps/dashboard/src/**` — hide identity surfaces in external modes.
+
+**InferiaAuth** (`inferia-auth/`):
+- `cmd/server/seed.go` — remove the hardcoded `inferiallmPermissions` FGA seed; keep the `inferiallm-dashboard` OAuth client seed.
+
+## Security posture
+- Fail-closed: unknown mode → boot error; external token verify failure → 401.
+- Catalog-admin token for declare is short-lived (~900s), same as InferiaGate.
+- Superadmin local recovery (`SUPERADMIN_EMAIL/PASSWORD`) works in all modes.
+- No secrets in git; dev values in `docker-compose.sso.yml` are DEV-ONLY.
+
+## Out of scope / deferred
+- Fine-grained `OIDC_GROUPS_CLAIM` → role mapping for the generic `oidc` mode (Phase: start with "authenticated ⇒ admin of shadow org", same interim as InferiaGate's oidc mode).
+- Per-org data-plane scoping changes beyond what shadow users already provide.
+- Migrating existing local users to InferiaAuth (data migration is a separate effort).
+
+## References
+- InferiaGate catalog: `../InferiaGate/internal/identity/catalog/catalog.go` + `declare.go`.
+- InferiaAuth catalog API: `../inferiaauth/internal/transport/rest/handler/catalog.go`.
+- Prior SSO work: `docs/specs|plans/2026-05-23-inferia-auth-sso-integration.md`.
+- InferiaGate three-mode model: `../InferiaGate/CLAUDE.md`.

--- a/package/src/inferia/services/api_gateway/app.py
+++ b/package/src/inferia/services/api_gateway/app.py
@@ -59,12 +59,12 @@ logger = setup_logging(
 async def _maybe_declare_catalog() -> None:
     """Best-effort catalog declaration to InferiaAuth on startup.
 
-    Runs only when auth_provider=="external", external_auth_url, and
+    Runs only when auth_provider=="inferiaauth", external_auth_url, and
     catalog_admin_token are all set.  Any failure is logged and swallowed —
     a catalog declare failure must never crash boot.
     """
     if (
-        settings.auth_provider == "external"
+        settings.auth_provider == "inferiaauth"
         and settings.external_auth_url
         and settings.catalog_admin_token
     ):
@@ -101,7 +101,7 @@ async def lifespan(app: FastAPI):
     await config_manager.initialize()
     config_manager.start_polling()
 
-    if settings.auth_provider == "external" and settings.external_auth_url:
+    if settings.is_external_mode and settings.external_auth_url:
         logger.info(f"External auth enabled via: {settings.external_auth_url}")
 
     # Declare catalog to InferiaAuth (best-effort, never raises)
@@ -118,7 +118,7 @@ async def lifespan(app: FastAPI):
     await gateway_http_client.close_all()
     await rate_limiter.close()
 
-    if settings.auth_provider == "external":
+    if settings.is_external_mode:
         from inferia.services.api_gateway.rbac.external_auth import close_client
         await close_client()
 

--- a/package/src/inferia/services/api_gateway/app.py
+++ b/package/src/inferia/services/api_gateway/app.py
@@ -56,6 +56,28 @@ logger = setup_logging(
 )
 
 
+async def _maybe_declare_catalog() -> None:
+    """Best-effort catalog declaration to InferiaAuth on startup.
+
+    Runs only when auth_provider=="external", external_auth_url, and
+    catalog_admin_token are all set.  Any failure is logged and swallowed —
+    a catalog declare failure must never crash boot.
+    """
+    if (
+        settings.auth_provider == "external"
+        and settings.external_auth_url
+        and settings.catalog_admin_token
+    ):
+        from inferia.services.api_gateway.rbac.catalog_declare import declare_catalog
+        ok = await declare_catalog(settings.external_auth_url, settings.catalog_admin_token)
+        if ok:
+            logger.info("Declared InferiaLLM catalog to InferiaAuth")
+        else:
+            logger.warning(
+                "Catalog declare to InferiaAuth failed (non-fatal; will retry next boot)"
+            )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown events."""
@@ -81,6 +103,9 @@ async def lifespan(app: FastAPI):
 
     if settings.auth_provider == "external" and settings.external_auth_url:
         logger.info(f"External auth enabled via: {settings.external_auth_url}")
+
+    # Declare catalog to InferiaAuth (best-effort, never raises)
+    await _maybe_declare_catalog()
 
     yield
     # Shutdown

--- a/package/src/inferia/services/api_gateway/config.py
+++ b/package/src/inferia/services/api_gateway/config.py
@@ -211,6 +211,23 @@ class Settings(UnifiedBaseSettings):
         validation_alias="CATALOG_ADMIN_TOKEN",
         description="Short-lived bearer token authorized to declare InferiaLLM's catalog to InferiaAuth.",
     )
+    oidc_groups_claim: str = Field(
+        default="groups",
+        validation_alias="OIDC_GROUPS_CLAIM",
+        description="JWT claim listing the user's IdP groups (oidc mode).",
+    )
+    oidc_role_map: dict[str, str] = Field(
+        default_factory=dict,
+        validation_alias="OIDC_ROLE_MAP",
+        description="Map of IdP group name -> InferiaLLM catalog role (admin|member|viewer). "
+                    "Empty = interim 'authenticated => admin'. Set via JSON, e.g. "
+                    '{"llm-admins":"admin","llm-users":"viewer"}.',
+    )
+    oidc_default_role: str = Field(
+        default="viewer",
+        validation_alias="OIDC_DEFAULT_ROLE",
+        description="Role assigned when no group matches oidc_role_map (oidc mode).",
+    )
 
     # Superadmin credentials - MUST be set via environment variables in production
     superadmin_email: Optional[str] = Field(default=None, validation_alias="SUPERADMIN_EMAIL")

--- a/package/src/inferia/services/api_gateway/config.py
+++ b/package/src/inferia/services/api_gateway/config.py
@@ -5,6 +5,7 @@ Uses Pydantic Settings for environment-based configuration.
 
 from typing import ClassVar, Literal, Optional, Any, Dict, List
 import logging
+import warnings
 from pydantic import Field, BaseModel, field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 from inferia.common.unified_config import UnifiedBaseSettings
@@ -155,11 +156,24 @@ class Settings(UnifiedBaseSettings):
     default_org_name: str = "Default Organization"
 
     # External Auth Provider (inferia-auth)
-    # Set to "external" to delegate authentication to inferia-auth service.
+    # Set to "inferiaauth" (SaaS) or "oidc" (enterprise self-hosted OIDC) to
+    # delegate authentication to an external IdP.
+    # "external" is accepted as a deprecated alias for "inferiaauth".
     # Superadmin login always works locally regardless of this setting.
-    auth_provider: Literal["local", "external"] = Field(
+    auth_provider: Literal["local", "oidc", "inferiaauth"] = Field(
         default="local", validation_alias="AUTH_PROVIDER"
     )
+
+    @field_validator("auth_provider", mode="before")
+    @classmethod
+    def _coerce_external_alias(cls, v: Any) -> Any:
+        """Map legacy AUTH_PROVIDER=external to inferiaauth with a deprecation warning."""
+        if v == "external":
+            msg = "AUTH_PROVIDER=external is deprecated; use 'inferiaauth'"
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            logger.warning(msg)
+            return "inferiaauth"
+        return v
     external_auth_url: Optional[str] = Field(
         default=None,
         validation_alias="EXTERNAL_AUTH_URL",
@@ -299,19 +313,28 @@ class Settings(UnifiedBaseSettings):
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+        populate_by_name=True,
     )
 
     _PLACEHOLDER_JWT_SECRET = "placeholder-secret-key-at-least-32-chars-long"
 
+    @property
+    def is_external_mode(self) -> bool:
+        """True when auth is delegated to an external IdP (oidc or inferiaauth)."""
+        return self.auth_provider in ("oidc", "inferiaauth")
+
     @model_validator(mode="after")
     def _validate_external_auth_complete(self):
-        """When AUTH_PROVIDER=external, the four external auth fields are mandatory.
+        """When AUTH_PROVIDER is oidc or inferiaauth, the four external auth fields are mandatory.
 
         Raises a single ValueError that lists every missing env var so operators
         can fix the config in one pass instead of guess-and-restart.
         """
-        if self.auth_provider == "external":
+        if self.is_external_mode:
             required = {
                 "EXTERNAL_AUTH_URL": self.external_auth_url,
                 "EXTERNAL_AUTH_ISSUER": self.external_auth_issuer,
@@ -321,7 +344,7 @@ class Settings(UnifiedBaseSettings):
             missing = [name for name, value in required.items() if not value]
             if missing:
                 raise ValueError(
-                    f"AUTH_PROVIDER=external requires: {', '.join(missing)}"
+                    f"AUTH_PROVIDER={self.auth_provider} requires: {', '.join(missing)}"
                 )
         return self
 

--- a/package/src/inferia/services/api_gateway/config.py
+++ b/package/src/inferia/services/api_gateway/config.py
@@ -192,6 +192,11 @@ class Settings(UnifiedBaseSettings):
         le=86400,
         description="JWKS cache lifetime in seconds (60–86400)",
     )
+    catalog_admin_token: Optional[str] = Field(
+        default=None,
+        validation_alias="CATALOG_ADMIN_TOKEN",
+        description="Short-lived bearer token authorized to declare InferiaLLM's catalog to InferiaAuth.",
+    )
 
     # Superadmin credentials - MUST be set via environment variables in production
     superadmin_email: Optional[str] = Field(default=None, validation_alias="SUPERADMIN_EMAIL")

--- a/package/src/inferia/services/api_gateway/management/organizations.py
+++ b/package/src/inferia/services/api_gateway/management/organizations.py
@@ -26,6 +26,7 @@ from inferia.services.api_gateway.rbac.authorization import authz_service
 from datetime import datetime, timedelta, timezone
 from inferia.services.api_gateway.audit.service import audit_service
 from inferia.services.api_gateway.models import AuditLogCreate
+from inferia.services.api_gateway.rbac.local_identity_guard import require_local_identity
 
 
 def utcnow_naive():
@@ -35,7 +36,7 @@ def build_invite_link_path(token: str) -> str:
     return f"/auth/accept-invite?token={token}"
 
 
-router = APIRouter(tags=["Organizations"])
+router = APIRouter(tags=["Organizations"], dependencies=[Depends(require_local_identity)])
 
 
 @router.post("/organizations", response_model=OrganizationResponse, status_code=201)

--- a/package/src/inferia/services/api_gateway/management/users.py
+++ b/package/src/inferia/services/api_gateway/management/users.py
@@ -12,8 +12,9 @@ from inferia.services.api_gateway.rbac.auth import auth_service
 from inferia.services.api_gateway.rbac.authorization import authz_service
 from inferia.services.api_gateway.audit.service import audit_service
 from inferia.services.api_gateway.models import AuditLogCreate
+from inferia.services.api_gateway.rbac.local_identity_guard import require_local_identity
 
-router = APIRouter(tags=["Users"])
+router = APIRouter(tags=["Users"], dependencies=[Depends(require_local_identity)])
 
 
 @router.post("/users", response_model=UserResponse, status_code=201)

--- a/package/src/inferia/services/api_gateway/rbac/catalog.py
+++ b/package/src/inferia/services/api_gateway/rbac/catalog.py
@@ -1,0 +1,212 @@
+"""
+InferiaLLM permission/role catalog.
+
+Defines the canonical set of permissions and roles that InferiaLLM self-declares
+to InferiaAuth via PUT /api/v1/services/:id/catalog. This module contains only
+pure data — no HTTP client, no config, no app wiring. Those concerns live in
+later boot-time tasks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Permission:
+    """A single declared permission entry."""
+
+    key: str
+    display_name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class Role:
+    """A catalog role with an ordered tuple of permission keys it grants."""
+
+    name: str
+    permissions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Catalog:
+    """Immutable snapshot of all permissions and roles declared by this service."""
+
+    permissions: tuple[Permission, ...]
+    roles: tuple[Role, ...]
+
+
+# ---------------------------------------------------------------------------
+# Permission definitions — key format: inferiallm:<resource>:<action>
+# Colon-form matches InferiaAuth's catalog key convention.
+# ---------------------------------------------------------------------------
+
+_PERMISSIONS: tuple[Permission, ...] = (
+    Permission(
+        key="inferiallm:deployment:read",
+        display_name="View deployments",
+        description="View model deployments and their status",
+    ),
+    Permission(
+        key="inferiallm:deployment:write",
+        display_name="Manage deployments",
+        description="Create, update, and scale model deployments",
+    ),
+    Permission(
+        key="inferiallm:deployment:delete",
+        display_name="Delete deployments",
+        description="Tear down model deployments",
+    ),
+    Permission(
+        key="inferiallm:provider:read",
+        display_name="View providers",
+        description="View compute and model providers",
+    ),
+    Permission(
+        key="inferiallm:provider:write",
+        display_name="Manage providers",
+        description="Configure compute and model providers",
+    ),
+    Permission(
+        key="inferiallm:user:read",
+        display_name="View users",
+        description="View users in the organization",
+    ),
+    Permission(
+        key="inferiallm:user:write",
+        display_name="Manage users",
+        description="Invite, edit, and remove users",
+    ),
+    Permission(
+        key="inferiallm:org:read",
+        display_name="View organization",
+        description="View organization settings",
+    ),
+    Permission(
+        key="inferiallm:org:write",
+        display_name="Manage organization",
+        description="Edit organization settings",
+    ),
+    Permission(
+        key="inferiallm:audit:read",
+        display_name="View audit log",
+        description="View the administrative audit log",
+    ),
+    Permission(
+        key="inferiallm:apikey:read",
+        display_name="View API keys",
+        description="View API key metadata",
+    ),
+    Permission(
+        key="inferiallm:apikey:write",
+        display_name="Manage API keys",
+        description="Create and revoke API keys",
+    ),
+    Permission(
+        key="inferiallm:model:read",
+        display_name="View models",
+        description="View the model catalog",
+    ),
+    Permission(
+        key="inferiallm:model:write",
+        display_name="Manage models",
+        description="Add and configure models",
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Role definitions
+# ---------------------------------------------------------------------------
+
+_ROLES: tuple[Role, ...] = (
+    # admin — full access to every declared permission
+    Role(
+        name="admin",
+        permissions=tuple(p.key for p in _PERMISSIONS),
+    ),
+    # member — read-only access to core resources + API key read
+    Role(
+        name="member",
+        permissions=(
+            "inferiallm:deployment:read",
+            "inferiallm:provider:read",
+            "inferiallm:user:read",
+            "inferiallm:org:read",
+            "inferiallm:model:read",
+            "inferiallm:apikey:read",
+        ),
+    ),
+    # viewer — minimal read-only surface
+    Role(
+        name="viewer",
+        permissions=(
+            "inferiallm:deployment:read",
+            "inferiallm:provider:read",
+            "inferiallm:model:read",
+        ),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Module-level catalog constant
+# ---------------------------------------------------------------------------
+
+CATALOG: Catalog = Catalog(permissions=_PERMISSIONS, roles=_ROLES)
+
+# ---------------------------------------------------------------------------
+# Module-load integrity check — fail fast on any typo in role permission keys
+# ---------------------------------------------------------------------------
+
+_declared_keys: frozenset[str] = frozenset(p.key for p in CATALOG.permissions)
+for _role in CATALOG.roles:
+    for _key in _role.permissions:
+        if _key not in _declared_keys:
+            raise ValueError(
+                f"Catalog integrity error: role '{_role.name}' references "
+                f"undeclared permission key '{_key}'. "
+                "Add it to _PERMISSIONS or fix the typo."
+            )
+del _declared_keys, _role, _key  # clean up module namespace
+
+
+# ---------------------------------------------------------------------------
+# Projection to InferiaAuth declare-request body
+# ---------------------------------------------------------------------------
+
+
+def to_declare_request(catalog: Catalog) -> dict:
+    """
+    Project a Catalog into the JSON body expected by InferiaAuth's
+    PUT /api/v1/services/:id/catalog endpoint.
+
+    Returns a plain dict ready for ``json.dumps`` or an httpx/requests call:
+
+        {
+            "permissions": [
+                {"key": "...", "display_name": "...", "description": "..."},
+                ...
+            ],
+            "roles": [
+                {"name": "...", "permissions": ["...", ...]},
+                ...
+            ],
+        }
+    """
+    return {
+        "permissions": [
+            {
+                "key": p.key,
+                "display_name": p.display_name,
+                "description": p.description,
+            }
+            for p in catalog.permissions
+        ],
+        "roles": [
+            {
+                "name": r.name,
+                "permissions": list(r.permissions),
+            }
+            for r in catalog.roles
+        ],
+    }

--- a/package/src/inferia/services/api_gateway/rbac/catalog_declare.py
+++ b/package/src/inferia/services/api_gateway/rbac/catalog_declare.py
@@ -1,0 +1,110 @@
+"""Async HTTP client that declares InferiaLLM's catalog to InferiaAuth.
+
+Issues a single ``PUT /api/v1/services/inferiallm/catalog`` request to the
+central auth service with a short-lived admin token.  The call is best-effort:
+on any transient failure (network error, timeout, 4xx/5xx) it returns ``False``
+and logs a warning rather than raising, so startup is never blocked by catalog
+declaration failures.
+
+Usage (later task wires this into app startup)::
+
+    ok = await declare_catalog(settings.auth_base_url, admin_token)
+
+Return-shape contract:
+  * Returns ``True`` on any 2xx response.
+  * Returns ``False`` (NO raise) on 4xx / 5xx, network errors, or timeouts.
+  * Returns ``False`` immediately (NO request) when inputs fail basic guards.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import httpx
+
+from inferia.services.api_gateway.rbac.catalog import CATALOG, to_declare_request
+
+logger = logging.getLogger(__name__)
+
+_MAX_ADMIN_TOKEN_LEN = 8192
+_DECLARE_TIMEOUT = 30.0
+_SERVICE_ID = "inferiallm"
+
+
+async def declare_catalog(
+    base_url: str,
+    admin_token: str,
+    *,
+    client: Optional[httpx.AsyncClient] = None,
+) -> bool:
+    """PUT InferiaLLM's catalog to InferiaAuth.
+
+    Args:
+        base_url: Base URL of the InferiaAuth service (trailing slash stripped).
+        admin_token: Short-lived admin bearer token issued by InferiaAuth for
+            catalog declaration.
+        client: Optional shared ``httpx.AsyncClient``.  When provided it is
+            used as-is and will NOT be closed by this function.  When omitted
+            a temporary client is created and closed after the request.
+
+    Returns:
+        ``True`` on a 2xx response, ``False`` on any failure.
+    """
+    # ------------------------------------------------------------------
+    # Input guards — fail fast without touching the network
+    # ------------------------------------------------------------------
+    if not base_url:
+        logger.warning("declare_catalog: base_url is empty; skipping declaration")
+        return False
+
+    if not admin_token:
+        logger.warning("declare_catalog: admin_token is empty; skipping declaration")
+        return False
+
+    if len(admin_token) > _MAX_ADMIN_TOKEN_LEN:
+        logger.warning(
+            "declare_catalog: admin_token exceeds %d chars; skipping declaration",
+            _MAX_ADMIN_TOKEN_LEN,
+        )
+        return False
+
+    url = f"{base_url.rstrip('/')}/api/v1/services/{_SERVICE_ID}/catalog"
+    body = to_declare_request(CATALOG)
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # ------------------------------------------------------------------
+    # Issue the request
+    # ------------------------------------------------------------------
+    _owned_client: Optional[httpx.AsyncClient] = None
+    if client is None:
+        _owned_client = httpx.AsyncClient(timeout=_DECLARE_TIMEOUT)
+        client = _owned_client
+
+    try:
+        resp = await client.put(url, json=body, headers=headers, timeout=_DECLARE_TIMEOUT)
+    except httpx.TimeoutException as exc:
+        logger.warning(
+            "declare_catalog: request timed out (%s); catalog not declared",
+            type(exc).__name__,
+        )
+        return False
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "declare_catalog: network error (%s: %s); catalog not declared",
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    finally:
+        if _owned_client is not None:
+            await _owned_client.aclose()
+
+    if resp.is_success:
+        return True
+
+    logger.warning(
+        "declare_catalog: InferiaAuth returned %d; catalog not declared",
+        resp.status_code,
+    )
+    return False

--- a/package/src/inferia/services/api_gateway/rbac/local_identity_guard.py
+++ b/package/src/inferia/services/api_gateway/rbac/local_identity_guard.py
@@ -1,0 +1,19 @@
+from fastapi import HTTPException, status
+from inferia.services.api_gateway.config import settings
+
+
+def require_local_identity() -> None:
+    """Block local org/user/team/role management when an external IdP owns identity.
+
+    In oidc/inferiaauth modes these resources are managed by the IdP
+    (InferiaAuth or the enterprise's own OIDC), so InferiaLLM returns 409.
+    A no-op in local mode.
+    """
+    if settings.is_external_mode:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Organization, user, and team management is handled by your "
+                "identity provider in this deployment mode."
+            ),
+        )

--- a/package/src/inferia/services/api_gateway/rbac/middleware.py
+++ b/package/src/inferia/services/api_gateway/rbac/middleware.py
@@ -135,12 +135,25 @@ async def _resolve_external_token(db, token: str) -> UserContext:
     )
 
 
-async def _resolve_oidc_token(db, token: str) -> UserContext:
-    """Verify a generic enterprise OIDC token (no InferiaLLM catalog claim).
+def _catalog_role_permissions(role_name: str) -> list[str]:
+    """Return the permission keys for a catalog role, or [] for unknown roles (fail-closed)."""
+    from inferia.services.api_gateway.rbac.catalog import CATALOG
 
-    Interim: an authenticated user is treated as admin of their shadow org —
-    same posture as InferiaGate's oidc mode. A later task maps OIDC group
-    claims to roles.
+    for r in CATALOG.roles:
+        if r.name == role_name:
+            return list(r.permissions)
+    return []  # unknown role -> no permissions (fail-closed)
+
+
+async def _resolve_oidc_token(db, token: str) -> UserContext:
+    """Verify a generic enterprise OIDC token and build a UserContext.
+
+    When oidc_role_map is empty (the default), every authenticated user
+    becomes admin of their shadow org — the same interim posture as before.
+
+    When oidc_role_map is configured, the user's IdP groups (read from the
+    claim named by oidc_groups_claim) are matched against the map; the first
+    matching group wins. If no group matches, oidc_default_role is used.
     """
     try:
         claims = _get_verifier().verify_sync(token)
@@ -165,18 +178,26 @@ async def _resolve_oidc_token(db, token: str) -> UserContext:
         org_ids = claims.get("org_ids") or []
         org_id = org_ids[0] if org_ids else None
 
-    # Interim: admin gets the full inferiallm catalog permission set.
-    from inferia.services.api_gateway.rbac.catalog import CATALOG
+    role_map = settings.oidc_role_map or {}
+    if not role_map:
+        # Interim default (unchanged): authenticated => admin of the shadow org.
+        role = "admin"
+    else:
+        groups = claims.get(settings.oidc_groups_claim) or []
+        if isinstance(groups, str):
+            groups = [groups]
+        role = next(
+            (role_map[g] for g in groups if g in role_map),
+            settings.oidc_default_role,
+        )
+    perms = _catalog_role_permissions(role)
 
-    admin_perms = [
-        p for r in CATALOG.roles if r.name == "admin" for p in r.permissions
-    ]
     return UserContext(
         user_id=user.id,
         username=user.email,
         email=user.email,
-        roles=["admin"],
-        permissions=admin_perms,
+        roles=[role],
+        permissions=perms,
         org_id=org_id,
         quota_limit=10000,
         quota_used=0,

--- a/package/src/inferia/services/api_gateway/rbac/middleware.py
+++ b/package/src/inferia/services/api_gateway/rbac/middleware.py
@@ -73,10 +73,17 @@ _verifier: Optional[JWKSVerifier] = None
 def _get_verifier() -> JWKSVerifier:
     global _verifier
     if _verifier is None:
+        # Generic OIDC IdPs issue tokens with aud = client_id, while
+        # InferiaAuth issues aud = app_namespace ("inferiallm").
+        audience = (
+            settings.oauth_client_id
+            if settings.auth_provider == "oidc"
+            else settings.app_namespace
+        )
         _verifier = JWKSVerifier(
             jwks_url=settings.external_auth_url.rstrip("/") + "/.well-known/jwks.json",
             issuer=settings.external_auth_issuer,
-            audience=settings.app_namespace,
+            audience=audience,
             cache_ttl=settings.oauth_jwks_cache_ttl_seconds,
         )
     return _verifier
@@ -128,14 +135,63 @@ async def _resolve_external_token(db, token: str) -> UserContext:
     )
 
 
+async def _resolve_oidc_token(db, token: str) -> UserContext:
+    """Verify a generic enterprise OIDC token (no InferiaLLM catalog claim).
+
+    Interim: an authenticated user is treated as admin of their shadow org —
+    same posture as InferiaGate's oidc mode. A later task maps OIDC group
+    claims to roles.
+    """
+    try:
+        claims = _get_verifier().verify_sync(token)
+    except JWKSVerifyError as e:
+        logger.info("OIDC token verification failed: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    sub = claims.get("sub", "")
+    external_user_id = sub.split(":", 1)[1] if ":" in sub else sub
+    email = claims.get("email", "")
+
+    user, _local_org_id, _local_roles = await get_or_create_shadow_user(
+        db, email=email, external_id=external_user_id
+    )
+
+    org_id = claims.get("org_id")
+    if not org_id:
+        org_ids = claims.get("org_ids") or []
+        org_id = org_ids[0] if org_ids else None
+
+    # Interim: admin gets the full inferiallm catalog permission set.
+    from inferia.services.api_gateway.rbac.catalog import CATALOG
+
+    admin_perms = [
+        p for r in CATALOG.roles if r.name == "admin" for p in r.permissions
+    ]
+    return UserContext(
+        user_id=user.id,
+        username=user.email,
+        email=user.email,
+        roles=["admin"],
+        permissions=admin_perms,
+        org_id=org_id,
+        quota_limit=10000,
+        quota_used=0,
+    )
+
+
 async def auth_middleware(request: Request, call_next):
     """
     Authentication middleware that validates JWT token and extracts user context.
     Adds user context to request.state if authenticated.
 
-    When AUTH_PROVIDER=external, tokens are validated in two steps:
-      1. Try local JWT decode (covers superadmin and locally-issued tokens).
-      2. If local decode fails, call inferia-auth introspect.
+    Auth branching per AUTH_PROVIDER:
+      - inferiaauth: try local (superadmin recovery), fall back to _resolve_external_token
+      - oidc:        try local (superadmin recovery), fall back to _resolve_oidc_token
+      - local:       _resolve_local_token only
     """
     # Skip auth for WebSocket connections - they handle auth differently (via query params)
     # Check both 'upgrade' header and the connection type
@@ -223,19 +279,22 @@ async def auth_middleware(request: Request, call_next):
     if cached is not None:
         request.state.user = cached
     else:
-        use_external = settings.auth_provider == "external" and settings.external_auth_url
+        mode = settings.auth_provider
 
         async with AsyncSessionLocal() as db:
             try:
-                if not use_external:
-                    # Pure local auth
-                    user_context = await _resolve_local_token(db, token)
-                else:
-                    # External mode: try local first (superadmin), fall back to external
+                if mode == "inferiaauth":
                     try:
-                        user_context = await _resolve_local_token(db, token)
+                        user_context = await _resolve_local_token(db, token)  # superadmin recovery
                     except HTTPException:
                         user_context = await _resolve_external_token(db, token)
+                elif mode == "oidc":
+                    try:
+                        user_context = await _resolve_local_token(db, token)  # superadmin recovery
+                    except HTTPException:
+                        user_context = await _resolve_oidc_token(db, token)
+                else:  # local
+                    user_context = await _resolve_local_token(db, token)
 
                 request.state.user = user_context
                 _auth_cache[token] = user_context

--- a/package/src/inferia/services/api_gateway/rbac/oauth_router.py
+++ b/package/src/inferia/services/api_gateway/rbac/oauth_router.py
@@ -63,10 +63,9 @@ def _pkce_challenge(verifier: str) -> str:
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
-def _require_external_mode() -> None:
+def _require_redirect_sso_mode() -> None:
     if (
-        settings.auth_provider != "external"
-        or not settings.external_auth_url
+        not settings.is_external_mode
         or not settings.oauth_client_id
         or not settings.oauth_redirect_uri
     ):
@@ -79,7 +78,7 @@ def _require_external_mode() -> None:
 @router.get("/auth/start")
 async def auth_start():
     """Kick off the OAuth2 PKCE flow and redirect to inferia-auth."""
-    _require_external_mode()
+    _require_redirect_sso_mode()
 
     verifier = secrets.token_urlsafe(64)
     challenge = _pkce_challenge(verifier)
@@ -122,7 +121,7 @@ async def auth_start():
 @router.get("/auth/callback")
 async def auth_callback(request: Request, code: str, state: str):
     """Exchange a one-time code for tokens, then redirect to dashboard."""
-    _require_external_mode()
+    _require_redirect_sso_mode()
 
     # Cheap input gates first, before any cookie inspection or network call.
     if not code or len(code) > _MAX_CODE_LEN:

--- a/package/src/inferia/services/api_gateway/rbac/roles_router.py
+++ b/package/src/inferia/services/api_gateway/rbac/roles_router.py
@@ -15,8 +15,9 @@ from inferia.services.api_gateway.models import (
 from .middleware import get_current_user_from_request
 from .authorization import authz_service
 from .permissions import normalize_permissions
+from .local_identity_guard import require_local_identity
 
-router = APIRouter(prefix="/admin/roles", tags=["RBAC Management"])
+router = APIRouter(prefix="/admin/roles", tags=["RBAC Management"], dependencies=[Depends(require_local_identity)])
 
 
 def _validate_permissions(permissions: list[str]) -> list[str]:

--- a/package/src/inferia/services/api_gateway/rbac/router.py
+++ b/package/src/inferia/services/api_gateway/rbac/router.py
@@ -25,6 +25,7 @@ from inferia.services.api_gateway.db.models import (
 )
 from inferia.services.api_gateway.models import OrganizationBasicInfo, SwitchOrgRequest, AuditLogCreate
 from inferia.services.api_gateway.audit.service import audit_service
+from inferia.services.api_gateway.rbac.local_identity_guard import require_local_identity
 from sqlalchemy.future import select
 from sqlalchemy import func
 import uuid
@@ -151,7 +152,7 @@ async def login(
     )
 
 
-@router.post("/register", response_model=AuthToken)
+@router.post("/register", response_model=AuthToken, dependencies=[Depends(require_local_identity)])
 async def register(reg_data: RegisterRequest, db: AsyncSession = Depends(get_db)):
     """
     Public registration is DISABLED.
@@ -163,7 +164,7 @@ async def register(reg_data: RegisterRequest, db: AsyncSession = Depends(get_db)
     )
 
 
-@router.post("/register-invite", response_model=AuthToken)
+@router.post("/register-invite", response_model=AuthToken, dependencies=[Depends(require_local_identity)])
 async def register_invite(
     reg_data: RegisterInviteRequest,
     http_request: Request,

--- a/package/src/inferia/services/api_gateway/rbac/users_router.py
+++ b/package/src/inferia/services/api_gateway/rbac/users_router.py
@@ -12,10 +12,11 @@ from inferia.services.api_gateway.models import (
 )  # existing in models.py
 from .middleware import get_current_user_from_request
 from .authorization import authz_service
+from .local_identity_guard import require_local_identity
 
 from pydantic import BaseModel
 
-router = APIRouter(prefix="/admin/users", tags=["User Management"])
+router = APIRouter(prefix="/admin/users", tags=["User Management"], dependencies=[Depends(require_local_identity)])
 
 
 class UserRoleUpdate(BaseModel):

--- a/package/src/inferia/services/api_gateway/tests/test_app_startup_catalog.py
+++ b/package/src/inferia/services/api_gateway/tests/test_app_startup_catalog.py
@@ -1,0 +1,105 @@
+"""Tests for catalog declaration wired into app startup lifespan.
+
+app.py has heavy transitive imports (websockets, jwt 1.3.1 conflict, DB drivers).
+We stub out the modules that cause ImportError before importing appmod, so the
+tests run without a full environment.  Only _maybe_declare_catalog and settings
+are exercised here.
+"""
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+# ---------------------------------------------------------------------------
+# Path fix: pyenv PyJWT must shadow the conflicting jwt 1.3.1 at ~/.local/lib
+# ---------------------------------------------------------------------------
+_PYENV_SITE = "/home/celestix/.pyenv/versions/3.12.9/lib/python3.12/site-packages"
+_LOCAL_SITE = "/home/celestix/.local/lib/python3.12/site-packages"
+sys.path = [_PYENV_SITE] + [p for p in sys.path if p != _LOCAL_SITE and p != _PYENV_SITE]
+
+# ---------------------------------------------------------------------------
+# Stub modules that are not installed in the test environment
+# ---------------------------------------------------------------------------
+def _stub(name: str, **attrs) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__dict__.update(attrs)
+    return mod
+
+
+def _ensure_stub(name: str, **attrs) -> None:
+    """Insert a stub only if the real module isn't importable."""
+    if name not in sys.modules:
+        sys.modules[name] = _stub(name, **attrs)
+
+
+# websockets (not installed in test env)
+_ensure_stub("websockets")
+_ensure_stub("websockets.exceptions")
+
+# asyncpg / SQLAlchemy drivers that may not be present
+_ensure_stub("asyncpg")
+
+# ---------------------------------------------------------------------------
+# Now import appmod — all heavy transitive deps are either real or stubbed
+# ---------------------------------------------------------------------------
+import pytest  # noqa: E402
+import inferia.services.api_gateway.app as appmod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_declares_in_external_mode(monkeypatch):
+    monkeypatch.setattr(appmod.settings, "auth_provider", "external")
+    monkeypatch.setattr(appmod.settings, "external_auth_url", "https://auth.example.com")
+    monkeypatch.setattr(appmod.settings, "catalog_admin_token", "tok")
+    mock = AsyncMock(return_value=True)
+    monkeypatch.setattr("inferia.services.api_gateway.rbac.catalog_declare.declare_catalog", mock)
+    await appmod._maybe_declare_catalog()
+    mock.assert_awaited_once_with("https://auth.example.com", "tok")
+
+
+@pytest.mark.asyncio
+async def test_no_declare_in_local_mode(monkeypatch):
+    monkeypatch.setattr(appmod.settings, "auth_provider", "local")
+    mock = AsyncMock(return_value=True)
+    monkeypatch.setattr("inferia.services.api_gateway.rbac.catalog_declare.declare_catalog", mock)
+    await appmod._maybe_declare_catalog()
+    mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_declare_without_token(monkeypatch):
+    monkeypatch.setattr(appmod.settings, "auth_provider", "external")
+    monkeypatch.setattr(appmod.settings, "external_auth_url", "https://auth.example.com")
+    monkeypatch.setattr(appmod.settings, "catalog_admin_token", None)
+    mock = AsyncMock(return_value=True)
+    monkeypatch.setattr("inferia.services.api_gateway.rbac.catalog_declare.declare_catalog", mock)
+    await appmod._maybe_declare_catalog()
+    mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_declare_without_external_auth_url(monkeypatch):
+    monkeypatch.setattr(appmod.settings, "auth_provider", "external")
+    monkeypatch.setattr(appmod.settings, "external_auth_url", None)
+    monkeypatch.setattr(appmod.settings, "catalog_admin_token", "tok")
+    mock = AsyncMock(return_value=True)
+    monkeypatch.setattr("inferia.services.api_gateway.rbac.catalog_declare.declare_catalog", mock)
+    await appmod._maybe_declare_catalog()
+    mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_declare_failure_is_non_fatal(monkeypatch):
+    """A False return from declare_catalog must not raise."""
+    monkeypatch.setattr(appmod.settings, "auth_provider", "external")
+    monkeypatch.setattr(appmod.settings, "external_auth_url", "https://auth.example.com")
+    monkeypatch.setattr(appmod.settings, "catalog_admin_token", "tok")
+    mock = AsyncMock(return_value=False)
+    monkeypatch.setattr("inferia.services.api_gateway.rbac.catalog_declare.declare_catalog", mock)
+    # Must complete without raising
+    await appmod._maybe_declare_catalog()
+    mock.assert_awaited_once_with("https://auth.example.com", "tok")

--- a/package/src/inferia/services/api_gateway/tests/test_app_startup_catalog.py
+++ b/package/src/inferia/services/api_gateway/tests/test_app_startup_catalog.py
@@ -51,8 +51,8 @@ import inferia.services.api_gateway.app as appmod  # noqa: E402
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_declares_in_external_mode(monkeypatch):
-    monkeypatch.setattr(appmod.settings, "auth_provider", "external")
+async def test_declares_in_inferiaauth_mode(monkeypatch):
+    monkeypatch.setattr(appmod.settings, "auth_provider", "inferiaauth")
     monkeypatch.setattr(appmod.settings, "external_auth_url", "https://auth.example.com")
     monkeypatch.setattr(appmod.settings, "catalog_admin_token", "tok")
     mock = AsyncMock(return_value=True)
@@ -72,7 +72,7 @@ async def test_no_declare_in_local_mode(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_no_declare_without_token(monkeypatch):
-    monkeypatch.setattr(appmod.settings, "auth_provider", "external")
+    monkeypatch.setattr(appmod.settings, "auth_provider", "inferiaauth")
     monkeypatch.setattr(appmod.settings, "external_auth_url", "https://auth.example.com")
     monkeypatch.setattr(appmod.settings, "catalog_admin_token", None)
     mock = AsyncMock(return_value=True)
@@ -83,8 +83,20 @@ async def test_no_declare_without_token(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_no_declare_without_external_auth_url(monkeypatch):
-    monkeypatch.setattr(appmod.settings, "auth_provider", "external")
+    monkeypatch.setattr(appmod.settings, "auth_provider", "inferiaauth")
     monkeypatch.setattr(appmod.settings, "external_auth_url", None)
+    monkeypatch.setattr(appmod.settings, "catalog_admin_token", "tok")
+    mock = AsyncMock(return_value=True)
+    monkeypatch.setattr("inferia.services.api_gateway.rbac.catalog_declare.declare_catalog", mock)
+    await appmod._maybe_declare_catalog()
+    mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_declare_in_oidc_mode(monkeypatch):
+    """Catalog declaration only happens for inferiaauth, NOT generic oidc."""
+    monkeypatch.setattr(appmod.settings, "auth_provider", "oidc")
+    monkeypatch.setattr(appmod.settings, "external_auth_url", "https://auth.example.com")
     monkeypatch.setattr(appmod.settings, "catalog_admin_token", "tok")
     mock = AsyncMock(return_value=True)
     monkeypatch.setattr("inferia.services.api_gateway.rbac.catalog_declare.declare_catalog", mock)
@@ -95,7 +107,7 @@ async def test_no_declare_without_external_auth_url(monkeypatch):
 @pytest.mark.asyncio
 async def test_declare_failure_is_non_fatal(monkeypatch):
     """A False return from declare_catalog must not raise."""
-    monkeypatch.setattr(appmod.settings, "auth_provider", "external")
+    monkeypatch.setattr(appmod.settings, "auth_provider", "inferiaauth")
     monkeypatch.setattr(appmod.settings, "external_auth_url", "https://auth.example.com")
     monkeypatch.setattr(appmod.settings, "catalog_admin_token", "tok")
     mock = AsyncMock(return_value=False)

--- a/package/src/inferia/services/api_gateway/tests/test_catalog.py
+++ b/package/src/inferia/services/api_gateway/tests/test_catalog.py
@@ -1,0 +1,33 @@
+from inferia.services.api_gateway.rbac.catalog import CATALOG, to_declare_request
+
+
+def test_every_role_permission_is_declared():
+    keys = {p.key for p in CATALOG.permissions}
+    for role in CATALOG.roles:
+        for k in role.permissions:
+            assert k in keys, f"role {role.name} references undeclared permission {k}"
+
+
+def test_admin_has_all_permissions():
+    admin = next(r for r in CATALOG.roles if r.name == "admin")
+    assert set(admin.permissions) == {p.key for p in CATALOG.permissions}
+
+
+def test_permission_keys_are_inferiallm_namespaced():
+    assert CATALOG.permissions, "catalog must declare permissions"
+    assert all(p.key.startswith("inferiallm:") for p in CATALOG.permissions)
+
+
+def test_role_names():
+    assert {r.name for r in CATALOG.roles} == {"admin", "member", "viewer"}
+
+
+def test_to_declare_request_shape():
+    body = to_declare_request(CATALOG)
+    assert set(body.keys()) == {"roles", "permissions"}
+    for p in body["permissions"]:
+        assert {"key", "display_name", "description"} <= set(p.keys())
+        assert all(isinstance(p[f], str) and p[f] for f in ("key", "display_name", "description"))
+    for r in body["roles"]:
+        assert {"name", "permissions"} <= set(r.keys())
+        assert isinstance(r["permissions"], list)

--- a/package/src/inferia/services/api_gateway/tests/test_catalog_declare.py
+++ b/package/src/inferia/services/api_gateway/tests/test_catalog_declare.py
@@ -1,0 +1,227 @@
+"""Tests for declare_catalog — HTTP client that PUTs InferiaLLM's catalog to InferiaAuth.
+
+Coverage:
+  - Happy path: correct URL, method, Authorization header, JSON body, returns True on 2xx
+  - 4xx response → False (no raise)
+  - 5xx response → False (no raise)
+  - Network error (ConnectError) → False (no raise)
+  - Timeout → False (no raise)
+  - Empty base_url → False (no request)
+  - Empty admin_token → False (no request)
+  - Absurdly long admin_token (> 8192 chars) → False (no request)
+  - Trailing slash stripped from base_url
+  - 201 Created is treated as success
+  - Client provided is used and NOT closed by declare_catalog
+  - Client not provided → a temporary one is created internally
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from inferia.services.api_gateway.rbac.catalog import CATALOG, to_declare_request
+from inferia.services.api_gateway.rbac.catalog_declare import declare_catalog
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_declare_puts_catalog_with_bearer():
+    """PUT to the correct URL with Bearer auth and the catalog body; returns True."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        captured["auth"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    ok = await declare_catalog("https://auth.example.com/", "tok123", client=client)
+    await client.aclose()
+
+    assert ok is True
+    assert captured["method"] == "PUT"
+    assert captured["url"] == "https://auth.example.com/api/v1/services/inferiallm/catalog"
+    assert captured["auth"] == "Bearer tok123"
+    assert captured["body"] == to_declare_request(CATALOG)
+
+
+@pytest.mark.asyncio
+async def test_declare_201_is_success():
+    """201 Created should also be treated as a successful declaration."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json={"created": True})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    ok = await declare_catalog("https://auth.example.com", "tok", client=client)
+    await client.aclose()
+
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_declare_trailing_slash_stripped():
+    """Trailing slash on base_url must be stripped so the path is clean."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    ok = await declare_catalog("https://auth.example.com///", "tok", client=client)
+    await client.aclose()
+
+    assert ok is True
+    assert captured["url"] == "https://auth.example.com/api/v1/services/inferiallm/catalog"
+
+
+# ---------------------------------------------------------------------------
+# Error cases — all return False, never raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_declare_returns_false_on_5xx():
+    """503 and other 5xx responses → False, no exception."""
+    client = httpx.AsyncClient(transport=httpx.MockTransport(lambda r: httpx.Response(503)))
+    ok = await declare_catalog("https://auth.example.com", "tok", client=client)
+    await client.aclose()
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_declare_returns_false_on_4xx():
+    """401 and other 4xx responses → False, no exception."""
+    client = httpx.AsyncClient(transport=httpx.MockTransport(lambda r: httpx.Response(401)))
+    ok = await declare_catalog("https://auth.example.com", "tok", client=client)
+    await client.aclose()
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_declare_returns_false_on_network_error():
+    """ConnectError → False, no exception."""
+    def boom(r: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("down")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(boom))
+    ok = await declare_catalog("https://auth.example.com", "tok", client=client)
+    await client.aclose()
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_declare_returns_false_on_timeout():
+    """ReadTimeout → False, no exception."""
+    def timeout_transport(r: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out", request=r)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(timeout_transport))
+    ok = await declare_catalog("https://auth.example.com", "tok", client=client)
+    await client.aclose()
+
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Input guards — return False before making any request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_declare_guards_empty_base_url():
+    """Empty base_url → False, no request made."""
+    request_made = False
+
+    def handler(r: httpx.Request) -> httpx.Response:
+        nonlocal request_made
+        request_made = True
+        return httpx.Response(200)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    ok = await declare_catalog("", "tok", client=client)
+    await client.aclose()
+
+    assert ok is False
+    assert not request_made
+
+
+@pytest.mark.asyncio
+async def test_declare_guards_empty_admin_token():
+    """Empty admin_token → False, no request made."""
+    request_made = False
+
+    def handler(r: httpx.Request) -> httpx.Response:
+        nonlocal request_made
+        request_made = True
+        return httpx.Response(200)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    ok = await declare_catalog("https://x", "", client=client)
+    await client.aclose()
+
+    assert ok is False
+    assert not request_made
+
+
+@pytest.mark.asyncio
+async def test_declare_guards_oversized_token():
+    """admin_token > 8192 chars → False, no request made."""
+    request_made = False
+
+    def handler(r: httpx.Request) -> httpx.Response:
+        nonlocal request_made
+        request_made = True
+        return httpx.Response(200)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    ok = await declare_catalog("https://x", "a" * 8193, client=client)
+    await client.aclose()
+
+    assert ok is False
+    assert not request_made
+
+
+@pytest.mark.asyncio
+async def test_declare_guards_combined_empty_inputs():
+    """Convenience: both empty inputs at once → both False without requests."""
+    assert await declare_catalog("", "tok") is False
+    assert await declare_catalog("https://x", "") is False
+
+
+# ---------------------------------------------------------------------------
+# Client lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_declare_does_not_close_provided_client():
+    """When the caller passes a client, declare_catalog must NOT close it."""
+    def handler(r: httpx.Request) -> httpx.Response:
+        return httpx.Response(200)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    await declare_catalog("https://auth.example.com", "tok", client=client)
+
+    assert not client.is_closed, "declare_catalog must not close the caller's client"
+    await client.aclose()  # cleanup
+
+
+@pytest.mark.asyncio
+async def test_declare_works_without_provided_client():
+    """When no client is provided, declare_catalog should create its own and succeed."""
+    # We can only verify it doesn't raise; we can't inspect the internal client.
+    # Use a real base_url that will fail — expect False (network error), no exception.
+    ok = await declare_catalog("http://127.0.0.1:1", "tok")
+    assert ok is False

--- a/package/src/inferia/services/api_gateway/tests/test_config_modes.py
+++ b/package/src/inferia/services/api_gateway/tests/test_config_modes.py
@@ -1,0 +1,218 @@
+"""Tests for the three-mode auth_provider config (local | oidc | inferiaauth).
+
+Run with --noconftest to avoid the jwt import conflict in conftest.py:
+    python -m pytest package/src/inferia/services/api_gateway/tests/test_config_modes.py -v --noconftest
+"""
+
+import warnings
+import pytest
+from inferia.services.api_gateway.config import Settings
+
+# ---- Shared helper: the four external-auth fields ----
+EXT = dict(
+    external_auth_url="https://auth.example.com",
+    external_auth_issuer="https://auth.example.com",
+    oauth_client_id="client-id-abc",
+    oauth_redirect_uri="https://myapp.example.com/auth/callback",
+)
+
+JWT = dict(jwt_secret_key="x" * 32)
+
+
+# ---------------------------------------------------------------------------
+# local mode
+# ---------------------------------------------------------------------------
+
+
+def test_local_requires_nothing():
+    s = Settings(auth_provider="local", **JWT)
+    assert s.auth_provider == "local"
+    assert s.is_external_mode is False
+
+
+def test_local_ignores_external_fields_when_provided():
+    """local mode should still accept (and ignore) external fields gracefully."""
+    s = Settings(auth_provider="local", **JWT, **EXT)
+    assert s.auth_provider == "local"
+    assert s.is_external_mode is False
+
+
+# ---------------------------------------------------------------------------
+# inferiaauth mode
+# ---------------------------------------------------------------------------
+
+
+def test_inferiaauth_requires_external_fields():
+    with pytest.raises(ValueError) as exc_info:
+        Settings(auth_provider="inferiaauth", **JWT)
+    err = str(exc_info.value)
+    assert "EXTERNAL_AUTH_URL" in err
+
+
+def test_inferiaauth_error_names_all_missing_fields():
+    """All four missing fields must be named in the single error."""
+    with pytest.raises(ValueError) as exc_info:
+        Settings(auth_provider="inferiaauth", **JWT)
+    err = str(exc_info.value)
+    assert "EXTERNAL_AUTH_URL" in err
+    assert "EXTERNAL_AUTH_ISSUER" in err
+    assert "OAUTH_CLIENT_ID" in err
+    assert "OAUTH_REDIRECT_URI" in err
+
+
+def test_inferiaauth_error_mentions_provider_name():
+    """Error message should indicate the active provider name."""
+    with pytest.raises(ValueError) as exc_info:
+        Settings(auth_provider="inferiaauth", **JWT)
+    assert "inferiaauth" in str(exc_info.value)
+
+
+def test_inferiaauth_ok_with_fields():
+    s = Settings(auth_provider="inferiaauth", **JWT, **EXT)
+    assert s.auth_provider == "inferiaauth"
+    assert s.is_external_mode is True
+
+
+def test_inferiaauth_partial_fields_error():
+    """Providing only some of the four fields should still raise."""
+    partial = dict(external_auth_url="https://auth.example.com")
+    with pytest.raises(ValueError) as exc_info:
+        Settings(auth_provider="inferiaauth", **JWT, **partial)
+    err = str(exc_info.value)
+    assert "EXTERNAL_AUTH_ISSUER" in err
+    assert "OAUTH_CLIENT_ID" in err
+    assert "OAUTH_REDIRECT_URI" in err
+
+
+# ---------------------------------------------------------------------------
+# oidc mode
+# ---------------------------------------------------------------------------
+
+
+def test_oidc_requires_external_fields():
+    with pytest.raises(ValueError) as exc_info:
+        Settings(auth_provider="oidc", **JWT)
+    err = str(exc_info.value)
+    assert "EXTERNAL_AUTH_URL" in err
+
+
+def test_oidc_error_names_all_missing_fields():
+    with pytest.raises(ValueError) as exc_info:
+        Settings(auth_provider="oidc", **JWT)
+    err = str(exc_info.value)
+    assert "EXTERNAL_AUTH_URL" in err
+    assert "EXTERNAL_AUTH_ISSUER" in err
+    assert "OAUTH_CLIENT_ID" in err
+    assert "OAUTH_REDIRECT_URI" in err
+
+
+def test_oidc_error_mentions_provider_name():
+    with pytest.raises(ValueError) as exc_info:
+        Settings(auth_provider="oidc", **JWT)
+    assert "oidc" in str(exc_info.value)
+
+
+def test_oidc_ok_with_fields():
+    s = Settings(auth_provider="oidc", **JWT, **EXT)
+    assert s.auth_provider == "oidc"
+    assert s.is_external_mode is True
+
+
+def test_oidc_partial_fields_error():
+    partial = dict(external_auth_url="https://auth.example.com", external_auth_issuer="https://auth.example.com")
+    with pytest.raises(ValueError) as exc_info:
+        Settings(auth_provider="oidc", **JWT, **partial)
+    err = str(exc_info.value)
+    assert "OAUTH_CLIENT_ID" in err
+    assert "OAUTH_REDIRECT_URI" in err
+
+
+# ---------------------------------------------------------------------------
+# is_external_mode property
+# ---------------------------------------------------------------------------
+
+
+def test_is_external_mode_local_is_false():
+    s = Settings(auth_provider="local", **JWT)
+    assert s.is_external_mode is False
+
+
+def test_is_external_mode_inferiaauth_is_true():
+    s = Settings(auth_provider="inferiaauth", **JWT, **EXT)
+    assert s.is_external_mode is True
+
+
+def test_is_external_mode_oidc_is_true():
+    s = Settings(auth_provider="oidc", **JWT, **EXT)
+    assert s.is_external_mode is True
+
+
+# ---------------------------------------------------------------------------
+# backward-compat: "external" → "inferiaauth"
+# ---------------------------------------------------------------------------
+
+
+def test_external_alias_maps_to_inferiaauth():
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        s = Settings(auth_provider="external", **JWT, **EXT)
+    assert s.auth_provider == "inferiaauth"
+
+
+def test_external_alias_emits_deprecation_warning():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        Settings(auth_provider="external", **JWT, **EXT)
+    assert any(issubclass(x.category, DeprecationWarning) for x in w), (
+        "Expected a DeprecationWarning when AUTH_PROVIDER=external"
+    )
+
+
+def test_external_alias_with_fields_is_external_mode():
+    """After alias mapping, the resulting object should be external_mode=True."""
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        s = Settings(auth_provider="external", **JWT, **EXT)
+    assert s.is_external_mode is True
+
+
+def test_external_alias_without_fields_still_raises():
+    """Alias maps correctly, then external-field validation fires."""
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError) as exc_info:
+            Settings(auth_provider="external", **JWT)
+    err = str(exc_info.value)
+    # After alias mapping auth_provider is "inferiaauth"; the error should name it
+    assert "inferiaauth" in err
+
+
+def test_external_alias_maps_to_inferiaauth_with_warning():
+    """Canonical test from spec: alias + warning together."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        s = Settings(auth_provider="external", **JWT, **EXT)
+    assert s.auth_provider == "inferiaauth"
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+
+# ---------------------------------------------------------------------------
+# invalid value rejected
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_auth_provider_rejected():
+    with pytest.raises((ValueError, Exception)):
+        Settings(auth_provider="unknown_mode", **JWT)
+
+
+# ---------------------------------------------------------------------------
+# default
+# ---------------------------------------------------------------------------
+
+
+def test_default_auth_provider_is_local():
+    """With no auth_provider kwarg the default must be 'local'."""
+    s = Settings(**JWT)
+    assert s.auth_provider == "local"
+    assert s.is_external_mode is False

--- a/package/src/inferia/services/api_gateway/tests/test_local_identity_guard.py
+++ b/package/src/inferia/services/api_gateway/tests/test_local_identity_guard.py
@@ -1,0 +1,113 @@
+"""Tests for the require_local_identity dependency.
+
+Run with --noconftest to avoid the jwt import conflict in conftest.py:
+    python -m pytest package/src/inferia/services/api_gateway/tests/test_local_identity_guard.py -v --noconftest
+"""
+import pytest
+from fastapi import FastAPI, Depends
+from fastapi.testclient import TestClient
+import inferia.services.api_gateway.rbac.local_identity_guard as guard
+
+
+def _app():
+    app = FastAPI()
+
+    @app.get("/x", dependencies=[Depends(guard.require_local_identity)])
+    def x():
+        return {"ok": True}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Dependency unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_blocks_in_external_mode(monkeypatch):
+    monkeypatch.setattr(guard.settings, "auth_provider", "inferiaauth", raising=False)
+    r = TestClient(_app()).get("/x")
+    assert r.status_code == 409
+
+
+def test_blocks_in_oidc_mode(monkeypatch):
+    monkeypatch.setattr(guard.settings, "auth_provider", "oidc", raising=False)
+    assert TestClient(_app()).get("/x").status_code == 409
+
+
+def test_allows_in_local_mode(monkeypatch):
+    monkeypatch.setattr(guard.settings, "auth_provider", "local", raising=False)
+    assert TestClient(_app()).get("/x").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Error body tests
+# ---------------------------------------------------------------------------
+
+
+def test_conflict_detail_message(monkeypatch):
+    monkeypatch.setattr(guard.settings, "auth_provider", "inferiaauth", raising=False)
+    r = TestClient(_app()).get("/x")
+    assert r.status_code == 409
+    body = r.json()
+    assert "identity provider" in body["detail"]
+
+
+def test_conflict_detail_message_oidc(monkeypatch):
+    monkeypatch.setattr(guard.settings, "auth_provider", "oidc", raising=False)
+    r = TestClient(_app()).get("/x")
+    assert r.status_code == 409
+    body = r.json()
+    assert "identity provider" in body["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Direct function call tests
+# ---------------------------------------------------------------------------
+
+
+def test_direct_call_raises_in_external_mode(monkeypatch):
+    """Calling require_local_identity() directly raises HTTPException when external."""
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(guard.settings, "auth_provider", "inferiaauth", raising=False)
+    with pytest.raises(HTTPException) as exc_info:
+        guard.require_local_identity()
+    assert exc_info.value.status_code == 409
+
+
+def test_direct_call_raises_in_oidc_mode(monkeypatch):
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(guard.settings, "auth_provider", "oidc", raising=False)
+    with pytest.raises(HTTPException) as exc_info:
+        guard.require_local_identity()
+    assert exc_info.value.status_code == 409
+
+
+def test_direct_call_noop_in_local_mode(monkeypatch):
+    """Calling require_local_identity() directly does NOT raise when local."""
+    monkeypatch.setattr(guard.settings, "auth_provider", "local", raising=False)
+    # Should not raise
+    result = guard.require_local_identity()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# is_external_mode property derives from auth_provider
+# ---------------------------------------------------------------------------
+
+
+def test_is_external_mode_true_for_inferiaauth(monkeypatch):
+    monkeypatch.setattr(guard.settings, "auth_provider", "inferiaauth", raising=False)
+    assert guard.settings.is_external_mode is True
+
+
+def test_is_external_mode_true_for_oidc(monkeypatch):
+    monkeypatch.setattr(guard.settings, "auth_provider", "oidc", raising=False)
+    assert guard.settings.is_external_mode is True
+
+
+def test_is_external_mode_false_for_local(monkeypatch):
+    monkeypatch.setattr(guard.settings, "auth_provider", "local", raising=False)
+    assert guard.settings.is_external_mode is False

--- a/package/src/inferia/services/api_gateway/tests/test_middleware_modes.py
+++ b/package/src/inferia/services/api_gateway/tests/test_middleware_modes.py
@@ -1,0 +1,474 @@
+"""Tests for the 3-way auth-mode branching in auth middleware.
+
+Tests _resolve_oidc_token and _resolve_external_token directly via stubbed
+verifier + fake db + stubbed get_or_create_shadow_user, plus a branch-selection
+test for auth_middleware.
+
+Run with --noconftest to avoid the shared-conftest jwt fixture conflict:
+  pytest package/.../tests/test_middleware_modes.py --noconftest
+"""
+
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import inferia.services.api_gateway.rbac.middleware as mw
+from inferia.services.api_gateway.rbac.jwks_verifier import JWKSVerifyError
+from inferia.services.api_gateway.models import UserContext
+
+
+class _FakeUser:
+    """Minimal shadow-user stand-in (mirrors DB User shape used by middleware)."""
+
+    id = "u1"
+    email = "a@b.com"
+
+
+def _make_verifier(claims: dict):
+    """Return a simple namespace whose verify_sync always returns `claims`."""
+    return types.SimpleNamespace(verify_sync=lambda t: claims)
+
+
+def _make_failing_verifier():
+    """Return a verifier whose verify_sync raises JWKSVerifyError."""
+    v = MagicMock()
+    v.verify_sync.side_effect = JWKSVerifyError("nope")
+    return v
+
+
+# ---------------------------------------------------------------------------
+# _resolve_oidc_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_authenticated_is_admin(monkeypatch):
+    """A valid OIDC token produces a UserContext with role=admin + all catalog perms."""
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "user:ext1", "email": "a@b.com", "org_id": "org9"}
+        ),
+    )
+    monkeypatch.setattr(
+        mw,
+        "get_or_create_shadow_user",
+        AsyncMock(return_value=(_FakeUser(), "org9", ["admin"])),
+    )
+    # Reset singleton so the patched _get_verifier is picked up
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["admin"]
+    assert "inferiallm:deployment:write" in ctx.permissions
+    assert "inferiallm:model:read" in ctx.permissions
+    assert ctx.org_id == "org9"
+    assert ctx.user_id == "u1"
+    assert ctx.email == "a@b.com"
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_admin_has_all_catalog_perms(monkeypatch):
+    """Admin permissions granted by OIDC path match the full catalog admin role."""
+    from inferia.services.api_gateway.rbac.catalog import CATALOG
+
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier({"sub": "ext2", "email": "b@c.com", "org_id": "o2"}),
+    )
+    monkeypatch.setattr(
+        mw,
+        "get_or_create_shadow_user",
+        AsyncMock(return_value=(_FakeUser(), "o2", [])),
+    )
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    expected = [p for r in CATALOG.roles if r.name == "admin" for p in r.permissions]
+    assert set(ctx.permissions) == set(expected)
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_org_id_from_org_ids_fallback(monkeypatch):
+    """When org_id claim absent, first entry of org_ids[] is used."""
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier(
+            {
+                "sub": "ext3",
+                "email": "c@d.com",
+                "org_ids": ["org-first", "org-second"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        mw,
+        "get_or_create_shadow_user",
+        AsyncMock(return_value=(_FakeUser(), "local-org", [])),
+    )
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.org_id == "org-first"
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_no_org_claim_gives_none_org(monkeypatch):
+    """When neither org_id nor org_ids present, org_id is None."""
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier({"sub": "ext4", "email": "d@e.com"}),
+    )
+    monkeypatch.setattr(
+        mw,
+        "get_or_create_shadow_user",
+        AsyncMock(return_value=(_FakeUser(), None, [])),
+    )
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.org_id is None
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_invalid_raises_401(monkeypatch):
+    """A JWKSVerifyError from _get_verifier surfaces as HTTPException(401)."""
+    monkeypatch.setattr(mw, "_get_verifier", _make_failing_verifier)
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    with pytest.raises(mw.HTTPException) as exc_info:
+        await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid token"
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_sub_colon_prefix_stripped(monkeypatch):
+    """The 'user:' prefix in sub is stripped before passing as external_id."""
+    shadow_mock = AsyncMock(return_value=(_FakeUser(), "org1", []))
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "user:the-real-id", "email": "e@f.com", "org_id": "org1"}
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", shadow_mock)
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    _, kwargs = shadow_mock.await_args
+    assert kwargs["external_id"] == "the-real-id"
+
+
+@pytest.mark.asyncio
+async def test_oidc_token_sub_no_colon_passed_through(monkeypatch):
+    """A bare sub (no colon prefix) is passed through unchanged."""
+    shadow_mock = AsyncMock(return_value=(_FakeUser(), "org2", []))
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "bare-id", "email": "f@g.com", "org_id": "org2"}
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", shadow_mock)
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    _, kwargs = shadow_mock.await_args
+    assert kwargs["external_id"] == "bare-id"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_external_token (inferiaauth path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inferiaauth_token_uses_claims(monkeypatch):
+    """InferiaAuth token: roles + permissions come straight from JWT claims."""
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier(
+            {
+                "sub": "user:ext1",
+                "email": "a@b.com",
+                "roles": ["viewer"],
+                "permissions": ["inferiallm:model:read"],
+                "org_id": "o1",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        mw,
+        "get_or_create_shadow_user",
+        AsyncMock(return_value=(_FakeUser(), "o1", ["viewer"])),
+    )
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    ctx = await mw._resolve_external_token(MagicMock(), "tok")
+
+    assert ctx.permissions == ["inferiallm:model:read"]
+    assert ctx.roles == ["viewer"]
+    assert ctx.org_id == "o1"
+
+
+@pytest.mark.asyncio
+async def test_inferiaauth_token_invalid_raises_401(monkeypatch):
+    """JWKSVerifyError from _resolve_external_token surfaces as HTTPException(401)."""
+    monkeypatch.setattr(mw, "_get_verifier", _make_failing_verifier)
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    with pytest.raises(mw.HTTPException) as exc_info:
+        await mw._resolve_external_token(MagicMock(), "tok")
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_inferiaauth_missing_roles_defaults_to_empty(monkeypatch):
+    """When roles/permissions claims are absent, lists default to empty."""
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext5", "email": "g@h.com", "org_id": "o5"}
+        ),
+    )
+    monkeypatch.setattr(
+        mw,
+        "get_or_create_shadow_user",
+        AsyncMock(return_value=(_FakeUser(), "o5", [])),
+    )
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    ctx = await mw._resolve_external_token(MagicMock(), "tok")
+
+    assert ctx.roles == []
+    assert ctx.permissions == []
+
+
+@pytest.mark.asyncio
+async def test_inferiaauth_org_id_falls_back_to_org_ids(monkeypatch):
+    """When org_id absent, first entry of org_ids[] used."""
+    monkeypatch.setattr(
+        mw,
+        "_get_verifier",
+        lambda: _make_verifier(
+            {
+                "sub": "ext6",
+                "email": "h@i.com",
+                "org_ids": ["o-first", "o-second"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        mw,
+        "get_or_create_shadow_user",
+        AsyncMock(return_value=(_FakeUser(), None, [])),
+    )
+    monkeypatch.setattr(mw, "_verifier", None)
+
+    ctx = await mw._resolve_external_token(MagicMock(), "tok")
+
+    assert ctx.org_id == "o-first"
+
+
+# ---------------------------------------------------------------------------
+# auth_middleware branch selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_branch_inferiaauth_calls_external_resolver(monkeypatch):
+    """With mode=inferiaauth, after local-token failure the external resolver runs."""
+    from fastapi import HTTPException as FastAPIHTTPException
+
+    monkeypatch.setattr(mw.settings, "auth_provider", "inferiaauth", raising=False)
+
+    local_fail = AsyncMock(side_effect=FastAPIHTTPException(status_code=401, detail="bad"))
+    external_ok = AsyncMock(
+        return_value=UserContext(
+            user_id="u2", username="x@y.com", email="x@y.com",
+            roles=["admin"], permissions=[], org_id="o2",
+            quota_limit=10000, quota_used=0,
+        )
+    )
+    monkeypatch.setattr(mw, "_resolve_local_token", local_fail)
+    monkeypatch.setattr(mw, "_resolve_external_token", external_ok)
+
+    fake_db = AsyncMock()
+    fake_db.__aenter__ = AsyncMock(return_value=fake_db)
+    fake_db.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(mw, "AsyncSessionLocal", return_value=fake_db):
+        # Build a minimal request with a cache-busting token
+        request = MagicMock()
+        request.headers.get = MagicMock(
+            side_effect=lambda h, d="": {
+                "upgrade": "",
+                "connection": "",
+                "Authorization": "Bearer fresh-token-inferiaauth",
+            }.get(h, d)
+        )
+        request.url.path = "/some/protected"
+        request.method = "GET"
+        request.state = MagicMock()
+        # Ensure cache miss
+        mw._auth_cache.clear()
+
+        async def _call_next(req):
+            return MagicMock(status_code=200)
+
+        await mw.auth_middleware(request, _call_next)
+
+    local_fail.assert_awaited_once()
+    external_ok.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_branch_oidc_calls_oidc_resolver(monkeypatch):
+    """With mode=oidc, after local-token failure the OIDC resolver runs."""
+    from fastapi import HTTPException as FastAPIHTTPException
+
+    monkeypatch.setattr(mw.settings, "auth_provider", "oidc", raising=False)
+
+    local_fail = AsyncMock(side_effect=FastAPIHTTPException(status_code=401, detail="bad"))
+    oidc_ok = AsyncMock(
+        return_value=UserContext(
+            user_id="u3", username="y@z.com", email="y@z.com",
+            roles=["admin"], permissions=[], org_id="o3",
+            quota_limit=10000, quota_used=0,
+        )
+    )
+    monkeypatch.setattr(mw, "_resolve_local_token", local_fail)
+    monkeypatch.setattr(mw, "_resolve_oidc_token", oidc_ok)
+
+    fake_db = AsyncMock()
+    fake_db.__aenter__ = AsyncMock(return_value=fake_db)
+    fake_db.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(mw, "AsyncSessionLocal", return_value=fake_db):
+        request = MagicMock()
+        request.headers.get = MagicMock(
+            side_effect=lambda h, d="": {
+                "upgrade": "",
+                "connection": "",
+                "Authorization": "Bearer fresh-token-oidc",
+            }.get(h, d)
+        )
+        request.url.path = "/api/protected"
+        request.method = "POST"
+        request.state = MagicMock()
+        mw._auth_cache.clear()
+
+        async def _call_next(req):
+            return MagicMock(status_code=200)
+
+        await mw.auth_middleware(request, _call_next)
+
+    local_fail.assert_awaited_once()
+    oidc_ok.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_branch_local_only_calls_local_resolver(monkeypatch):
+    """With mode=local, only _resolve_local_token is called (no external)."""
+    monkeypatch.setattr(mw.settings, "auth_provider", "local", raising=False)
+
+    local_ok = AsyncMock(
+        return_value=UserContext(
+            user_id="u4", username="z@a.com", email="z@a.com",
+            roles=["member"], permissions=["inferiallm:model:read"], org_id="o4",
+            quota_limit=10000, quota_used=0,
+        )
+    )
+    external_mock = AsyncMock()
+    oidc_mock = AsyncMock()
+    monkeypatch.setattr(mw, "_resolve_local_token", local_ok)
+    monkeypatch.setattr(mw, "_resolve_external_token", external_mock)
+    monkeypatch.setattr(mw, "_resolve_oidc_token", oidc_mock)
+
+    fake_db = AsyncMock()
+    fake_db.__aenter__ = AsyncMock(return_value=fake_db)
+    fake_db.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(mw, "AsyncSessionLocal", return_value=fake_db):
+        request = MagicMock()
+        request.headers.get = MagicMock(
+            side_effect=lambda h, d="": {
+                "upgrade": "",
+                "connection": "",
+                "Authorization": "Bearer fresh-token-local",
+            }.get(h, d)
+        )
+        request.url.path = "/api/data"
+        request.method = "GET"
+        request.state = MagicMock()
+        mw._auth_cache.clear()
+
+        async def _call_next(req):
+            return MagicMock(status_code=200)
+
+        await mw.auth_middleware(request, _call_next)
+
+    local_ok.assert_awaited_once()
+    external_mock.assert_not_awaited()
+    oidc_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_branch_inferiaauth_superadmin_local_token_succeeds(monkeypatch):
+    """With mode=inferiaauth, if local token succeeds the external path is NOT called."""
+    monkeypatch.setattr(mw.settings, "auth_provider", "inferiaauth", raising=False)
+
+    local_ok = AsyncMock(
+        return_value=UserContext(
+            user_id="superadmin", username="sa@inferia.local", email="sa@inferia.local",
+            roles=["admin"], permissions=[], org_id=None,
+            quota_limit=10000, quota_used=0,
+        )
+    )
+    external_mock = AsyncMock()
+    monkeypatch.setattr(mw, "_resolve_local_token", local_ok)
+    monkeypatch.setattr(mw, "_resolve_external_token", external_mock)
+
+    fake_db = AsyncMock()
+    fake_db.__aenter__ = AsyncMock(return_value=fake_db)
+    fake_db.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(mw, "AsyncSessionLocal", return_value=fake_db):
+        request = MagicMock()
+        request.headers.get = MagicMock(
+            side_effect=lambda h, d="": {
+                "upgrade": "",
+                "connection": "",
+                "Authorization": "Bearer fresh-token-superadmin",
+            }.get(h, d)
+        )
+        request.url.path = "/api/admin"
+        request.method = "GET"
+        request.state = MagicMock()
+        mw._auth_cache.clear()
+
+        async def _call_next(req):
+            return MagicMock(status_code=200)
+
+        await mw.auth_middleware(request, _call_next)
+
+    local_ok.assert_awaited_once()
+    external_mock.assert_not_awaited()

--- a/package/src/inferia/services/api_gateway/tests/test_oauth_router_modes.py
+++ b/package/src/inferia/services/api_gateway/tests/test_oauth_router_modes.py
@@ -1,0 +1,141 @@
+"""Tests for /auth/start availability across the 3 auth modes.
+
+Verifies that the redirect-SSO flow is available in BOTH external modes
+(oidc, inferiaauth) and disabled (503) in local mode.
+
+Run with --noconftest to avoid the shared-conftest jwt fixture conflict:
+  PYTHONPATH=/home/celestix/.pyenv/versions/3.12.9/lib/python3.12/site-packages:package/src \\
+    pytest package/src/inferia/services/api_gateway/tests/test_oauth_router_modes.py --noconftest
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import inferia.services.api_gateway.rbac.oauth_router as orouter
+
+
+def _client(monkeypatch, mode: str) -> TestClient:
+    """Build a TestClient that mounts ONLY the oauth_router with mocked settings."""
+    monkeypatch.setattr(orouter.settings, "auth_provider", mode, raising=False)
+    monkeypatch.setattr(orouter.settings, "oauth_client_id", "inferiallm-dashboard", raising=False)
+    monkeypatch.setattr(orouter.settings, "oauth_redirect_uri", "https://app/auth/callback", raising=False)
+    monkeypatch.setattr(orouter.settings, "external_auth_url", "https://auth.example.com", raising=False)
+    monkeypatch.setattr(orouter.settings, "app_namespace", "inferiallm", raising=False)
+
+    # is_external_mode is a @property that derives from auth_provider — monkeypatching
+    # auth_provider above is sufficient for it to return the correct value automatically.
+
+    # Reset singleton oauth_client so any freshly patched settings are picked up.
+    orouter._oauth_client = None
+
+    app = FastAPI()
+    app.include_router(orouter.router)
+    return TestClient(app, follow_redirects=False)
+
+
+# ---------------------------------------------------------------------------
+# /auth/start — mode gates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["oidc", "inferiaauth"])
+def test_auth_start_redirects_in_external_modes(monkeypatch, mode):
+    """/auth/start must return 302 for oidc and inferiaauth modes."""
+    r = _client(monkeypatch, mode).get("/auth/start")
+    assert r.status_code == 302
+    assert "/oauth/authorize" in r.headers["location"]
+
+
+def test_auth_start_503_in_local_mode(monkeypatch):
+    """/auth/start must return 503 when auth_provider is local."""
+    r = _client(monkeypatch, "local").get("/auth/start")
+    assert r.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# /auth/callback — mode gates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["oidc", "inferiaauth"])
+def test_auth_callback_reaches_logic_in_external_modes(monkeypatch, mode):
+    """/auth/callback must NOT return 503 due to mode gate for oidc/inferiaauth.
+
+    Without valid PKCE cookies it returns 400 (missing state) — that is past
+    the mode guard, which is all we need to verify here.
+    """
+    r = _client(monkeypatch, mode).get("/auth/callback?code=abc&state=xyz")
+    assert r.status_code != 503
+
+
+def test_auth_callback_503_in_local_mode(monkeypatch):
+    """/auth/callback must return 503 when auth_provider is local."""
+    r = _client(monkeypatch, "local").get("/auth/callback?code=abc&state=xyz")
+    assert r.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Redirect target sanity (oidc + inferiaauth share identical PKCE logic)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["oidc", "inferiaauth"])
+def test_auth_start_location_points_to_authorize_endpoint(monkeypatch, mode):
+    """The redirect URL must target /oauth/authorize on the configured IdP."""
+    from urllib.parse import parse_qs, urlparse
+
+    r = _client(monkeypatch, mode).get("/auth/start")
+    assert r.status_code == 302
+
+    parsed = urlparse(r.headers["location"])
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "auth.example.com"
+    assert parsed.path == "/oauth/authorize"
+
+    qs = parse_qs(parsed.query)
+    assert qs["response_type"] == ["code"]
+    assert qs["client_id"] == ["inferiallm-dashboard"]
+    assert qs["redirect_uri"] == ["https://app/auth/callback"]
+    assert qs["code_challenge_method"] == ["S256"]
+    assert "code_challenge" in qs
+    assert "state" in qs
+
+
+# ---------------------------------------------------------------------------
+# Absent oauth fields still 503 even for external modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["oidc", "inferiaauth"])
+def test_auth_start_503_when_client_id_missing(monkeypatch, mode):
+    """503 when oauth_client_id is blank, regardless of mode."""
+    monkeypatch.setattr(orouter.settings, "auth_provider", mode, raising=False)
+    monkeypatch.setattr(orouter.settings, "oauth_client_id", "", raising=False)
+    monkeypatch.setattr(orouter.settings, "oauth_redirect_uri", "https://app/auth/callback", raising=False)
+    monkeypatch.setattr(orouter.settings, "external_auth_url", "https://auth.example.com", raising=False)
+    monkeypatch.setattr(orouter.settings, "app_namespace", "inferiallm", raising=False)
+    orouter._oauth_client = None
+
+    app = FastAPI()
+    app.include_router(orouter.router)
+    r = TestClient(app, follow_redirects=False).get("/auth/start")
+    assert r.status_code == 503
+
+
+@pytest.mark.parametrize("mode", ["oidc", "inferiaauth"])
+def test_auth_start_503_when_redirect_uri_missing(monkeypatch, mode):
+    """503 when oauth_redirect_uri is blank, regardless of mode."""
+    monkeypatch.setattr(orouter.settings, "auth_provider", mode, raising=False)
+    monkeypatch.setattr(orouter.settings, "oauth_client_id", "inferiallm-dashboard", raising=False)
+    monkeypatch.setattr(orouter.settings, "oauth_redirect_uri", "", raising=False)
+    monkeypatch.setattr(orouter.settings, "external_auth_url", "https://auth.example.com", raising=False)
+    monkeypatch.setattr(orouter.settings, "app_namespace", "inferiallm", raising=False)
+    orouter._oauth_client = None
+
+    app = FastAPI()
+    app.include_router(orouter.router)
+    r = TestClient(app, follow_redirects=False).get("/auth/start")
+    assert r.status_code == 503

--- a/package/src/inferia/services/api_gateway/tests/test_oidc_role_mapping.py
+++ b/package/src/inferia/services/api_gateway/tests/test_oidc_role_mapping.py
@@ -1,0 +1,411 @@
+"""Tests for OIDC group→role mapping in _resolve_oidc_token.
+
+Covers:
+  - empty oidc_role_map (default) → admin with full catalog perms (unchanged behavior)
+  - group match → correct role assigned
+  - viewer role → only viewer perms, no admin-only keys
+  - no group match → oidc_default_role
+  - custom oidc_groups_claim is honored
+  - single-string groups value is coerced to list
+  - unknown role in map → fail-closed (empty permissions)
+  - multiple groups, first match wins
+
+Run with --noconftest to avoid the shared-conftest jwt fixture conflict:
+  PYTHONNOUSERSITE=1 PYTHONPATH=package/src \
+    pytest package/.../tests/test_oidc_role_mapping.py --noconftest
+"""
+
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import inferia.services.api_gateway.rbac.middleware as mw
+from inferia.services.api_gateway.rbac.jwks_verifier import JWKSVerifyError
+from inferia.services.api_gateway.rbac.catalog import CATALOG
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeUser:
+    """Minimal shadow-user stand-in."""
+
+    id = "u1"
+    email = "a@b.com"
+
+
+def _make_verifier(claims: dict):
+    """Return a simple namespace whose verify_sync always returns `claims`."""
+    return types.SimpleNamespace(verify_sync=lambda t: claims)
+
+
+def _admin_perms() -> list[str]:
+    """Return the full admin permission list from the catalog."""
+    return [p for r in CATALOG.roles if r.name == "admin" for p in r.permissions]
+
+
+def _viewer_perms() -> list[str]:
+    """Return the viewer permission list from the catalog."""
+    return [p for r in CATALOG.roles if r.name == "viewer" for p in r.permissions]
+
+
+def _member_perms() -> list[str]:
+    """Return the member permission list from the catalog."""
+    return [p for r in CATALOG.roles if r.name == "member" for p in r.permissions]
+
+
+def _make_settings_stub(
+    oidc_role_map: dict,
+    oidc_groups_claim: str = "groups",
+    oidc_default_role: str = "viewer",
+):
+    """Create a minimal settings stub with only the OIDC-mapping fields."""
+    stub = MagicMock()
+    stub.oidc_role_map = oidc_role_map
+    stub.oidc_groups_claim = oidc_groups_claim
+    stub.oidc_default_role = oidc_default_role
+    return stub
+
+
+def _shadow_mock():
+    """Return a patched get_or_create_shadow_user that yields _FakeUser."""
+    return AsyncMock(return_value=(_FakeUser(), "org1", []))
+
+
+# ---------------------------------------------------------------------------
+# Default: empty oidc_role_map → admin (unchanged interim behavior)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_role_map_gives_admin(monkeypatch):
+    """When oidc_role_map is empty, any authenticated user gets role=admin."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier({"sub": "ext1", "email": "a@b.com", "org_id": "o1",
+                                "groups": ["some-group"]}),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(mw, "settings", _make_settings_stub(oidc_role_map={}))
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["admin"]
+    assert "inferiallm:deployment:write" in ctx.permissions
+    assert set(ctx.permissions) == set(_admin_perms())
+
+
+@pytest.mark.asyncio
+async def test_empty_role_map_no_groups_claim_still_admin(monkeypatch):
+    """Empty map + no groups in token still resolves to admin (default unchanged)."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier({"sub": "ext2", "email": "b@c.com", "org_id": "o2"}),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(mw, "settings", _make_settings_stub(oidc_role_map={}))
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["admin"]
+    assert "inferiallm:deployment:write" in ctx.permissions
+
+
+# ---------------------------------------------------------------------------
+# Group match → admin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_group_match_admin(monkeypatch):
+    """oidc_role_map={"llm-admins":"admin"} + groups=["llm-admins"] → role=admin."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext3", "email": "c@d.com", "org_id": "o3",
+             "groups": ["llm-admins"]}
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(oidc_role_map={"llm-admins": "admin"}),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["admin"]
+    assert set(ctx.permissions) == set(_admin_perms())
+
+
+# ---------------------------------------------------------------------------
+# Group match → viewer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_group_match_viewer(monkeypatch):
+    """oidc_role_map={"llm-users":"viewer"} + groups=["llm-users"] → role=viewer."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext4", "email": "d@e.com", "org_id": "o4",
+             "groups": ["llm-users"]}
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(oidc_role_map={"llm-users": "viewer"}),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["viewer"]
+    # Must include the 3 viewer read keys
+    expected_viewer = set(_viewer_perms())
+    assert set(ctx.permissions) == expected_viewer
+    # Must NOT include admin-only write key
+    assert "inferiallm:deployment:write" not in ctx.permissions
+    assert "inferiallm:model:read" in ctx.permissions
+
+
+# ---------------------------------------------------------------------------
+# No group match → oidc_default_role
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_group_match_falls_back_to_default_role(monkeypatch):
+    """When no group matches the map, oidc_default_role is used."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext5", "email": "e@f.com", "org_id": "o5",
+             "groups": ["other-group", "unrelated"]}
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(
+            oidc_role_map={"x": "admin"},
+            oidc_default_role="viewer",
+        ),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["viewer"]
+    assert set(ctx.permissions) == set(_viewer_perms())
+
+
+@pytest.mark.asyncio
+async def test_no_groups_claim_in_token_falls_back_to_default_role(monkeypatch):
+    """When the groups claim is absent, oidc_default_role is used."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier({"sub": "ext6", "email": "f@g.com", "org_id": "o6"}),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(
+            oidc_role_map={"llm-admins": "admin"},
+            oidc_default_role="viewer",
+        ),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["viewer"]
+
+
+# ---------------------------------------------------------------------------
+# Custom oidc_groups_claim is honored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_custom_groups_claim_is_honored(monkeypatch):
+    """oidc_groups_claim='roles' reads groups from the 'roles' JWT claim."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext7", "email": "g@h.com", "org_id": "o7",
+             "roles": ["llm-admins"],  # custom claim
+             "groups": ["not-used"]}  # default claim should NOT be read
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(
+            oidc_role_map={"llm-admins": "admin", "not-used": "viewer"},
+            oidc_groups_claim="roles",
+        ),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    # The "roles" claim has "llm-admins" → admin
+    assert ctx.roles == ["admin"]
+    assert set(ctx.permissions) == set(_admin_perms())
+
+
+# ---------------------------------------------------------------------------
+# Member role mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_group_match_member(monkeypatch):
+    """Group mapped to 'member' yields member catalog permissions."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext8", "email": "h@i.com", "org_id": "o8",
+             "groups": ["llm-members"]}
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(oidc_role_map={"llm-members": "member"}),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["member"]
+    assert set(ctx.permissions) == set(_member_perms())
+    assert "inferiallm:deployment:write" not in ctx.permissions
+    assert "inferiallm:deployment:read" in ctx.permissions
+
+
+# ---------------------------------------------------------------------------
+# Unknown role in map → fail-closed (empty permissions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_role_in_map_gives_no_permissions(monkeypatch):
+    """A role name that doesn't exist in the catalog yields empty permissions (fail-closed)."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext9", "email": "i@j.com", "org_id": "o9",
+             "groups": ["mystery-group"]}
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(oidc_role_map={"mystery-group": "nonexistent-role"}),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["nonexistent-role"]
+    assert ctx.permissions == []
+
+
+# ---------------------------------------------------------------------------
+# Multiple groups, first match wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_matching_group_wins(monkeypatch):
+    """When multiple groups appear in the map, the first one (iteration order) wins."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext10", "email": "j@k.com", "org_id": "o10",
+             "groups": ["llm-viewers", "llm-admins"]}
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(
+            oidc_role_map={"llm-viewers": "viewer", "llm-admins": "admin"},
+        ),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    # "llm-viewers" appears first in the groups list, so viewer wins
+    assert ctx.roles == ["viewer"]
+
+
+# ---------------------------------------------------------------------------
+# Single string groups coerced to list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_string_groups_claim_is_coerced(monkeypatch):
+    """If the groups claim is a bare string (not a list), it is treated as one-element list."""
+    monkeypatch.setattr(
+        mw, "_get_verifier",
+        lambda: _make_verifier(
+            {"sub": "ext11", "email": "k@l.com", "org_id": "o11",
+             "groups": "llm-admins"}  # string, not list
+        ),
+    )
+    monkeypatch.setattr(mw, "get_or_create_shadow_user", _shadow_mock())
+    monkeypatch.setattr(mw, "_verifier", None)
+    monkeypatch.setattr(
+        mw, "settings",
+        _make_settings_stub(oidc_role_map={"llm-admins": "admin"}),
+    )
+
+    ctx = await mw._resolve_oidc_token(MagicMock(), "tok")
+
+    assert ctx.roles == ["admin"]
+    assert set(ctx.permissions) == set(_admin_perms())
+
+
+# ---------------------------------------------------------------------------
+# _catalog_role_permissions helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_role_permissions_admin():
+    """_catalog_role_permissions('admin') returns the full admin perm list."""
+    perms = mw._catalog_role_permissions("admin")
+    assert set(perms) == set(_admin_perms())
+    assert "inferiallm:deployment:write" in perms
+
+
+def test_catalog_role_permissions_viewer():
+    """_catalog_role_permissions('viewer') returns only the 3 viewer keys."""
+    perms = mw._catalog_role_permissions("viewer")
+    assert set(perms) == set(_viewer_perms())
+    assert len(perms) == 3
+
+
+def test_catalog_role_permissions_member():
+    """_catalog_role_permissions('member') returns the 6 member keys."""
+    perms = mw._catalog_role_permissions("member")
+    assert set(perms) == set(_member_perms())
+
+
+def test_catalog_role_permissions_unknown_returns_empty():
+    """_catalog_role_permissions for an unknown role returns [] (fail-closed)."""
+    assert mw._catalog_role_permissions("superuser") == []
+    assert mw._catalog_role_permissions("") == []
+    assert mw._catalog_role_permissions("ADMIN") == []  # case-sensitive


### PR DESCRIPTION
## Summary
Make InferiaLLM's auth mirror **InferiaGate**: three deployment modes, and have InferiaLLM **self-declare its permission/role catalog** to InferiaAuth instead of InferiaAuth hardcoding it.

Spec/plan: `docs/specs|plans/2026-06-09-inferiallm-auth-modes-and-catalog.md`.

## Three modes (`AUTH_PROVIDER`)
| Mode | Identity owner | Local org/user/team |
|---|---|---|
| `local` (open-source) | InferiaLLM basic user/password | active |
| `oidc` (enterprise self-hosted) | the enterprise's own OIDC IdP | hidden |
| `inferiaauth` (SaaS) | InferiaAuth | hidden |

`external` is accepted as a deprecated alias for `inferiaauth`.

## What's in here
- **Catalog self-declaration** — `rbac/catalog.py` (InferiaLLM's `inferiallm:*` permissions + `admin`/`member`/`viewer` roles) + `rbac/catalog_declare.py` (`PUT …/services/inferiallm/catalog`), declared at boot in `inferiaauth` mode. **Requires the companion InferiaAuth PR** (`feat/inferiallm-catalog-self-declare`) which drops the hardcoded seed.
- **Per-mode request auth** (`rbac/middleware.py`) — local JWT; inferiaauth = JWKS-verify + permissions/roles from token claims; oidc = JWKS-verify (audience-correct) + optional `OIDC_ROLE_MAP` group→role (default: authenticated⇒admin).
- **Redirect-SSO** available in both external modes; SSO compose updated to `inferiaauth`; dashboard `isExternalAuthMode()` helper.
- **Org/user/team moved to the IdP** — backend `require_local_identity` 409-gates the management routers + register routes (login/SSO/data-plane stay open); dashboard hides Organization/Users/Roles in external modes. `local` keeps everything.

## Tests
Every change is TDD'd; unit tests pass per task (catalog, declare client, config modes, middleware modes, oidc mapping, oauth router, local-identity guard, dashboard helper + guard). Full live deploy verification (`make docker-up-sso`, three-mode matrix) is **deferred** to a follow-up.
