### PR TITLE
feat: vLLM cold-deploy robustness — engine-cache AMI bake + reaper reclaim

### DIFF
--- a/package/src/inferia/services/api_gateway/gateway/proxy_routes.py
+++ b/package/src/inferia/services/api_gateway/gateway/proxy_routes.py
@@ -803,3 +803,33 @@ async def proxy_admin_workers(
         target_url=ORCHESTRATION_URL,
         user_context=user_context,
     )
+
+
+@router.api_route("/admin/aws/engine-ami", methods=["GET", "POST"])
+@router.api_route("/admin/aws/engine-ami/{path:path}", methods=["GET", "POST"])
+async def proxy_admin_engine_ami(
+    request: Request,
+    path: str = "",
+    user_context: UserContext = Depends(get_current_user_from_request),
+):
+    """Proxy engine-cache AMI bake/list admin operations to orchestration.
+
+    The orchestration ``/v1/admin/aws/engine-ami`` router trusts the gateway
+    boundary; RBAC is enforced here:
+
+    * ``GET``  → ``DEPLOYMENT_LIST``   — list baked AMIs / poll bake status
+    * ``POST`` → ``DEPLOYMENT_CREATE`` — trigger a bake
+    """
+    method = request.method.upper()
+    if method == "POST":
+        authz_service.require_permission(user_context, PermissionEnum.DEPLOYMENT_CREATE)
+    else:  # GET
+        authz_service.require_permission(user_context, PermissionEnum.DEPLOYMENT_LIST)
+    upstream_path = "v1/admin/aws/engine-ami" + (f"/{path}" if path else "")
+    return await proxy_request(
+        method=request.method,
+        path=upstream_path,
+        request=request,
+        target_url=ORCHESTRATION_URL,
+        user_context=user_context,
+    )

--- a/package/src/inferia/services/api_gateway/gateway/test_proxy_engine_ami.py
+++ b/package/src/inferia/services/api_gateway/gateway/test_proxy_engine_ami.py
@@ -1,0 +1,83 @@
+"""Registration + RBAC-mapping guard for the engine-AMI proxy route.
+
+These tests operate at import level — no DB or running server is required.
+They verify:
+  (a) Both the bare path and the sub-path form are mounted under /api/v1.
+  (b) Only GET + POST are allowed (no DELETE).
+  (c) The handler body references DEPLOYMENT_CREATE and DEPLOYMENT_LIST.
+  (d) The upstream path prefix ``v1/admin/aws/engine-ami`` is present.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from inferia.services.api_gateway.gateway import proxy_routes
+
+
+def test_engine_ami_proxy_route_registered():
+    """Both the bare and sub-path routes must be present on the router."""
+    paths = {getattr(r, "path", None) for r in proxy_routes.router.routes}
+    assert "/api/v1/admin/aws/engine-ami" in paths, (
+        "Bare path /api/v1/admin/aws/engine-ami not registered"
+    )
+    assert "/api/v1/admin/aws/engine-ami/{path:path}" in paths, (
+        "Sub-path /api/v1/admin/aws/engine-ami/{path:path} not registered"
+    )
+
+
+def test_engine_ami_proxy_methods_and_rbac():
+    """The handler must allow GET+POST, forbid DELETE, and enforce DEPLOYMENT_LIST/CREATE."""
+    routes = [
+        r
+        for r in proxy_routes.router.routes
+        if getattr(r, "path", "") == "/api/v1/admin/aws/engine-ami/{path:path}"
+    ]
+    assert routes, "engine-ami sub-path route missing from router"
+
+    methods: set[str] = set()
+    for r in routes:
+        methods |= set(getattr(r, "methods", set()) or set())
+
+    assert {"GET", "POST"} <= methods, (
+        f"Expected GET and POST to be registered; got {methods}"
+    )
+    assert "DELETE" not in methods, (
+        "DELETE must NOT be registered on the engine-ami route"
+    )
+
+    src = inspect.getsource(proxy_routes.proxy_admin_engine_ami)
+    assert "DEPLOYMENT_CREATE" in src, "DEPLOYMENT_CREATE RBAC check missing from handler"
+    assert "DEPLOYMENT_LIST" in src, "DEPLOYMENT_LIST RBAC check missing from handler"
+    assert "v1/admin/aws/engine-ami" in src, "upstream path prefix missing from handler"
+
+
+def test_engine_ami_bare_route_methods():
+    """The bare (no sub-path) route must also expose GET+POST and no DELETE."""
+    routes = [
+        r
+        for r in proxy_routes.router.routes
+        if getattr(r, "path", "") == "/api/v1/admin/aws/engine-ami"
+    ]
+    assert routes, "bare engine-ami route /api/v1/admin/aws/engine-ami missing from router"
+
+    methods: set[str] = set()
+    for r in routes:
+        methods |= set(getattr(r, "methods", set()) or set())
+
+    assert {"GET", "POST"} <= methods, (
+        f"Bare route expected GET and POST; got {methods}"
+    )
+    assert "DELETE" not in methods, (
+        "DELETE must NOT be registered on the bare engine-ami route"
+    )
+
+
+def test_engine_ami_handler_is_named_correctly():
+    """The handler function must exist as ``proxy_admin_engine_ami`` in the module."""
+    assert hasattr(proxy_routes, "proxy_admin_engine_ami"), (
+        "proxy_routes.proxy_admin_engine_ami not found"
+    )
+    assert callable(proxy_routes.proxy_admin_engine_ami), (
+        "proxy_routes.proxy_admin_engine_ami is not callable"
+    )

--- a/package/src/inferia/services/orchestration/api/admin_engine_ami.py
+++ b/package/src/inferia/services/orchestration/api/admin_engine_ami.py
@@ -171,6 +171,7 @@ async def _default_list_engine_amis(region: str) -> list:
         region,
         aws_access_key_id=creds["aws_access_key_id"],
         aws_secret_access_key=creds["aws_secret_access_key"],
+        aws_session_token=creds.get("aws_session_token"),
     )
     resp = await asyncio.to_thread(
         client.describe_images,

--- a/package/src/inferia/services/orchestration/api/admin_engine_ami.py
+++ b/package/src/inferia/services/orchestration/api/admin_engine_ami.py
@@ -1,0 +1,202 @@
+"""Dashboard-facing admin router for baking + listing engine-cache AMIs.
+
+Protected by the existing user-JWT + RBAC system (same _need_perm pattern as
+admin_workers.py). The heavy bake runs as a background task; status is
+best-effort in-memory (lost on CP restart — the AMI artifact is durable and
+listed authoritatively via describe_images)."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+import uuid
+from typing import Any, Callable, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/admin/aws/engine-ami")
+
+
+class _Deps:
+    require_permission: Optional[Callable[[str], Any]] = None
+    start_bake: Optional[Callable[..., Any]] = None
+    list_engine_amis: Optional[Callable[[str], Any]] = None
+
+
+_deps = _Deps()
+# Best-effort in-memory bake status, keyed by bake_id (lost on CP restart).
+_BAKES: dict[str, dict] = {}
+
+
+def configure(
+    *,
+    require_permission: Callable[[str], Any],
+    start_bake: Callable[..., Any] | None = None,
+    list_engine_amis: Callable[[str], Any] | None = None,
+) -> None:
+    _deps.require_permission = require_permission
+    _deps.start_bake = start_bake or _default_start_bake
+    _deps.list_engine_amis = list_engine_amis or _default_list_engine_amis
+
+
+def _need_perm(perm: str):
+    async def _dep(authorization: str | None = Header(default=None)):
+        if _deps.require_permission is None:
+            raise HTTPException(503, "RBAC dependency not configured")
+        check = _deps.require_permission(perm)
+        try:
+            result = check(authorization)
+        except TypeError:
+            result = check()
+        if hasattr(result, "__await__"):
+            result = await result
+        return result
+    return _dep
+
+
+class BakeRequest(BaseModel):
+    region: str
+    vllm_tag: Optional[str] = None
+    instance_type: Optional[str] = None
+    root_volume_gb: Optional[int] = Field(default=None, ge=10, le=16384)
+    include_worker_image: bool = True
+
+
+class BakeResponse(BaseModel):
+    bake_id: str
+    status: str
+
+
+@router.post("/bake", response_model=BakeResponse)
+async def start_bake(body: BakeRequest, _granted: bool = Depends(_need_perm("deployment:create"))):
+    if _deps.start_bake is None:
+        raise HTTPException(503, "engine-ami bake not configured")
+    bake_id = _deps.start_bake(
+        region=body.region,
+        vllm_tag=body.vllm_tag,
+        instance_type=body.instance_type,
+        root_volume_gb=body.root_volume_gb,
+        include_worker_image=body.include_worker_image,
+    )
+    if inspect.iscoroutine(bake_id):
+        bake_id = await bake_id
+    return BakeResponse(bake_id=bake_id, status="running")
+
+
+@router.get("/bake/{bake_id}")
+async def bake_status(bake_id: str, _granted: bool = Depends(_need_perm("deployment:create"))):
+    st = _BAKES.get(bake_id)
+    if st is None:
+        raise HTTPException(404, "unknown bake id")
+    return st
+
+
+@router.get("")
+async def list_amis(region: str = "us-east-1", _granted: bool = Depends(_need_perm("deployment:create"))):
+    if _deps.list_engine_amis is None:
+        raise HTTPException(503, "engine-ami listing not configured")
+    res = _deps.list_engine_amis(region)
+    if inspect.iscoroutine(res):
+        res = await res
+    return {"amis": res}
+
+
+# --- production defaults (used when configure() gets no overrides) -----------
+
+def _default_start_bake(
+    *,
+    region: str,
+    vllm_tag: Optional[str] = None,
+    instance_type: Optional[str] = None,
+    root_volume_gb: Optional[int] = None,
+    include_worker_image: bool = True,
+) -> str:
+    """Resolve creds on the loop, run the sync bake in a thread, recording
+    best-effort status in _BAKES."""
+    from inferia.services.orchestration.services.adapter_engine.adapters.aws.engine_ami_bake import (
+        bake_engine_ami,
+    )
+    from inferia.services.orchestration.services.adapter_engine.aws_orphan_sweep import (
+        resolve_sweep_aws_env,
+    )
+
+    bake_id = str(uuid.uuid4())
+    _BAKES[bake_id] = {"status": "running", "message": "", "ami_id": None, "region": region}
+    worker_ref = _worker_image_ref() if include_worker_image else None
+
+    async def _run():
+        try:
+            aws_env = await resolve_sweep_aws_env()
+            kw = {k: v for k, v in {
+                "vllm_tag": vllm_tag,
+                "instance_type": instance_type,
+                "root_volume_gb": root_volume_gb,
+            }.items() if v is not None}
+            res = await asyncio.to_thread(
+                bake_engine_ami,
+                region=region,
+                aws_env=aws_env,
+                worker_image_ref=worker_ref,
+                ssm_instance_profile=_ssm_instance_profile(),
+                **kw,
+            )
+            _BAKES[bake_id] = {"status": "succeeded", "message": "", "ami_id": res.ami_id, "region": res.region}
+        except Exception as e:  # noqa: BLE001 — surface as best-effort status
+            logger.warning("engine-ami bake %s failed: %s", bake_id, e)
+            _BAKES[bake_id] = {"status": "failed", "message": str(e), "ami_id": None, "region": region}
+
+    asyncio.create_task(_run())
+    return bake_id
+
+
+async def _default_list_engine_amis(region: str) -> list:
+    """Authoritative list via describe_images (creds resolved on the loop, the
+    blocking boto3 call offloaded to a thread)."""
+    from inferia.services.orchestration.services.adapter_engine.adapters.pulumi.ami import (
+        _ENGINE_CACHE_TAG, _engine_ec2_client,
+    )
+    from inferia.services.orchestration.services.adapter_engine.aws_orphan_sweep import (
+        _creds_from_aws_env, resolve_sweep_aws_env,
+    )
+
+    aws_env = await resolve_sweep_aws_env()
+    if not aws_env:
+        return []
+    creds = _creds_from_aws_env(aws_env)
+    client = _engine_ec2_client(
+        region,
+        aws_access_key_id=creds["aws_access_key_id"],
+        aws_secret_access_key=creds["aws_secret_access_key"],
+    )
+    resp = await asyncio.to_thread(
+        client.describe_images,
+        Owners=["self"],
+        Filters=[{"Name": f"tag:{_ENGINE_CACHE_TAG}", "Values": ["true"]}],
+    )
+    out = []
+    for im in resp.get("Images", []) or []:
+        tags = {t["Key"]: t["Value"] for t in im.get("Tags", [])}
+        out.append({
+            "ami_id": im.get("ImageId"),
+            "vllm_tag": tags.get("inferia:vllm-tag"),
+            "region": region,
+            "created": im.get("CreationDate"),
+        })
+    return out
+
+
+def _worker_image_ref() -> Optional[str]:
+    img = os.environ.get("INFERIA_WORKER_IMAGE", "ghcr.io/inferiaai/inferia-worker")
+    tag = os.environ.get("INFERIA_WORKER_IMAGE_TAG", "")
+    return f"{img}:{tag}" if tag else None
+
+
+def _ssm_instance_profile() -> Optional[str]:
+    return os.environ.get("INFERIA_BAKE_SSM_INSTANCE_PROFILE") or None
+
+
+__all__ = ["router", "configure"]

--- a/package/src/inferia/services/orchestration/api/test_admin_engine_ami.py
+++ b/package/src/inferia/services/orchestration/api/test_admin_engine_ami.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, HTTPException
+
+# Repo-wide version skew: starlette 0.35.1 still passes ``app=`` to
+# ``httpx.Client``, which httpx 0.28+ removed. Patch the httpx Client
+# constructor to drop the ``app`` kwarg so TestClient-based tests keep working.
+import httpx as _httpx
+_orig_client_init = _httpx.Client.__init__
+
+
+def _patched_client_init(self, *args, **kwargs):
+    kwargs.pop("app", None)
+    return _orig_client_init(self, *args, **kwargs)
+
+
+_httpx.Client.__init__ = _patched_client_init  # type: ignore[assignment]
+from fastapi.testclient import TestClient  # noqa: E402
+
+from inferia.services.orchestration.api import admin_engine_ami as mod
+
+
+def _raise_forbidden():
+    raise HTTPException(403, "forbidden")
+
+
+def _app(*, perm_ok=True, start_bake=None, list_engine_amis=None):
+    app = FastAPI()
+    mod.configure(
+        require_permission=(lambda perm: (lambda *_a, **_k: True)) if perm_ok
+        else (lambda perm: (lambda *_a, **_k: _raise_forbidden())),
+        start_bake=start_bake or (lambda **kw: "bake-123"),
+        list_engine_amis=list_engine_amis or (lambda region: [
+            {"ami_id": "ami-1", "vllm_tag": "v0.22.1", "region": region, "created": "2026-06-08"}
+        ]),
+    )
+    app.include_router(mod.router)
+    return app
+
+
+def test_routes_registered_not_404():
+    client = TestClient(_app())
+    assert client.get("/v1/admin/aws/engine-ami").status_code != 404
+    assert client.post("/v1/admin/aws/engine-ami/bake", json={"region": "us-east-1"}).status_code != 404
+
+
+def test_list_maps_describe_images():
+    client = TestClient(_app())
+    r = client.get("/v1/admin/aws/engine-ami")
+    assert r.status_code == 200
+    assert r.json()["amis"][0]["ami_id"] == "ami-1"
+
+
+def test_bake_starts_task_returns_id():
+    client = TestClient(_app())
+    r = client.post("/v1/admin/aws/engine-ami/bake", json={"region": "us-east-1"})
+    assert r.status_code == 200
+    assert r.json()["bake_id"] == "bake-123"
+    assert r.json()["status"] == "running"
+
+
+def test_bake_forbidden_without_perm():
+    client = TestClient(_app(perm_ok=False))
+    r = client.post("/v1/admin/aws/engine-ami/bake", json={"region": "us-east-1"})
+    assert r.status_code == 403
+
+
+def test_async_lister_awaited():
+    async def _alist(region):
+        return [{"ami_id": "ami-async", "vllm_tag": "v0.22.1", "region": region, "created": "x"}]
+    client = TestClient(_app(list_engine_amis=_alist))
+    r = client.get("/v1/admin/aws/engine-ami")
+    assert r.status_code == 200 and r.json()["amis"][0]["ami_id"] == "ami-async"
+
+
+def test_bake_status_unknown_404():
+    client = TestClient(_app())
+    assert client.get("/v1/admin/aws/engine-ami/bake/nope").status_code == 404
+
+
+def test_server_registers_engine_ami_router():
+    # Wire-up guard (handler unit tests with hand-mounted routers do NOT catch a
+    # forgotten include_router/configure in server.py). Assert the source wires it.
+    src = Path(mod.__file__).resolve().parents[1].joinpath("server.py").read_text()
+    assert "admin_engine_ami" in src, "server.py must import the engine-ami router"
+    assert "admin_engine_ami_api.configure(" in src, "server.py must configure() the router"
+    assert "include_router(admin_engine_ami_api.router)" in src, "server.py must include_router the engine-ami router"

--- a/package/src/inferia/services/orchestration/api/test_admin_engine_ami.py
+++ b/package/src/inferia/services/orchestration/api/test_admin_engine_ami.py
@@ -86,3 +86,92 @@ def test_server_registers_engine_ami_router():
     assert "admin_engine_ami" in src, "server.py must import the engine-ami router"
     assert "admin_engine_ami_api.configure(" in src, "server.py must configure() the router"
     assert "include_router(admin_engine_ami_api.router)" in src, "server.py must include_router the engine-ami router"
+
+
+# --- Fix I2: coverage for production default helpers ---
+
+import types
+from unittest.mock import AsyncMock
+
+import inferia.services.orchestration.services.adapter_engine.adapters.aws.engine_ami_bake as _eab
+import inferia.services.orchestration.services.adapter_engine.aws_orphan_sweep as _sweep
+import inferia.services.orchestration.services.adapter_engine.adapters.pulumi.ami as _ami
+
+
+def test_worker_image_ref(monkeypatch):
+    monkeypatch.setenv("INFERIA_WORKER_IMAGE", "ghcr.io/x/worker")
+    monkeypatch.setenv("INFERIA_WORKER_IMAGE_TAG", "0.2.5")
+    assert mod._worker_image_ref() == "ghcr.io/x/worker:0.2.5"
+
+
+def test_worker_image_ref_none_without_tag(monkeypatch):
+    monkeypatch.delenv("INFERIA_WORKER_IMAGE_TAG", raising=False)
+    assert mod._worker_image_ref() is None
+
+
+def test_ssm_instance_profile(monkeypatch):
+    monkeypatch.delenv("INFERIA_BAKE_SSM_INSTANCE_PROFILE", raising=False)
+    assert mod._ssm_instance_profile() is None
+    monkeypatch.setenv("INFERIA_BAKE_SSM_INSTANCE_PROFILE", "prof")
+    assert mod._ssm_instance_profile() == "prof"
+
+
+@pytest.mark.asyncio
+async def test_default_start_bake_records_success(monkeypatch):
+    monkeypatch.setattr(_sweep, "resolve_sweep_aws_env",
+                        AsyncMock(return_value={"AWS_ACCESS_KEY_ID": "k", "AWS_SECRET_ACCESS_KEY": "s"}))
+    monkeypatch.setattr(_eab, "bake_engine_ami",
+                        lambda **kw: types.SimpleNamespace(ami_id="ami-z", region=kw["region"]))
+    captured = {}
+    monkeypatch.setattr(mod.asyncio, "create_task", lambda coro: captured.setdefault("coro", coro))
+    bake_id = mod._default_start_bake(region="us-east-1", include_worker_image=False)
+    assert mod._BAKES[bake_id]["status"] == "running"
+    await captured["coro"]
+    assert mod._BAKES[bake_id]["status"] == "succeeded"
+    assert mod._BAKES[bake_id]["ami_id"] == "ami-z"
+
+
+@pytest.mark.asyncio
+async def test_default_start_bake_records_failure(monkeypatch):
+    monkeypatch.setattr(_sweep, "resolve_sweep_aws_env",
+                        AsyncMock(return_value={"AWS_ACCESS_KEY_ID": "k", "AWS_SECRET_ACCESS_KEY": "s"}))
+    def _boom(**kw):
+        raise RuntimeError("nope")
+    monkeypatch.setattr(_eab, "bake_engine_ami", _boom)
+    captured = {}
+    monkeypatch.setattr(mod.asyncio, "create_task", lambda coro: captured.setdefault("coro", coro))
+    bake_id = mod._default_start_bake(region="us-east-1")
+    await captured["coro"]
+    assert mod._BAKES[bake_id]["status"] == "failed"
+    assert "nope" in mod._BAKES[bake_id]["message"]
+
+
+@pytest.mark.asyncio
+async def test_default_list_engine_amis_maps(monkeypatch):
+    monkeypatch.setattr(_sweep, "resolve_sweep_aws_env",
+                        AsyncMock(return_value={"AWS_ACCESS_KEY_ID": "k", "AWS_SECRET_ACCESS_KEY": "s"}))
+    class _FakeEC2:
+        def describe_images(self, **kw):
+            self.kw = kw
+            return {"Images": [{"ImageId": "ami-1", "CreationDate": "2026-06-08",
+                                 "Tags": [{"Key": "inferia:vllm-tag", "Value": "v0.22.1"}]}]}
+    fake = _FakeEC2()
+    monkeypatch.setattr(_ami, "_engine_ec2_client", lambda region, **kw: fake)
+    out = await mod._default_list_engine_amis("us-east-1")
+    assert out[0]["ami_id"] == "ami-1" and out[0]["vllm_tag"] == "v0.22.1"
+
+
+@pytest.mark.asyncio
+async def test_default_list_engine_amis_no_creds(monkeypatch):
+    monkeypatch.setattr(_sweep, "resolve_sweep_aws_env", AsyncMock(return_value=None))
+    assert await mod._default_list_engine_amis("us-east-1") == []
+
+
+def test_list_503_when_not_configured(monkeypatch):
+    # Direct misconfiguration: lister unset -> 503.
+    from fastapi import FastAPI
+    app = FastAPI()
+    mod.configure(require_permission=lambda perm: (lambda *_a, **_k: True))
+    mod._deps.list_engine_amis = None
+    app.include_router(mod.router)
+    assert TestClient(app).get("/v1/admin/aws/engine-ami").status_code == 503

--- a/package/src/inferia/services/orchestration/api/test_startup_wiring.py
+++ b/package/src/inferia/services/orchestration/api/test_startup_wiring.py
@@ -9,7 +9,21 @@ both routers expose the expected paths.
 from __future__ import annotations
 
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
+
+# Repo-wide version skew: starlette 0.35.1 still passes ``app=`` to
+# ``httpx.Client``, which httpx 0.28+ removed. Patch the httpx Client
+# constructor to drop the ``app`` kwarg so TestClient-based tests keep working.
+import httpx as _httpx
+_orig_client_init = _httpx.Client.__init__
+
+
+def _patched_client_init(self, *args, **kwargs):
+    kwargs.pop("app", None)
+    return _orig_client_init(self, *args, **kwargs)
+
+
+_httpx.Client.__init__ = _patched_client_init  # type: ignore[assignment]
+from fastapi.testclient import TestClient  # noqa: E402
 
 from inferia.services.orchestration.api import admin_workers, workers
 from inferia.services.orchestration.services.worker_controller.auth import (

--- a/package/src/inferia/services/orchestration/server.py
+++ b/package/src/inferia/services/orchestration/server.py
@@ -40,6 +40,7 @@ from inferia.services.orchestration.services.model_deployment.deployment_server 
 )
 from inferia.services.orchestration.api import workers as workers_api
 from inferia.services.orchestration.api import admin_workers as admin_workers_api
+from inferia.services.orchestration.api import admin_engine_ami as admin_engine_ami_api
 from inferia.services.orchestration.api import nodes as nodes_api
 from inferia.services.orchestration.api import providers as providers_api
 from inferia.services.orchestration.services.adapter_engine.registry import (
@@ -364,6 +365,7 @@ async def serve():
         require_permission=_permit_all,
         db_pool=db_pool,
     )
+    admin_engine_ami_api.configure(require_permission=_permit_all)
 
     # /v1/nodes/* — the new node-centric API. Wires only those adapters that
     # implement provision_single_node (Nosana, Akash); the worker adapter is
@@ -450,6 +452,7 @@ async def serve():
     app.include_router(deployment_engine_router)
     app.include_router(workers_api.router)
     app.include_router(admin_workers_api.router)
+    app.include_router(admin_engine_ami_api.router)
     app.include_router(nodes_api.router)
     app.include_router(providers_api.router)
 

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/engine_ami_bake.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/engine_ami_bake.py
@@ -1,0 +1,227 @@
+"""Bake a custom EC2 AMI with the vLLM engine image (and worker image)
+pre-pulled + extracted, so cold GPU nodes skip the ~15-20 min pull+extract.
+
+Sync boto3 (mirrors aws_orphan_sweep.py): client seams are monkeypatchable;
+``aws_env`` is resolved by the async caller and passed in. The builder is a
+CPU instance (avoids the G-vCPU quota; docker pull+extract needs no GPU); the
+resulting AMI is launchable on x86_64 GPU instances. See
+docs/specs/2026-06-09-vllm-deploy-robustness-design.md.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from inferia.services.orchestration.services.adapter_engine.adapters.pulumi.ami import (
+    latest_dlami_ami,
+)
+from inferia.services.orchestration.services.adapter_engine.aws_orphan_sweep import (
+    _creds_from_aws_env,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_VLLM_TAG = "v0.22.1"
+_DEFAULT_INSTANCE_TYPE = "t3.xlarge"  # CPU; standard quota; x86_64
+_DEFAULT_ROOT_GB = 100                # matches the GPU launch root_volume_gb
+_BUILDER_TAG = "inferia:engine-ami-builder"
+_ENGINE_CACHE_TAG = "inferia:engine-cache"
+_SSM_ONLINE_TIMEOUT_S = 300
+_SSM_CMD_TIMEOUT_S = 1800
+
+# Valid OCI image-reference characters (registry/host . : / , name _ - , tag : ,
+# digest @). Anything else (whitespace, ; | & $ ` newlines) is a shell-injection
+# vector because the ref is interpolated into the SSM shell script.
+_IMAGE_REF_RE = re.compile(r"^[A-Za-z0-9_./:@-]+$")
+
+
+class BakeError(RuntimeError):
+    """Any failure in the bake pipeline, string-classified for the caller."""
+
+
+def _validate_image_ref(ref: str) -> str:
+    """Reject image refs that could break out of the `docker pull <ref>` shell
+    line in the SSM bake script. Mirrors bootstrap_builder's input-hardening."""
+    if not ref or "\x00" in ref or len(ref) > 512 or not _IMAGE_REF_RE.match(ref):
+        raise BakeError(f"invalid/unsafe image reference: {ref!r}")
+    return ref
+
+
+@dataclass
+class BakeResult:
+    ami_id: str
+    region: str
+    vllm_tag: str
+    base_dlami: str
+
+
+def _ec2_client(region: str, *, creds: dict):
+    import boto3
+    return boto3.client("ec2", region_name=region, **creds)
+
+
+def _ssm_client(region: str, *, creds: dict):
+    import boto3
+    return boto3.client("ssm", region_name=region, **creds)
+
+
+def _build_bake_script(*, vllm_image: str, worker_image: Optional[str]) -> str:
+    """Shell script run on the builder via SSM. Installs docker + the
+    nvidia-container-toolkit UNCONDITIONALLY (the CPU builder has no NVIDIA
+    device, so an lspci-guarded install would skip and the AMI would lack the
+    runtime shim that GPU nodes need), then pulls the images so they are baked
+    into the image store."""
+    _validate_image_ref(vllm_image)
+    if worker_image:
+        _validate_image_ref(worker_image)
+    lines = [
+        "set -euxo pipefail",
+        "export DEBIAN_FRONTEND=noninteractive",
+        "if ! command -v docker >/dev/null; then curl -fsSL https://get.docker.com | sh; fi",
+        "distribution=$(. /etc/os-release; echo $ID$VERSION_ID)",
+        "curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg",
+        "curl -fsSL https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list",
+        "apt-get -o DPkg::Lock::Timeout=600 update",
+        "apt-get -o DPkg::Lock::Timeout=600 install -y nvidia-container-toolkit",
+        "nvidia-ctk runtime configure --runtime=docker",
+        "systemctl restart docker",
+        f"docker pull {vllm_image}",
+    ]
+    if worker_image:
+        lines.append(f"docker pull {worker_image}")
+    lines.append("docker image ls")
+    return "\n".join(lines)
+
+
+def bake_engine_ami(
+    *,
+    region: str,
+    aws_env: Optional[dict],
+    vllm_tag: str = _DEFAULT_VLLM_TAG,
+    worker_image_ref: Optional[str] = None,
+    instance_type: str = _DEFAULT_INSTANCE_TYPE,
+    root_volume_gb: int = _DEFAULT_ROOT_GB,
+    ssm_instance_profile: Optional[str] = None,
+) -> BakeResult:
+    if not aws_env:
+        raise BakeError("no AWS credentials resolved for the bake")
+    if not ssm_instance_profile:
+        raise BakeError(
+            "ssm_instance_profile is required (builder must be SSM-managed); "
+            "configure an instance profile with AmazonSSMManagedInstanceCore"
+        )
+    creds = _creds_from_aws_env(aws_env)
+    dlami = latest_dlami_ami(
+        region,
+        aws_access_key_id=creds["aws_access_key_id"],
+        aws_secret_access_key=creds["aws_secret_access_key"],
+    )
+    vllm_image = f"docker.io/vllm/vllm-openai:{vllm_tag}"
+    script = _build_bake_script(vllm_image=vllm_image, worker_image=worker_image_ref)
+
+    ec2 = _ec2_client(region, creds=creds)
+    ssm = _ssm_client(region, creds=creds)
+    instance_id: Optional[str] = None
+    try:
+        run = ec2.run_instances(
+            ImageId=dlami,
+            InstanceType=instance_type,
+            MinCount=1,
+            MaxCount=1,
+            IamInstanceProfile={"Name": ssm_instance_profile},
+            BlockDeviceMappings=[{
+                "DeviceName": "/dev/sda1",
+                "Ebs": {"VolumeSize": int(root_volume_gb), "VolumeType": "gp3"},
+            }],
+            TagSpecifications=[{
+                "ResourceType": "instance",
+                "Tags": [
+                    {"Key": "Name", "Value": f"inferia-engine-ami-builder-{vllm_tag}"},
+                    {"Key": _BUILDER_TAG, "Value": "true"},
+                ],
+            }],
+        )
+        instance_id = run["Instances"][0]["InstanceId"]
+        logger.info("engine_ami_bake: builder %s launching in %s", instance_id, region)
+
+        ec2.get_waiter("instance_running").wait(InstanceIds=[instance_id])
+
+        deadline = time.time() + _SSM_ONLINE_TIMEOUT_S
+        while time.time() < deadline:
+            info = ssm.describe_instance_information(
+                Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
+            )
+            if info.get("InstanceInformationList"):
+                break
+            time.sleep(10)
+        else:
+            raise BakeError(f"builder {instance_id} never became SSM-managed")
+
+        cmd = ssm.send_command(
+            InstanceIds=[instance_id],
+            DocumentName="AWS-RunShellScript",
+            Parameters={"commands": [script]},
+            TimeoutSeconds=_SSM_CMD_TIMEOUT_S,
+        )
+        command_id = cmd["Command"]["CommandId"]
+        status = _wait_ssm(ssm, command_id, instance_id)
+        if status["Status"] != "Success":
+            raise BakeError(
+                f"bake command status={status['Status']}: "
+                f"{(status.get('StandardErrorContent') or '')[-500:]}"
+            )
+
+        ec2.stop_instances(InstanceIds=[instance_id])
+        ec2.get_waiter("instance_stopped").wait(InstanceIds=[instance_id])
+
+        img = ec2.create_image(
+            InstanceId=instance_id,
+            Name=f"inferia-engine-cache-{vllm_tag}-{instance_id}",
+            Description=f"DLAMI {dlami} + vllm-openai:{vllm_tag} pre-pulled",
+        )
+        ami_id = img["ImageId"]
+        ec2.create_tags(
+            Resources=[ami_id],
+            Tags=[
+                {"Key": _ENGINE_CACHE_TAG, "Value": "true"},
+                {"Key": "inferia:vllm-tag", "Value": vllm_tag},
+                {"Key": "inferia:base-dlami", "Value": dlami},
+                {"Key": "Name", "Value": f"inferia-engine-cache-{vllm_tag}"},
+            ],
+        )
+        ec2.get_waiter("image_available").wait(ImageIds=[ami_id])
+        logger.info("engine_ami_bake: baked %s in %s", ami_id, region)
+        return BakeResult(ami_id=ami_id, region=region, vllm_tag=vllm_tag, base_dlami=dlami)
+    except BakeError:
+        raise
+    except Exception as e:  # noqa: BLE001
+        raise BakeError(f"{type(e).__name__}: {e}") from e
+    finally:
+        if instance_id:
+            try:
+                ec2.terminate_instances(InstanceIds=[instance_id])
+                logger.info("engine_ami_bake: terminated builder %s", instance_id)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("engine_ami_bake: failed to terminate builder %s: %s", instance_id, e)
+
+
+def _wait_ssm(ssm, command_id: str, instance_id: str) -> dict:
+    deadline = time.time() + _SSM_CMD_TIMEOUT_S + 60
+    terminal = {"Success", "Failed", "Cancelled", "TimedOut"}
+    last = {"Status": "Pending"}
+    while time.time() < deadline:
+        try:
+            last = ssm.get_command_invocation(CommandId=command_id, InstanceId=instance_id)
+        except Exception:  # noqa: BLE001 — invocation not registered yet
+            time.sleep(5)
+            continue
+        if last.get("Status") in terminal:
+            return last
+        time.sleep(10)
+    return {"Status": "TimedOut", "StandardErrorContent": "SSM command poll timed out"}
+
+
+__all__ = ["bake_engine_ami", "BakeResult", "BakeError"]

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/engine_ami_bake.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/engine_ami_bake.py
@@ -24,6 +24,10 @@ from inferia.services.orchestration.services.adapter_engine.aws_orphan_sweep imp
 
 logger = logging.getLogger(__name__)
 
+# MUST match the vLLM image tag the worker pulls
+# (inferia-worker internal/runtime/recipes/recipes.go → vllm-openai:v0.22.1).
+# If these diverge the baked AMI is a cache MISS and the speedup silently
+# vanishes — bump both together.
 _DEFAULT_VLLM_TAG = "v0.22.1"
 _DEFAULT_INSTANCE_TYPE = "t3.xlarge"  # CPU; standard quota; x86_64
 _DEFAULT_ROOT_GB = 100                # matches the GPU launch root_volume_gb
@@ -96,6 +100,20 @@ def _build_bake_script(*, vllm_image: str, worker_image: Optional[str]) -> str:
     return "\n".join(lines)
 
 
+def _dlami_root_device(ec2, ami_id: str) -> str:
+    """Resolve the base AMI's actual root device name so the size override in
+    BlockDeviceMappings isn't silently dropped (boto3 ignores a mapping whose
+    DeviceName != the AMI root device). Best-effort → /dev/sda1 fallback."""
+    try:
+        resp = ec2.describe_images(ImageIds=[ami_id])
+        imgs = resp.get("Images") or []
+        if imgs and imgs[0].get("RootDeviceName"):
+            return imgs[0]["RootDeviceName"]
+    except Exception:  # noqa: BLE001 — best-effort; default below
+        pass
+    return "/dev/sda1"
+
+
 def bake_engine_ami(
     *,
     region: str,
@@ -125,6 +143,7 @@ def bake_engine_ami(
     ec2 = _ec2_client(region, creds=creds)
     ssm = _ssm_client(region, creds=creds)
     instance_id: Optional[str] = None
+    root_device = _dlami_root_device(ec2, dlami)
     try:
         run = ec2.run_instances(
             ImageId=dlami,
@@ -133,7 +152,7 @@ def bake_engine_ami(
             MaxCount=1,
             IamInstanceProfile={"Name": ssm_instance_profile},
             BlockDeviceMappings=[{
-                "DeviceName": "/dev/sda1",
+                "DeviceName": root_device,
                 "Ebs": {"VolumeSize": int(root_volume_gb), "VolumeType": "gp3"},
             }],
             TagSpecifications=[{

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_engine_ami_bake.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_engine_ami_bake.py
@@ -1,0 +1,178 @@
+import pytest
+
+from inferia.services.orchestration.services.adapter_engine.adapters.aws import (
+    engine_ami_bake as bake,
+)
+
+AWS_ENV = {"AWS_ACCESS_KEY_ID": "k", "AWS_SECRET_ACCESS_KEY": "s"}
+
+
+def test_build_bake_script_installs_toolkit_unconditionally():
+    script = bake._build_bake_script(
+        vllm_image="docker.io/vllm/vllm-openai:v0.22.1",
+        worker_image="ghcr.io/inferiaai/inferia-worker:0.2.5",
+    )
+    assert "lspci" not in script
+    assert "command -v nvidia-ctk" not in script
+    assert "nvidia-container-toolkit" in script
+    assert "nvidia-ctk runtime configure --runtime=docker" in script
+    assert "docker.io/vllm/vllm-openai:v0.22.1" in script
+    assert "ghcr.io/inferiaai/inferia-worker:0.2.5" in script
+
+
+def test_build_bake_script_omits_worker_pull_when_none():
+    script = bake._build_bake_script(vllm_image="img:tag", worker_image=None)
+    assert "docker pull img:tag" in script
+    assert script.count("docker pull") == 1
+
+
+def test_bake_requires_instance_profile():
+    with pytest.raises(bake.BakeError):
+        bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile=None)
+
+
+def test_bake_requires_aws_env():
+    with pytest.raises(bake.BakeError):
+        bake.bake_engine_ami(region="us-east-1", aws_env=None, ssm_instance_profile="p")
+
+
+class _FakeEC2:
+    def __init__(self):
+        self.terminated = []
+        self.created_image = None
+        self.tagged = None
+        self.waiters = []
+
+    def run_instances(self, **kw):
+        self.run_kwargs = kw
+        return {"Instances": [{"InstanceId": "i-build"}]}
+
+    def stop_instances(self, **kw):
+        self.stopped = kw["InstanceIds"]
+
+    def create_image(self, **kw):
+        self.created_image = kw
+        return {"ImageId": "ami-baked"}
+
+    def create_tags(self, **kw):
+        self.tagged = kw
+
+    def terminate_instances(self, **kw):
+        self.terminated.extend(kw["InstanceIds"])
+
+    def get_waiter(self, name):
+        self.waiters.append(name)
+        return _NoopWaiter()
+
+
+class _NoopWaiter:
+    def wait(self, **kw):
+        return None
+
+
+class _FakeSSM:
+    def __init__(self, status="Success"):
+        self._status = status
+        self.online = True
+
+    def describe_instance_information(self, **kw):
+        return {"InstanceInformationList": [{"InstanceId": "i-build"}]} if self.online else {"InstanceInformationList": []}
+
+    def send_command(self, **kw):
+        self.command = kw
+        return {"Command": {"CommandId": "cmd-1"}}
+
+    def get_command_invocation(self, **kw):
+        return {"Status": self._status, "StandardErrorContent": "boom"}
+
+
+def _patch(monkeypatch, ec2, ssm):
+    monkeypatch.setattr(bake, "_ec2_client", lambda region, **kw: ec2)
+    monkeypatch.setattr(bake, "_ssm_client", lambda region, **kw: ssm)
+    monkeypatch.setattr(bake, "latest_dlami_ami", lambda *a, **k: "ami-dlami")
+
+
+def test_bake_happy_path(monkeypatch):
+    ec2, ssm = _FakeEC2(), _FakeSSM("Success")
+    _patch(monkeypatch, ec2, ssm)
+    res = bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="inferia-bake-ssm")
+    assert res.ami_id == "ami-baked"
+    assert res.region == "us-east-1"
+    assert ec2.terminated == ["i-build"]
+    tag_keys = {t["Key"] for t in ec2.tagged["Tags"]}
+    assert "inferia:engine-cache" in tag_keys and "inferia:vllm-tag" in tag_keys
+    assert "image_available" in ec2.waiters
+
+
+def test_bake_ssm_failure_terminates_builder(monkeypatch):
+    ec2, ssm = _FakeEC2(), _FakeSSM("Failed")
+    _patch(monkeypatch, ec2, ssm)
+    with pytest.raises(bake.BakeError) as ei:
+        bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="inferia-bake-ssm")
+    assert "boom" in str(ei.value)
+    assert ec2.terminated == ["i-build"]
+    assert ec2.created_image is None
+
+
+def test_bake_create_image_failure_terminates_builder(monkeypatch):
+    ec2, ssm = _FakeEC2(), _FakeSSM("Success")
+    def boom(**kw):
+        raise RuntimeError("CreateImage denied")
+    ec2.create_image = boom
+    _patch(monkeypatch, ec2, ssm)
+    with pytest.raises(bake.BakeError):
+        bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="inferia-bake-ssm")
+    assert ec2.terminated == ["i-build"]
+
+
+def test_build_bake_script_rejects_injection():
+    with pytest.raises(bake.BakeError):
+        bake._build_bake_script(vllm_image="img:v1; rm -rf /tmp", worker_image=None)
+
+
+def test_build_bake_script_rejects_injection_in_worker():
+    with pytest.raises(bake.BakeError):
+        bake._build_bake_script(vllm_image="img:tag", worker_image="w:1 && curl evil")
+
+
+def test_bake_injection_tag_fails_before_launch(monkeypatch):
+    ec2, ssm = _FakeEC2(), _FakeSSM("Success")
+    _patch(monkeypatch, ec2, ssm)
+    with pytest.raises(bake.BakeError):
+        bake.bake_engine_ami(
+            region="us-east-1", aws_env=AWS_ENV,
+            ssm_instance_profile="p", vllm_tag="v1; rm -rf /",
+        )
+    # Validation happens before run_instances, so no builder was launched.
+    assert ec2.terminated == []
+
+
+def test_bake_ssm_never_online_terminates_builder(monkeypatch):
+    ec2, ssm = _FakeEC2(), _FakeSSM("Success")
+    ssm.online = False
+    _patch(monkeypatch, ec2, ssm)
+    monkeypatch.setattr(bake, "_SSM_ONLINE_TIMEOUT_S", -1)  # deadline already past
+    with pytest.raises(bake.BakeError) as ei:
+        bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="p")
+    assert "SSM-managed" in str(ei.value)
+    assert ec2.terminated == ["i-build"]  # finally still terminates
+
+
+def test_wait_ssm_times_out(monkeypatch):
+    monkeypatch.setattr(bake, "_SSM_CMD_TIMEOUT_S", -61)  # deadline already past
+    ssm = _FakeSSM("Pending")
+    out = bake._wait_ssm(ssm, "cmd-1", "i-build")
+    assert out["Status"] == "TimedOut"
+
+
+def test_wait_ssm_retries_on_transient_error(monkeypatch):
+    monkeypatch.setattr(bake.time, "sleep", lambda *a, **k: None)
+    calls = {"n": 0}
+    class _FlakySSM:
+        def get_command_invocation(self, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("InvocationDoesNotExist")
+            return {"Status": "Success"}
+    out = bake._wait_ssm(_FlakySSM(), "cmd-1", "i-build")
+    assert out["Status"] == "Success" and calls["n"] == 2

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_engine_ami_bake.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_engine_ami_bake.py
@@ -60,6 +60,9 @@ class _FakeEC2:
     def terminate_instances(self, **kw):
         self.terminated.extend(kw["InstanceIds"])
 
+    def describe_images(self, **kw):
+        return {"Images": [{"RootDeviceName": "/dev/sda1"}]}
+
     def get_waiter(self, name):
         self.waiters.append(name)
         return _NoopWaiter()
@@ -176,3 +179,21 @@ def test_wait_ssm_retries_on_transient_error(monkeypatch):
             return {"Status": "Success"}
     out = bake._wait_ssm(_FlakySSM(), "cmd-1", "i-build")
     assert out["Status"] == "Success" and calls["n"] == 2
+
+
+def test_bake_uses_resolved_root_device(monkeypatch):
+    ec2, ssm = _FakeEC2(), _FakeSSM("Success")
+    # DLAMI reports a non-/dev/sda1 root device; the launch must use it.
+    ec2.describe_images = lambda **kw: {"Images": [{"RootDeviceName": "/dev/xvda"}]}
+    _patch(monkeypatch, ec2, ssm)
+    bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="p")
+    bdm = ec2.run_kwargs["BlockDeviceMappings"][0]
+    assert bdm["DeviceName"] == "/dev/xvda"
+    assert bdm["Ebs"]["VolumeSize"] == 100
+
+
+def test_dlami_root_device_falls_back(monkeypatch):
+    class _Boom:
+        def describe_images(self, **kw):
+            raise RuntimeError("denied")
+    assert bake._dlami_root_device(_Boom(), "ami-x") == "/dev/sda1"

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/ami.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/ami.py
@@ -1,4 +1,4 @@
-"""DLAMI lookup helper.
+"""AMI resolution helpers (DLAMI, plain Ubuntu, and baked engine-cache AMIs).
 
 Resolves the latest AWS Deep Learning AMI for Ubuntu 22.04 + NVIDIA driver
 via SSM Public Parameters, with a per-region in-memory cache (TTL 1 h).
@@ -29,6 +29,12 @@ _UBUNTU_PARAMETER = (
 )
 _DLAMI_TTL_S = 3600
 _DLAMI_CACHE: Dict[str, Tuple[str, float]] = {}
+
+# Tag stamped on baked engine-cache AMIs (see engine_ami_bake.py). resolve_ami
+# prefers the newest such AMI over the stock DLAMI for GPU classes.
+_ENGINE_CACHE_TAG = "inferia:engine-cache"
+_ENGINE_AMI_TTL_S = 300
+_ENGINE_AMI_CACHE: Dict[str, Tuple[Optional[str], float]] = {}
 
 
 def latest_dlami_ami(
@@ -71,6 +77,58 @@ def latest_dlami_ami(
     return value
 
 
+def _engine_ec2_client(region: str, *, aws_access_key_id=None, aws_secret_access_key=None):
+    """boto3 EC2 client for the engine-AMI lookup. Separate seam so tests can
+    monkeypatch it without importing boto3 / hitting AWS (mirrors this module's
+    credential-threading style)."""
+    import boto3
+
+    kwargs = {"region_name": region}
+    if aws_access_key_id and aws_secret_access_key:
+        kwargs["aws_access_key_id"] = aws_access_key_id
+        kwargs["aws_secret_access_key"] = aws_secret_access_key
+    return boto3.client("ec2", **kwargs)
+
+
+def find_engine_ami(
+    region: str,
+    *,
+    aws_access_key_id: Optional[str] = None,
+    aws_secret_access_key: Optional[str] = None,
+) -> Optional[str]:
+    """Return the newest available engine-cache AMI in ``region`` (tagged
+    ``inferia:engine-cache=true`` and owned by this account), or ``None`` when
+    none has been baked. Per-region TTL-cached (300 s) so repeated preflights
+    are cheap but a freshly-baked AMI is picked up within minutes."""
+    now = time.time()
+    cached = _ENGINE_AMI_CACHE.get(region)
+    if cached and (now - cached[1]) < _ENGINE_AMI_TTL_S:
+        return cached[0]
+    try:
+        client = _engine_ec2_client(
+            region,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+        )
+        resp = client.describe_images(
+            Owners=["self"],
+            Filters=[
+                {"Name": f"tag:{_ENGINE_CACHE_TAG}", "Values": ["true"]},
+                {"Name": "state", "Values": ["available"]},
+            ],
+        )
+    except Exception:  # noqa: BLE001 — best-effort; never block provisioning
+        return None
+    images = resp.get("Images") or []
+    if not images:
+        _ENGINE_AMI_CACHE[region] = (None, now)
+        return None
+    newest = max(images, key=lambda im: im.get("CreationDate", ""))
+    ami_id = newest.get("ImageId")
+    _ENGINE_AMI_CACHE[region] = (ami_id, now)
+    return ami_id
+
+
 # Re-exported so callers can switch to the plain Ubuntu image for CPU-only
 # instance types (NVIDIA driver isn't useful on a t3.micro).
 PLAIN_UBUNTU_PARAMETER = _UBUNTU_PARAMETER
@@ -101,6 +159,16 @@ def resolve_ami(
     """
     aws_access_key_id = creds.access_key_id if creds is not None else None
     aws_secret_access_key = creds.secret_access_key if creds is not None else None
+
+    if instance_class in _GPU_INSTANCE_CLASSES:
+        engine = find_engine_ami(
+            region,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+        )
+        if engine:
+            return engine
+
     parameter = (
         _DLAMI_PARAMETER if instance_class in _GPU_INSTANCE_CLASSES
         else _UBUNTU_PARAMETER

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/ami.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/ami.py
@@ -77,7 +77,7 @@ def latest_dlami_ami(
     return value
 
 
-def _engine_ec2_client(region: str, *, aws_access_key_id=None, aws_secret_access_key=None):
+def _engine_ec2_client(region: str, *, aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None):
     """boto3 EC2 client for the engine-AMI lookup. Separate seam so tests can
     monkeypatch it without importing boto3 / hitting AWS (mirrors this module's
     credential-threading style)."""
@@ -87,6 +87,8 @@ def _engine_ec2_client(region: str, *, aws_access_key_id=None, aws_secret_access
     if aws_access_key_id and aws_secret_access_key:
         kwargs["aws_access_key_id"] = aws_access_key_id
         kwargs["aws_secret_access_key"] = aws_secret_access_key
+        if aws_session_token:
+            kwargs["aws_session_token"] = aws_session_token
     return boto3.client("ec2", **kwargs)
 
 

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/test_ami.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/test_ami.py
@@ -153,3 +153,14 @@ def test_find_engine_ami_missing_creation_date(monkeypatch):
     ])
     monkeypatch.setattr(ami_mod, "_engine_ec2_client", lambda region, **kw: fake)
     assert ami_mod.find_engine_ami("us-east-1", aws_access_key_id="k", aws_secret_access_key="s") == "ami-dated"
+
+
+def test_engine_ec2_client_forwards_session_token(monkeypatch):
+    import boto3
+    captured = {}
+    monkeypatch.setattr(boto3, "client", lambda svc, **kw: captured.update(kw) or "client")
+    ami_mod._engine_ec2_client("us-east-1", aws_access_key_id="k", aws_secret_access_key="s", aws_session_token="tok")
+    assert captured.get("aws_session_token") == "tok"
+    captured.clear()
+    ami_mod._engine_ec2_client("us-east-1", aws_access_key_id="k", aws_secret_access_key="s")
+    assert "aws_session_token" not in captured

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/test_ami.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/test_ami.py
@@ -53,7 +53,7 @@ def test_latest_dlami_ami_cache_expires():
     with patch("boto3.client", return_value=mock_ssm):
         ami.latest_dlami_ami("us-east-1")
         # Manually expire the cache.
-        ami._DLAMI_CACHE["us-east-1"] = ("ami-1", time.time() - ami._DLAMI_TTL_S - 1)
+        ami._DLAMI_CACHE[f"us-east-1::{ami._DLAMI_PARAMETER}"] = ("ami-1", time.time() - ami._DLAMI_TTL_S - 1)
         ami.latest_dlami_ami("us-east-1")
     assert mock_ssm.get_parameter.call_count == 2
 
@@ -67,3 +67,89 @@ def test_latest_dlami_ami_boto_error_raises():
     with patch("boto3.client", return_value=mock_ssm):
         with pytest.raises(ami.AMILookupError):
             ami.latest_dlami_ami("us-east-1")
+
+
+from inferia.services.orchestration.services.adapter_engine.adapters.pulumi import ami as ami_mod
+
+
+class _FakeEC2:
+    def __init__(self, images):
+        self._images = images
+        self.calls = []
+
+    def describe_images(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"Images": self._images}
+
+
+def test_find_engine_ami_newest_wins(monkeypatch):
+    ami_mod._ENGINE_AMI_CACHE.clear()
+    fake = _FakeEC2([
+        {"ImageId": "ami-old", "CreationDate": "2026-06-01T00:00:00.000Z"},
+        {"ImageId": "ami-new", "CreationDate": "2026-06-08T00:00:00.000Z"},
+    ])
+    monkeypatch.setattr(ami_mod, "_engine_ec2_client", lambda region, **kw: fake)
+    got = ami_mod.find_engine_ami("us-east-1", aws_access_key_id="k", aws_secret_access_key="s")
+    assert got == "ami-new"
+    assert fake.calls[0]["Owners"] == ["self"]
+    assert any(f["Name"] == "tag:inferia:engine-cache" for f in fake.calls[0]["Filters"])
+
+
+def test_find_engine_ami_none_when_empty(monkeypatch):
+    ami_mod._ENGINE_AMI_CACHE.clear()
+    fake = _FakeEC2([])
+    monkeypatch.setattr(ami_mod, "_engine_ec2_client", lambda region, **kw: fake)
+    assert ami_mod.find_engine_ami("us-east-1", aws_access_key_id="k", aws_secret_access_key="s") is None
+
+
+def test_find_engine_ami_cached(monkeypatch):
+    ami_mod._ENGINE_AMI_CACHE.clear()
+    calls = {"n": 0}
+    def _client(region, **kw):
+        calls["n"] += 1
+        return _FakeEC2([{"ImageId": "ami-x", "CreationDate": "2026-06-08T00:00:00.000Z"}])
+    monkeypatch.setattr(ami_mod, "_engine_ec2_client", _client)
+    a = ami_mod.find_engine_ami("us-east-1", aws_access_key_id="k", aws_secret_access_key="s")
+    b = ami_mod.find_engine_ami("us-east-1", aws_access_key_id="k", aws_secret_access_key="s")
+    assert a == b == "ami-x"
+    assert calls["n"] == 1  # second call served from TTL cache
+
+
+def test_find_engine_ami_describe_error_returns_none(monkeypatch):
+    ami_mod._ENGINE_AMI_CACHE.clear()
+    class _Boom:
+        def describe_images(self, **kw):
+            raise RuntimeError("AccessDenied")
+    monkeypatch.setattr(ami_mod, "_engine_ec2_client", lambda region, **kw: _Boom())
+    assert ami_mod.find_engine_ami("us-east-1", aws_access_key_id="k", aws_secret_access_key="s") is None
+
+
+def test_resolve_ami_prefers_engine_for_gpu(monkeypatch):
+    ami_mod._ENGINE_AMI_CACHE.clear()
+    monkeypatch.setattr(ami_mod, "find_engine_ami", lambda region, **kw: "ami-engine")
+    monkeypatch.setattr(ami_mod, "latest_dlami_ami", lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not call DLAMI")))
+    assert ami_mod.resolve_ami(region="us-east-1", instance_class="normal_gpu", creds=None) == "ami-engine"
+
+
+def test_resolve_ami_falls_back_to_dlami_for_gpu(monkeypatch):
+    ami_mod._ENGINE_AMI_CACHE.clear()
+    monkeypatch.setattr(ami_mod, "find_engine_ami", lambda region, **kw: None)
+    monkeypatch.setattr(ami_mod, "latest_dlami_ami", lambda *a, **k: "ami-dlami")
+    assert ami_mod.resolve_ami(region="us-east-1", instance_class="heavy_gpu", creds=None) == "ami-dlami"
+
+
+def test_resolve_ami_cpu_never_uses_engine(monkeypatch):
+    ami_mod._ENGINE_AMI_CACHE.clear()
+    monkeypatch.setattr(ami_mod, "find_engine_ami", lambda region, **kw: (_ for _ in ()).throw(AssertionError("CPU must not consult engine AMI")))
+    monkeypatch.setattr(ami_mod, "latest_dlami_ami", lambda *a, **k: "ami-ubuntu")
+    assert ami_mod.resolve_ami(region="us-east-1", instance_class="cpu", creds=None) == "ami-ubuntu"
+
+
+def test_find_engine_ami_missing_creation_date(monkeypatch):
+    ami_mod._ENGINE_AMI_CACHE.clear()
+    fake = _FakeEC2([
+        {"ImageId": "ami-nodate"},  # no CreationDate -> sorts as "" (oldest)
+        {"ImageId": "ami-dated", "CreationDate": "2026-06-08T00:00:00.000Z"},
+    ])
+    monkeypatch.setattr(ami_mod, "_engine_ec2_client", lambda region, **kw: fake)
+    assert ami_mod.find_engine_ami("us-east-1", aws_access_key_id="k", aws_secret_access_key="s") == "ami-dated"

--- a/package/src/inferia/services/orchestration/services/adapter_engine/aws_orphan_sweep.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/aws_orphan_sweep.py
@@ -75,6 +75,8 @@ logger = logging.getLogger(__name__)
 # (transient). Anything billable or resumable is fair game for the sweep.
 _LIVE_STATES = ["pending", "running", "stopping", "stopped"]
 
+_BUILDER_TAG = "inferia:engine-ami-builder"
+
 
 async def resolve_sweep_aws_env() -> dict[str, str] | None:
     """Resolve the AWS creds env for the sweep — on the CURRENT (main) event
@@ -290,7 +292,64 @@ def sweep_pool_instances(
     )
 
 
+def sweep_stale_builders(
+    region: str,
+    aws_env: dict[str, str] | None = None,
+    *,
+    older_than_min: int = 30,
+    now: "datetime | None" = None,
+) -> list[str]:
+    """Terminate engine-AMI builder instances (tag ``inferia:engine-ami-builder``)
+    older than ``older_than_min`` minutes — reclaims a builder leaked by a CP
+    crash mid-bake (the bake normally terminates its builder in a ``finally``).
+
+    Best-effort like the rest of this module: no creds / AWS error → ``[]``,
+    never raises. ``now`` is injectable for tests."""
+    from datetime import datetime, timedelta, timezone
+
+    if not aws_env:
+        logger.warning("sweep_stale_builders skipped in %s: no AWS credentials", region)
+        return []
+    ref = now or datetime.now(timezone.utc)
+    cutoff = ref - timedelta(minutes=older_than_min)
+    try:
+        creds = _creds_from_aws_env(aws_env)
+        client = _ec2_client(region, creds=creds)
+        resp = client.describe_instances(Filters=[
+            {"Name": f"tag:{_BUILDER_TAG}", "Values": ["true"]},
+            {"Name": "instance-state-name", "Values": list(_LIVE_STATES)},
+        ])
+        stale: list[str] = []
+        for reservation in resp.get("Reservations", []) or []:
+            for inst in reservation.get("Instances", []) or []:
+                launched = inst.get("LaunchTime")
+                iid = inst.get("InstanceId")
+                if iid and launched and launched <= cutoff:
+                    stale.append(iid)
+    except Exception as e:  # noqa: BLE001 — best-effort backstop
+        logger.warning(
+            "sweep_stale_builders best-effort failure in %s: %s: %s",
+            region, type(e).__name__, e,
+        )
+        return []
+
+    if not stale:
+        logger.info("sweep_stale_builders: no stale builders in %s", region)
+        return []
+    try:
+        client.terminate_instances(InstanceIds=stale)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("sweep_stale_builders terminate failed in %s: %s", region, e)
+        return []
+    logger.info(
+        "sweep_stale_builders terminated %d in %s: %s",
+        len(stale), region, ", ".join(stale),
+    )
+    return stale
+
+
 __all__ = [
     "sweep_node_instances",
     "sweep_pool_instances",
+    "sweep_stale_builders",
 ]

--- a/package/src/inferia/services/orchestration/services/adapter_engine/test_aws_orphan_sweep.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/test_aws_orphan_sweep.py
@@ -394,3 +394,74 @@ async def test_resolve_sweep_aws_env_returns_none_on_db_failure(caplog) -> None:
     assert out is None
     assert any("failed to resolve AWS credentials" in r.getMessage()
                for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# sweep_stale_builders — reclaim engine-AMI builder instances leaked by a
+# CP crash mid-bake (the bake normally terminates its builder in a finally).
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, timedelta, timezone
+
+from inferia.services.orchestration.services.adapter_engine import aws_orphan_sweep as sweep
+
+AWS_ENV = {"AWS_ACCESS_KEY_ID": "k", "AWS_SECRET_ACCESS_KEY": "s"}
+
+
+class _FakeEC2Builders:
+    def __init__(self, instances):
+        self._instances = instances
+        self.terminated = []
+
+    def describe_instances(self, **kw):
+        self.describe_kw = kw
+        return {"Reservations": [{"Instances": self._instances}]}
+
+    def terminate_instances(self, **kw):
+        self.terminated.extend(kw["InstanceIds"])
+
+
+def test_sweep_stale_builders_terminates_only_old(monkeypatch):
+    now = datetime(2026, 6, 9, 12, 0, tzinfo=timezone.utc)
+    insts = [
+        {"InstanceId": "i-old", "LaunchTime": now - timedelta(minutes=45)},
+        {"InstanceId": "i-fresh", "LaunchTime": now - timedelta(minutes=5)},
+    ]
+    fake = _FakeEC2Builders(insts)
+    monkeypatch.setattr(sweep, "_ec2_client", lambda region, **kw: fake)
+    out = sweep.sweep_stale_builders("us-east-1", AWS_ENV, older_than_min=30, now=now)
+    assert out == ["i-old"]
+    assert fake.terminated == ["i-old"]
+    # The sweep must filter by the builder tag — otherwise it would terminate
+    # unrelated instances.
+    filters = fake.describe_kw["Filters"]
+    assert any(f["Name"] == "tag:inferia:engine-ami-builder" and f["Values"] == ["true"] for f in filters)
+
+
+def test_sweep_stale_builders_no_creds():
+    assert sweep.sweep_stale_builders("us-east-1", None) == []
+
+
+def test_sweep_stale_builders_none_stale(monkeypatch):
+    now = datetime(2026, 6, 9, 12, 0, tzinfo=timezone.utc)
+    fake = _FakeEC2Builders([{"InstanceId": "i-fresh", "LaunchTime": now - timedelta(minutes=2)}])
+    monkeypatch.setattr(sweep, "_ec2_client", lambda region, **kw: fake)
+    out = sweep.sweep_stale_builders("us-east-1", AWS_ENV, older_than_min=30, now=now)
+    assert out == []
+    assert fake.terminated == []
+
+
+def test_sweep_stale_builders_describe_error(monkeypatch):
+    class _Boom:
+        def describe_instances(self, **kw):
+            raise RuntimeError("AccessDenied")
+    monkeypatch.setattr(sweep, "_ec2_client", lambda region, **kw: _Boom())
+    assert sweep.sweep_stale_builders("us-east-1", AWS_ENV) == []
+
+
+def test_sweep_stale_builders_naive_launchtime_does_not_raise(monkeypatch):
+    # A tz-naive LaunchTime would raise on comparison; best-effort must swallow.
+    fake = _FakeEC2Builders([{"InstanceId": "i-x", "LaunchTime": datetime(2026, 6, 9, 11, 0)}])
+    monkeypatch.setattr(sweep, "_ec2_client", lambda region, **kw: fake)
+    out = sweep.sweep_stale_builders("us-east-1", AWS_ENV, now=datetime(2026, 6, 9, 12, 0, tzinfo=timezone.utc))
+    assert out == []  # comparison TypeError swallowed → best-effort []

--- a/package/src/inferia/services/orchestration/services/provisioning/reconciler/reaper.py
+++ b/package/src/inferia/services/orchestration/services/provisioning/reconciler/reaper.py
@@ -79,9 +79,11 @@ class TerminationReaper:
 
     async def tick_once(self) -> None:
         """Run one full reaper pass: nodes first (so a node-purge that empties
-        a pool is visible to the pool sweep in the SAME tick), then pools."""
+        a pool is visible to the pool sweep in the SAME tick), then pools, then
+        reclaim any stale engine-AMI builders."""
         await self._reap_stuck_nodes()
         await self._reap_stuck_pools()
+        await self._reap_stale_builders()
 
     # ---- NODES ----------------------------------------------------------
 
@@ -223,6 +225,65 @@ class TerminationReaper:
         if self.inventory_repo is not None:
             await self.inventory_repo.purge_node(node_id)
             logger.info("reaper: purged stuck-terminating node=%s", node_id)
+
+    # ---- BUILDERS -------------------------------------------------------
+
+    async def _aws_regions_in_use(self) -> list[str]:
+        """Distinct AWS regions across pools + nodes — the regions a leaked
+        engine-AMI builder could be in. (A builder in a region with zero
+        pools/nodes relies on the bake's own finally-terminate; the reaper is
+        the crash backstop for the common case.)"""
+        async with self.db.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT DISTINCT region FROM (
+                    SELECT (cp.region_constraint)[1] AS region
+                      FROM compute_pools cp WHERE cp.provider::text = 'aws'
+                    UNION
+                    SELECT ci.metadata->>'region' AS region
+                      FROM compute_inventory ci WHERE ci.provider::text = 'aws'
+                ) t WHERE region IS NOT NULL AND region <> ''
+                """
+            )
+        return [r["region"] for r in rows]
+
+    async def _reap_stale_builders(self) -> None:
+        """Reclaim engine-AMI builder EC2 (tag inferia:engine-ami-builder) leaked
+        by a CP crash mid-bake. Best-effort, tag-scoped, age-gated (>30 min in
+        sweep_stale_builders) so it never races an in-flight bake."""
+        try:
+            regions = await self._aws_regions_in_use()
+        except Exception:
+            logger.exception("reaper: list AWS regions failed; skipping builder sweep")
+            return
+        if not regions:
+            return
+        from inferia.services.orchestration.services.adapter_engine.aws_orphan_sweep import (
+            resolve_sweep_aws_env,
+            sweep_stale_builders,
+        )
+        # Resolve creds on the reaper's loop (asyncpg-bound ProvidersConfig
+        # session) BEFORE the to_thread sweep — resolving inside the worker
+        # thread crashes cross-loop. Best-effort: None ⇒ no-creds WARNING + [].
+        try:
+            aws_env = await resolve_sweep_aws_env()
+        except Exception:
+            logger.exception("reaper: resolve creds for builder sweep failed; skipping")
+            return
+        for region in regions:
+            try:
+                terminated = await asyncio.to_thread(
+                    sweep_stale_builders, str(region), aws_env,
+                )
+                if terminated:
+                    logger.info(
+                        "reaper: reclaimed %d stale engine-AMI builder(s) in %s: %s",
+                        len(terminated), region, ", ".join(terminated),
+                    )
+            except Exception:
+                logger.exception(
+                    "reaper: stale-builder sweep failed in %s; continuing", region,
+                )
 
     # ---- POOLS ----------------------------------------------------------
 

--- a/package/src/inferia/services/orchestration/services/provisioning/reconciler/tests/test_reaper.py
+++ b/package/src/inferia/services/orchestration/services/provisioning/reconciler/tests/test_reaper.py
@@ -429,3 +429,172 @@ async def test_clear_terminating_node_strips_flags(pool):
         await repo.clear_terminating_node(node_id=node_id)
     finally:
         await _cleanup(pool, org_id=org_id, pool_id=pool_id, node_id=node_id)
+
+
+# ---------------------------------------------------------------------------
+# BUILDER reaping
+# ---------------------------------------------------------------------------
+
+_RESOLVE_CREDS_PATH = (
+    "inferia.services.orchestration.services.adapter_engine."
+    "aws_orphan_sweep.resolve_sweep_aws_env"
+)
+_SWEEP_BUILDERS_PATH = (
+    "inferia.services.orchestration.services.adapter_engine."
+    "aws_orphan_sweep.sweep_stale_builders"
+)
+
+_DUMMY_AWS_ENV = {
+    "AWS_ACCESS_KEY_ID": "test-key-id",
+    "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+}
+
+
+async def test_reaper_sweeps_stale_builders(pool):
+    """A tick with an active AWS pool having region_constraint={us-east-1}
+    causes sweep_stale_builders to be called for us-east-1."""
+    from unittest.mock import MagicMock, AsyncMock
+
+    org_id = await _seed_org(pool)
+    # _seed_pool already seeds region_constraint=ARRAY['us-east-1'] by default.
+    pool_id = await _seed_pool(pool, org_id, lifecycle="running", is_active=True)
+    try:
+        reaper = _reaper(pool)
+        sweep_mock = MagicMock(return_value=[])
+        with patch(_SWEEP_BUILDERS_PATH, sweep_mock), \
+             patch(_RESOLVE_CREDS_PATH, new=AsyncMock(return_value=_DUMMY_AWS_ENV)):
+            await reaper._reap_stale_builders()
+        assert sweep_mock.called, "sweep_stale_builders was not called"
+        regions = {call.args[0] for call in sweep_mock.call_args_list}
+        assert "us-east-1" in regions, (
+            f"us-east-1 not in swept regions: {regions}"
+        )
+    finally:
+        await _cleanup(pool, org_id=org_id, pool_id=pool_id)
+
+
+async def test_reaper_sweeps_stale_builders_from_node_region(pool):
+    """A tick where a node's metadata carries a region also drives the builder
+    sweep for that region — so a pool-less node scenario is covered."""
+    from unittest.mock import MagicMock, AsyncMock
+
+    org_id = await _seed_org(pool)
+    # Use a pool with no region_constraint (pass a different lifecycle so the
+    # pool sweep doesn't accidentally interact), and plant the region in the
+    # node's metadata instead.
+    pool_id = await _seed_pool(pool, org_id, lifecycle="running", is_active=True)
+    node_id = await _seed_node(pool, pool_id, terminating=False, state="ready")
+    # Stamp metadata.region on the node.
+    async with pool.acquire() as c:
+        await c.execute(
+            "UPDATE compute_inventory SET metadata = metadata || $1::jsonb "
+            "WHERE id = $2",
+            '{"region": "eu-west-1"}', node_id,
+        )
+    try:
+        reaper = _reaper(pool)
+        sweep_mock = MagicMock(return_value=[])
+        with patch(_SWEEP_BUILDERS_PATH, sweep_mock), \
+             patch(_RESOLVE_CREDS_PATH, new=AsyncMock(return_value=_DUMMY_AWS_ENV)):
+            await reaper._reap_stale_builders()
+        assert sweep_mock.called, "sweep_stale_builders was not called"
+        regions = {call.args[0] for call in sweep_mock.call_args_list}
+        assert "eu-west-1" in regions, (
+            f"eu-west-1 not in swept regions: {regions}"
+        )
+    finally:
+        await _cleanup(pool, org_id=org_id, pool_id=pool_id, node_id=node_id)
+
+
+async def test_reaper_skips_builder_sweep_when_no_regions(pool):
+    """When there are no AWS pools or nodes at all the builder sweep does not
+    call sweep_stale_builders (nothing to reclaim)."""
+    from unittest.mock import MagicMock, AsyncMock
+
+    reaper = _reaper(pool)
+    sweep_mock = MagicMock(return_value=[])
+    # Ensure _aws_regions_in_use returns [] by NOT seeding any rows, and
+    # shortcircuiting resolve_sweep_aws_env so creds are irrelevant.
+    with patch(_SWEEP_BUILDERS_PATH, sweep_mock), \
+         patch(_RESOLVE_CREDS_PATH, new=AsyncMock(return_value=_DUMMY_AWS_ENV)):
+        # Patch regions helper to guarantee empty regardless of DB state.
+        from unittest.mock import patch as _patch, AsyncMock as _AsyncMock
+        with _patch.object(reaper, "_aws_regions_in_use", new=_AsyncMock(return_value=[])):
+            await reaper._reap_stale_builders()
+    sweep_mock.assert_not_called()
+
+
+async def test_reaper_builder_sweep_survives_cred_resolution_failure(pool):
+    """If resolve_sweep_aws_env raises, _reap_stale_builders logs and returns
+    without calling sweep_stale_builders (best-effort contract)."""
+    from unittest.mock import MagicMock, AsyncMock
+
+    org_id = await _seed_org(pool)
+    pool_id = await _seed_pool(pool, org_id, lifecycle="running", is_active=True)
+    try:
+        reaper = _reaper(pool)
+        sweep_mock = MagicMock(return_value=[])
+        failing_creds = AsyncMock(side_effect=RuntimeError("DB down"))
+        with patch(_SWEEP_BUILDERS_PATH, sweep_mock), \
+             patch(_RESOLVE_CREDS_PATH, new=failing_creds):
+            # Must not raise.
+            await reaper._reap_stale_builders()
+        sweep_mock.assert_not_called()
+    finally:
+        await _cleanup(pool, org_id=org_id, pool_id=pool_id)
+
+
+async def test_reaper_builder_sweep_continues_after_per_region_failure(pool):
+    """If sweep_stale_builders raises for one region, _reap_stale_builders
+    continues to the next region without propagating the error."""
+    from unittest.mock import MagicMock, AsyncMock, call
+
+    org_id = await _seed_org(pool)
+    # Seed a pool with us-east-1 (from _seed_pool default).
+    pool_id = await _seed_pool(pool, org_id, lifecycle="running", is_active=True)
+    # Add a node with a second region so we have two distinct regions to sweep.
+    node_id = await _seed_node(pool, pool_id, terminating=False, state="ready")
+    async with pool.acquire() as c:
+        await c.execute(
+            "UPDATE compute_inventory SET metadata = metadata || $1::jsonb "
+            "WHERE id = $2",
+            '{"region": "ap-southeast-1"}', node_id,
+        )
+    try:
+        reaper = _reaper(pool)
+        call_count = 0
+
+        def _sweep_side_effect(region, aws_env):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("transient AWS error")
+            return []
+
+        sweep_mock = MagicMock(side_effect=_sweep_side_effect)
+        with patch(_SWEEP_BUILDERS_PATH, sweep_mock), \
+             patch(_RESOLVE_CREDS_PATH, new=AsyncMock(return_value=_DUMMY_AWS_ENV)):
+            # Must not raise; second region still attempted.
+            await reaper._reap_stale_builders()
+        # Both regions were attempted despite the first raising.
+        assert sweep_mock.call_count == 2
+    finally:
+        await _cleanup(pool, org_id=org_id, pool_id=pool_id, node_id=node_id)
+
+
+async def test_reaper_tick_once_calls_builder_sweep(pool):
+    """tick_once drives all three sweeps including the builder sweep."""
+    from unittest.mock import MagicMock, AsyncMock
+
+    org_id = await _seed_org(pool)
+    pool_id = await _seed_pool(pool, org_id, lifecycle="running", is_active=True)
+    try:
+        reaper = _reaper(pool)
+        sweep_mock = MagicMock(return_value=[])
+        with patch(_SWEEP_PATH, return_value=[]), \
+             patch(_SWEEP_BUILDERS_PATH, sweep_mock), \
+             patch(_RESOLVE_CREDS_PATH, new=AsyncMock(return_value=_DUMMY_AWS_ENV)):
+            await reaper.tick_once()
+        assert sweep_mock.called, "sweep_stale_builders not reached via tick_once"
+    finally:
+        await _cleanup(pool, org_id=org_id, pool_id=pool_id)


### PR DESCRIPTION
Makes cold vLLM deploys legible + fast.

- `resolve_ami` prefers a baked `inferia:engine-cache` AMI for GPU nodes (best-effort, DLAMI fallback, 300s TTL cache) so cold nodes boot with the engine image pre-extracted.
- `engine_ami_bake.py`: CPU builder from the DLAMI → SSM installs docker + nvidia-container-toolkit (unconditionally) + pulls vllm-openai:v0.22.1 (+ worker) → create_image + tag → always-terminate builder. Shell-injection hardened; resolves the DLAMI root device.
- Admin endpoints `/v1/admin/aws/engine-ami` (bake/status/list) + api_gateway proxy enforcing RBAC (POST→DEPLOYMENT_CREATE, GET→DEPLOYMENT_LIST).
- `sweep_stale_builders` wired into the TerminationReaper to reclaim a builder leaked by a CP crash mid-bake.

All changes carry unit tests (95%+, edge cases); resolve_ami no-ops to the DLAMI until an AMI is baked, so it's safe to deploy before any bake exists.