### PR TITLE
fix(sso): set GRPC_SERVICE_TOKEN so inferia-auth boots in the SSO topology

### DIFF
--- a/deploy/docker-compose.sso.yml
+++ b/deploy/docker-compose.sso.yml
@@ -104,6 +104,11 @@ services:
       SERVER_HTTP_PORT: "3000"
       SERVER_GRPC_PORT: "50051"
       SERVER_ISSUER: "https://auth.inferia.local"
+      # Required by current inferia-auth (the gRPC server refuses to boot without
+      # it). DEV-ONLY shared secret — downstream services present it as a Bearer
+      # token in gRPC metadata. InferiaLLM verifies tokens via JWKS (HTTP), so it
+      # doesn't need this; it's just to let the auth server's gRPC plane start.
+      GRPC_SERVICE_TOKEN: "dev-shared-grpc-service-token-change-me"
       DATABASE_URL: "postgres://inferia:inferia@postgres:5432/inferia_auth?sslmode=disable"
       OPENFGA_DATABASE_URL: "postgres://inferia:inferia@postgres:5432/inferia_openfga?sslmode=disable"
       OPENFGA_STORE_NAME: "inferia-auth"


### PR DESCRIPTION
The 2026-05-23 `deploy/docker-compose.sso.yml` predates current inferia-auth's requirement that `GRPC_SERVICE_TOKEN` be set for the gRPC server to boot. Without it, `inferia-auth` crash-loops (`GRPC_SERVICE_TOKEN is required`) and `inferia-app` never starts. This adds a DEV-ONLY shared secret to the auth service env.

InferiaLLM verifies InferiaAuth tokens via JWKS (HTTP), so it does not consume this token — it only lets the auth server's gRPC plane start.

Found while bringing up the SSO topology for the three-auth-modes Phase 5 verification (`make docker-up-sso`); with this set, the full stack comes up healthy (auth + app /health → 200, OIDC discovery + JWKS served).