### PR TITLE
feat: provider-config UX — AWS creds-only, engine-AMI UI, multi-HF-token, deploy AMI/token pickers

### DIFF
--- a/apps/dashboard/src/pages/Compute/NewPool.tsx
+++ b/apps/dashboard/src/pages/Compute/NewPool.tsx
@@ -537,7 +537,13 @@ export default function NewPool() {
             return
         }
 
-        // For cluster providers, validate region selection
+        // For AWS pools a region is mandatory — the backend 422s without it.
+        if (selectedProvider === "aws" && !selectedRegion) {
+            toast.error("Select a region for the AWS pool")
+            return
+        }
+
+        // For other cluster providers, validate region selection
         if (isClusterProvider && !selectedRegion) {
             toast.error("Please select a region")
             return

--- a/apps/dashboard/src/pages/NewDeployment.tsx
+++ b/apps/dashboard/src/pages/NewDeployment.tsx
@@ -24,6 +24,7 @@ import {
 import { calculateCompatibility, fetchExternalRegistry, GPU_SPECS, type FitLevel, type ExternalModel } from "@/services/gpuCompatibility"
 import { getOllamaModels, searchOllamaModels, formatModelSize, type OllamaModel } from "@/services/ollamaService"
 import { CompatibilityProjectionChart } from "@/components/deployment/CompatibilityProjectionChart"
+import { ConfigService } from "@/services/configService"
 
 // --- Constants ---
 
@@ -203,21 +204,14 @@ type State = {
   maxModelLen: string;
   gpuUtil: string;
   hfToken: string;
-  vllmImage: string;
-  cudaVersions: string[];
   selectedProvider: string;
   customProviderName: string;
   externalModelName: string;
   endpointUrl: string;
   apiKey: string;
-  // Advanced VLLM config
+  // vLLM runtime hints (used by compatibility widget "Apply Settings")
   dtype: string;
   enforceEager: boolean;
-  maxNumSeqs: string;
-  kvCacheDtype: string;
-  trustRemoteCode: boolean;
-  cudaModuleLoading: string;
-  nvidiaDisableCudaCompat: string;
   quantization: string;
   isAdvancedOpen: boolean;
   // Advanced Embedding config
@@ -230,6 +224,9 @@ type State = {
   trustRemoteCode: boolean;
   modelOffload: boolean;
   groupOffload: boolean;
+  // vLLM AMI + HF token dropdowns
+  selectedAmiId: string;
+  selectedHfTokenName: string;
 
   preflightStatus: 'idle' | 'checking' | 'passed' | 'failed';
   preflightErrors: Array<{ check: string; message: string; needs_hf_token: boolean }>;
@@ -292,21 +289,14 @@ const initialState: State = {
   maxModelLen: "4192",
   gpuUtil: "0.80",
   hfToken: "",
-  vllmImage: "docker.io/vllm/vllm-openai:v0.22.1",
-  cudaVersions: ["12.0", "12.1", "12.2", "12.3", "12.4", "12.5", "12.6", "12.7", "12.8", "12.9", "13.0", "13.1", "13.2"],
   selectedProvider: "",
   customProviderName: "",
   externalModelName: "",
   endpointUrl: "",
   apiKey: "",
-  // Advanced VLLM defaults
+  // vLLM runtime hints (used by compatibility widget "Apply Settings")
   dtype: "auto",
   enforceEager: true,
-  maxNumSeqs: "128",
-  kvCacheDtype: "auto",
-  trustRemoteCode: true,
-  cudaModuleLoading: "LAZY",
-  nvidiaDisableCudaCompat: "",
   quantization: "",
   isAdvancedOpen: false,
   // Advanced Embedding defaults
@@ -316,7 +306,12 @@ const initialState: State = {
   requiredRam: "4096",
   gpuEnabled: false,
   // InferaDiffusion defaults
+  trustRemoteCode: true,
   modelOffload: false,
+  groupOffload: false,
+  // vLLM AMI + HF token dropdowns
+  selectedAmiId: "",
+  selectedHfTokenName: "",
 
   preflightStatus: 'idle',
   preflightErrors: [],
@@ -614,12 +609,14 @@ export default function NewDeployment() {
     mode, step, deploymentType, modelType, instanceName, selectedEngine,
     selectedPool, userPools, selectedHFModel, jobDescription, modelId,
     gitRepo, trainingScript, datasetUrl, baseModel, batchSize,
-    maxSequenceLength, maxModelLen, gpuUtil, hfToken, vllmImage,
+    maxSequenceLength, maxModelLen, gpuUtil, hfToken,
     selectedProvider, customProviderName, externalModelName, endpointUrl, apiKey,
-    // Advanced VLLM config
-    dtype, enforceEager, maxNumSeqs, kvCacheDtype, trustRemoteCode, cudaModuleLoading, nvidiaDisableCudaCompat, quantization, cudaVersions,
+    // vLLM runtime hints
+    dtype, enforceEager, quantization,
     // Advanced Embedding config
-    maxBatchTokens, pooling, requiredCpu, requiredRam, gpuEnabled
+    maxBatchTokens, pooling, requiredCpu, requiredRam, gpuEnabled,
+    // vLLM AMI + HF token dropdowns
+    selectedAmiId, selectedHfTokenName,
   } = state;
 
   const externalModelType = modelType === "embedding" ? "embedding" : modelType === "image_generation" ? "image_generation" : "inference"
@@ -690,59 +687,14 @@ export default function NewDeployment() {
   // Split vLLM Logic into dedicated function to avoid multiple setState calls in one effect
   const buildJobSpec = useCallback(() => {
     if (selectedEngine === "vllm" && modelType === "inference") {
-      const finalMaxNumSeqs = maxNumSeqs || "128";
-      const finalMaxModelLen = maxModelLen || "4192";
-      const finalGpuUtil = gpuUtil || "0.80";
       const finalModelId = modelId || "meta-llama/Meta-Llama-3-8B-Instruct";
-
-      const cmd = [
-        finalModelId,
-        "--served-model-name", finalModelId,
-        "--port", "9000",
-        "--max-model-len", finalMaxModelLen,
-        "--gpu-memory-utilization", finalGpuUtil,
-        "--max-num-seqs", finalMaxNumSeqs,
-        "--dtype", dtype,
-      ]
-
-      if (trustRemoteCode) {
-        cmd.push("--trust-remote-code")
-      }
-
-      cmd.push("--kv-cache-dtype", kvCacheDtype || "auto")
-
-      if (enforceEager) {
-        cmd.push("--enforce-eager")
-      }
-
-      if (quantization) {
-        cmd.push("--quantization", quantization)
-      }
-
-      const env: Record<string, string> = {}
-      if (hfToken) env["HF_TOKEN"] = hfToken
-      if (cudaModuleLoading) env["CUDA_MODULE_LOADING"] = cudaModuleLoading
-      if (nvidiaDisableCudaCompat) env["NVIDIA_DISABLE_CUDA_COMPAT"] = nvidiaDisableCudaCompat
-
+      // Image, CUDA requirements, HF_TOKEN, and advanced flags are supplied by
+      // the baked engine AMI and the backend (hf_token_name resolution).
       const spec = {
         model_id: finalModelId,
         engine: "vllm",
-        image: vllmImage,
-        required_cuda: cudaVersions.length > 0 ? cudaVersions : undefined,
-        cmd,
-        env,
         expose: [{ "port": 9000, "health_checks": [{ "body": JSON.stringify({ model: finalModelId, messages: [{ role: "user", content: "Respond with a single word: Ready" }], stream: false }), "path": "/v1/chat/completions", "type": "http", "method": "POST", "headers": { "Content-Type": "application/json" }, "continuous": false, "expected_status": 200 }] }],
         gpu: true,
-        gpu_util: parseFloat(finalGpuUtil) || 0.80,
-        max_model_len: parseInt(finalMaxModelLen) || 4192,
-        dtype: dtype,
-        enforce_eager: enforceEager,
-        max_num_seqs: parseInt(finalMaxNumSeqs) || 128,
-        kv_cache_dtype: kvCacheDtype,
-        trust_remote_code: trustRemoteCode,
-        cuda_module_loading: cudaModuleLoading,
-        nvidia_disable_cuda_compat: nvidiaDisableCudaCompat,
-        quantization: quantization || null,
       }
       return JSON.stringify(spec, null, 4)
     } else if (selectedEngine === "ollama") {
@@ -816,7 +768,7 @@ export default function NewDeployment() {
       return JSON.stringify({ image: "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime", cmd: ["sleep", "infinity"], gpu: true }, null, 4)
     }
     return ""
-  }, [selectedEngine, modelId, maxModelLen, gpuUtil, hfToken, vllmImage, modelType, dtype, enforceEager, maxNumSeqs, kvCacheDtype, trustRemoteCode, cudaModuleLoading, nvidiaDisableCudaCompat, quantization, cudaVersions, batchSize, maxBatchTokens, pooling, requiredCpu, requiredRam, gpuEnabled, state.trustRemoteCode, state.modelOffload, state.groupOffload])
+  }, [selectedEngine, modelId, modelType, hfToken, batchSize, maxBatchTokens, pooling, requiredCpu, requiredRam, gpuEnabled, state.trustRemoteCode, state.modelOffload, state.groupOffload])
 
   useEffect(() => {
     const spec = buildJobSpec()
@@ -845,18 +797,17 @@ export default function NewDeployment() {
     }
   })
 
-  const runPreflight = async (modelId: string, engine: string, token?: string): Promise<boolean> => {
+  const runPreflight = async (modelId: string, engine: string, token?: string, tokenName?: string): Promise<boolean> => {
     dispatch({ type: 'SET_FIELD', field: 'preflightStatus', value: 'checking' });
     dispatch({ type: 'SET_FIELD', field: 'preflightErrors', value: [] });
     try {
-      const parsedConfig = (() => { try { return JSON.parse(jobDescription) } catch { return {} } })();
       const { data } = await computeApi.post("/deployment/preflight", {
-        model_id: modelId, engine, hf_token: token || undefined,
+        model_id: modelId, engine,
+        hf_token: token || undefined,
+        hf_token_name: tokenName || undefined,
         gpu_per_replica: 1,
         pool_id: selectedPool?.pool_id || undefined,
         model_type: modelType,
-        max_model_len: parseInt(maxModelLen) || undefined,
-        image: (parsedConfig as any)?.image || undefined,
       });
       if (data.ready) {
         dispatch({ type: 'SET_FIELD', field: 'preflightStatus', value: 'passed' });
@@ -876,24 +827,28 @@ export default function NewDeployment() {
   const handleManagedLaunch = async () => {
     if (!instanceName) return toast.error("Please name your deployment")
     if (!selectedPool) return toast.error("Select a compute node")
+    if (selectedEngine === "vllm" && !selectedAmiId) return toast.error("Select an engine AMI")
     const targetOrgId = user?.org_id || organizations?.[0]?.id;
     if (!targetOrgId) return toast.error("Organization context missing. Please reload.")
 
     let config = {}
     try { config = JSON.parse(jobDescription) } catch (e) { return toast.error("Invalid Job JSON specification") }
 
-    // Run preflight checks
+    // Run preflight checks — forward named HF token for vLLM; raw hfToken for other engines
     const preflightOk = await runPreflight(
       modelId || (config as any).model_id || "",
       selectedEngine,
-      hfToken || undefined,
+      selectedEngine === "vllm" ? undefined : (hfToken || undefined),
+      selectedEngine === "vllm" ? (selectedHfTokenName || undefined) : undefined,
     );
     if (!preflightOk) return;
 
     const payload = {
       model_name: instanceName, model_version: "latest", replicas: 1, gpu_per_replica: 1, workload_type: deploymentType === "image" ? "inference" : deploymentType, pool_id: selectedPool.pool_id, engine: selectedEngine, model_type: modelType === "image_generation" ? "image_generation" : modelType,
       configuration: deploymentType === "training" ? { workload_type: "training", image: computeEngines.find(e => e.id === selectedEngine)?.image || "pytorch/pytorch:latest", git_repo: gitRepo, training_script: trainingScript, dataset_url: datasetUrl, base_model: baseModel, gpu_count: 1, hf_token: hfToken || undefined } : config,
-      owner_id: user?.user_id, org_id: targetOrgId, inference_model: modelId || undefined, job_definition: config
+      owner_id: user?.user_id, org_id: targetOrgId, inference_model: modelId || undefined, job_definition: config,
+      ami_id: selectedEngine === "vllm" ? selectedAmiId : undefined,
+      hf_token_name: selectedEngine === "vllm" ? (selectedHfTokenName || undefined) : undefined,
     }
     createMutation.mutate(payload)
   }
@@ -959,7 +914,7 @@ export default function NewDeployment() {
 // --- Sub-Components ---
 
 function ManagedFlow({ state, dispatch, onLaunch, isPending, externalRegistry }: { state: State; dispatch: React.Dispatch<Action>; onLaunch: () => void; isPending: boolean; externalRegistry?: ExternalModel[] }) {
-  const { step, deploymentType, modelType, instanceName, selectedEngine, selectedPool, userPools, selectedHFModel, jobDescription, modelId, gitRepo, trainingScript, datasetUrl, baseModel, batchSize, maxSequenceLength, maxModelLen, gpuUtil, hfToken, vllmImage } = state;
+  const { step, deploymentType, modelType, instanceName, selectedEngine, selectedPool, userPools, selectedHFModel, jobDescription, modelId, gitRepo, trainingScript, datasetUrl, baseModel, batchSize, maxSequenceLength, maxModelLen, gpuUtil, hfToken } = state;
 
   return (
     <>
@@ -1087,12 +1042,12 @@ function PoolSelection({ userPools, poolsLoading, selectedPool, dispatch, setSte
 function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry }: { state: State; dispatch: React.Dispatch<Action>; onLaunch: () => void; isPending: boolean; externalRegistry?: ExternalModel[] }) {
   const {
     deploymentType, modelType, instanceName, selectedEngine, selectedHFModel, modelId,
-    vllmImage, maxModelLen, gpuUtil, hfToken, batchSize, maxSequenceLength, gitRepo,
-    trainingScript, datasetUrl, baseModel, dtype, enforceEager, maxNumSeqs,
-    kvCacheDtype, trustRemoteCode, cudaModuleLoading,
-    nvidiaDisableCudaCompat, quantization, isAdvancedOpen, cudaVersions,
+    maxModelLen, gpuUtil, hfToken, batchSize, maxSequenceLength, gitRepo,
+    trainingScript, datasetUrl, baseModel, dtype, enforceEager, quantization,
+    isAdvancedOpen,
     maxBatchTokens, pooling, requiredCpu, requiredRam, gpuEnabled,
-    selectedPool, preflightStatus, preflightErrors
+    selectedPool, preflightStatus, preflightErrors,
+    selectedAmiId, selectedHfTokenName,
   } = state;
 
   const { data: hfConfig } = useQuery({
@@ -1100,6 +1055,27 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
     queryFn: () => getModelConfig(modelId),
     enabled: !!modelId && (selectedEngine === "vllm" || selectedEngine === "ollama"),
     staleTime: 1000 * 60 * 60 // 1 hour
+  });
+
+  // Engine AMI list — region derived from pool's region_constraint or metadata
+  const amiRegion: string =
+    selectedPool?.region_constraint?.[0] ||
+    selectedPool?.metadata?.region ||
+    "us-east-1";
+
+  const { data: engineAmis = [], isLoading: amisLoading } = useQuery({
+    queryKey: ['engine-amis', amiRegion],
+    queryFn: () => ConfigService.listEngineAmis(amiRegion),
+    enabled: selectedEngine === "vllm",
+    staleTime: 1000 * 60 * 5,
+  });
+
+  // HF token names list
+  const { data: hfTokenNames = [] } = useQuery({
+    queryKey: ['hf-token-names'],
+    queryFn: () => ConfigService.listHfTokenNames(),
+    enabled: selectedEngine === "vllm",
+    staleTime: 1000 * 60 * 5,
   });
 
   // Extract full architecture details from HF config
@@ -1281,133 +1257,58 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
       {selectedEngine === "vllm" && (
         <div className="space-y-4 p-4 bg-muted/50 rounded-lg border">
           <div className="flex items-center gap-2 mb-2"><Cpu className="w-4 h-4 text-primary" /><h4 className="font-medium text-sm">vLLM Configuration</h4></div>
-          <div><label htmlFor="vllmImage" className="block text-xs font-medium text-muted-foreground mb-1.5">vLLM Image</label><input id="vllmImage" value={vllmImage} onChange={e => dispatch({ type: 'SET_FIELD', field: 'vllmImage', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
+
+          {/* Engine AMI dropdown (required) */}
           <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1.5">Required CUDA Versions</label>
-            <div className="flex flex-wrap gap-2">
-              {["12.0", "12.1", "12.2", "12.3", "12.4", "12.5", "12.6", "12.7", "12.8", "12.9", "13.0", "13.1", "13.2"].map(v => (
-                <label key={v} className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium cursor-pointer transition-colors", cudaVersions.includes(v) ? "bg-ember-50 border-ember-300 text-ember-700 dark:bg-ember-900/20 dark:border-ember-700 dark:text-ember-400" : "bg-card border-border text-muted-foreground dark:bg-card dark:border-border dark:text-muted-foreground hover:border-border dark:hover:border-border")}>
-                  <input
-                    type="checkbox"
-                    checked={cudaVersions.includes(v)}
-                    onChange={e => {
-                      const updated = e.target.checked
-                        ? [...cudaVersions, v].sort()
-                        : cudaVersions.filter(c => c !== v);
-                      dispatch({ type: 'SET_FIELD', field: 'cudaVersions', value: updated });
-                    }}
-                    className="sr-only"
-                  />
-                  {v}
-                </label>
-              ))}
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div><label htmlFor="maxModelLen" className="block text-xs font-medium text-muted-foreground mb-1.5">Max Model Length</label><input id="maxModelLen" value={maxModelLen} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxModelLen', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
-            <div><label htmlFor="gpuUtil" className="block text-xs font-medium text-muted-foreground mb-1.5">GPU Memory Util</label><input id="gpuUtil" value={gpuUtil} onChange={e => dispatch({ type: 'SET_FIELD', field: 'gpuUtil', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" /></div>
-          </div>
-          <div><label htmlFor="hfTokenVllm" className="block text-xs font-medium text-muted-foreground mb-1.5">HF Token</label><input id="hfTokenVllm" type="password" value={hfToken} onChange={e => dispatch({ type: 'SET_FIELD', field: 'hfToken', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" placeholder="hf_..." /></div>
-
-
-
-          {/* Advanced Configuration */}
-          <div className="border-t border-border pt-4 mt-4">
-            <button
-              type="button"
-              onClick={() => dispatch({ type: 'SET_FIELD', field: 'isAdvancedOpen', value: !isAdvancedOpen })}
-              className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-ember-600 dark:hover:text-ember-400 transition-colors"
-            >
-              {isAdvancedOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-              Advanced Configuration
-            </button>
-
-            {isAdvancedOpen && (
-              <div className="mt-4 grid grid-cols-2 gap-4">
-                <div>
-                  <label htmlFor="dtype" className="block text-xs font-medium text-muted-foreground mb-1.5">Data Type (dtype)</label>
-                  <select id="dtype" value={dtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'dtype', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white">
-                    <option value="auto">auto</option>
-                    <option value="float16">float16</option>
-                    <option value="bfloat16">bfloat16</option>
-                    <option value="float32">float32</option>
-                  </select>
-                </div>
-                <div>
-                  <label htmlFor="kvCacheDtype" className="block text-xs font-medium text-muted-foreground mb-1.5">KV Cache dtype</label>
-                  <select id="kvCacheDtype" value={kvCacheDtype} onChange={e => dispatch({ type: 'SET_FIELD', field: 'kvCacheDtype', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white">
-                    <option value="auto">auto</option>
-                    <option value="fp8">fp8</option>
-                    <option value="fp8_e4m3">fp8_e4m3</option>
-                    <option value="fp8_e5m2">fp8_e5m2</option>
-                  </select>
-                </div>
-                <div>
-                  <label htmlFor="maxNumSeqs" className="block text-xs font-medium text-muted-foreground mb-1.5">Max Num Sequences</label>
-                  <input id="maxNumSeqs" type="number" min="1" value={maxNumSeqs} onChange={e => dispatch({ type: 'SET_FIELD', field: 'maxNumSeqs', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" />
-                </div>
-                <div>
-                  <label htmlFor="quantization" className="block text-xs font-medium text-muted-foreground mb-1.5">Quantization</label>
-                  <select id="quantization" value={quantization} onChange={e => dispatch({ type: 'SET_FIELD', field: 'quantization', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white">
-                    <option value="">None</option>
-                    <option value="awq">AWQ</option>
-                    <option value="awq_marlin">AWQ Marlin</option>
-                    <option value="gptq">GPTQ</option>
-                    <option value="gptq_marlin">GPTQ Marlin</option>
-                    <option value="gptq_marlin_24">GPTQ Marlin 24</option>
-                    <option value="marlin">Marlin</option>
-                    <option value="fp8">FP8</option>
-                    <option value="bitsandbytes">BitsAndBytes</option>
-                    <option value="gguf">GGUF</option>
-                    <option value="deepspeedfp">DeepSpeedFP</option>
-                    <option value="eetq">EETQ</option>
-                    <option value="hqq">HQQ</option>
-                    <option value="compressed-tensors">Compressed Tensors</option>
-                    <option value="experts_int8">Experts INT8</option>
-                    <option value="squeezellm">SqueezeLLM</option>
-                  </select>
-                </div>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="trustRemoteCode"
-                    type="checkbox"
-                    checked={trustRemoteCode}
-                    onChange={e => dispatch({ type: 'SET_FIELD', field: 'trustRemoteCode', value: e.target.checked })}
-                    className="w-4 h-4 rounded border-border"
-                  />
-                  <label htmlFor="trustRemoteCode" className="text-xs font-medium text-muted-foreground">Trust Remote Code</label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="enforceEager"
-                    type="checkbox"
-                    checked={enforceEager}
-                    onChange={e => dispatch({ type: 'SET_FIELD', field: 'enforceEager', value: e.target.checked })}
-                    className="w-4 h-4 rounded border-border"
-                  />
-                  <label htmlFor="enforceEager" className="text-xs font-medium text-muted-foreground">Enforce Eager Mode</label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="cudaModuleLoading"
-                    type="checkbox"
-                    checked={!!cudaModuleLoading}
-                    onChange={e => dispatch({ type: 'SET_FIELD', field: 'cudaModuleLoading', value: e.target.checked ? "LAZY" : "" })}
-                    className="w-4 h-4 rounded border-border"
-                  />
-                  <label htmlFor="cudaModuleLoading" className="text-xs font-medium text-muted-foreground">CUDA Module Loading: LAZY</label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="nvidiaDisableCudaCompat"
-                    type="checkbox"
-                    checked={!!nvidiaDisableCudaCompat}
-                    onChange={e => dispatch({ type: 'SET_FIELD', field: 'nvidiaDisableCudaCompat', value: e.target.checked ? "1" : "" })}
-                    className="w-4 h-4 rounded border-border"
-                  />
-                  <label htmlFor="nvidiaDisableCudaCompat" className="text-xs font-medium text-muted-foreground">NVIDIA Disable CUDA Compat</label>
-                </div>
+            <label htmlFor="engineAmi" className="block text-xs font-medium text-muted-foreground mb-1.5">
+              Engine AMI <span className="text-rose-500">*</span>
+            </label>
+            {amisLoading ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
+                <Loader2 className="w-3 h-3 animate-spin" /> Loading AMIs for {amiRegion}…
               </div>
+            ) : engineAmis.length === 0 ? (
+              <div className="flex items-center gap-2 p-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md text-xs text-amber-700 dark:text-amber-300">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                No engine AMIs in {amiRegion} — bake one first (Settings → Providers → AWS).
+              </div>
+            ) : (
+              <select
+                id="engineAmi"
+                value={selectedAmiId}
+                onChange={e => dispatch({ type: 'SET_FIELD', field: 'selectedAmiId', value: e.target.value })}
+                className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white"
+              >
+                <option value="">— select an AMI —</option>
+                {engineAmis.map(ami => (
+                  <option key={ami.ami_id} value={ami.ami_id}>
+                    {ami.ami_id}{ami.vllm_tag ? ` — vLLM ${ami.vllm_tag}` : ""}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {/* HF token name dropdown (optional) */}
+          <div>
+            <label htmlFor="hfTokenName" className="block text-xs font-medium text-muted-foreground mb-1.5">
+              HuggingFace Token <span className="text-muted-foreground/60">(optional — required for gated models)</span>
+            </label>
+            <select
+              id="hfTokenName"
+              value={selectedHfTokenName}
+              onChange={e => dispatch({ type: 'SET_FIELD', field: 'selectedHfTokenName', value: e.target.value })}
+              className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white"
+            >
+              <option value="">None</option>
+              {hfTokenNames.map(name => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+            {hfTokenNames.length === 0 && (
+              <p className="text-xs text-muted-foreground mt-1">
+                No saved tokens — add one at Settings → Providers → HuggingFace.
+              </p>
             )}
           </div>
         </div>

--- a/apps/dashboard/src/pages/Settings/Providers/EngineAmiSection.tsx
+++ b/apps/dashboard/src/pages/Settings/Providers/EngineAmiSection.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+import { ConfigService } from "@/services/configService";
+import { toast } from "sonner";
+
+type Ami = { ami_id: string; vllm_tag?: string; region: string; created: string };
+
+export function EngineAmiSection() {
+    const [region, setRegion] = useState("us-east-1");
+    const [amis, setAmis] = useState<Ami[]>([]);
+    const [vllmTag, setVllmTag] = useState("");
+    const [baking, setBaking] = useState(false);
+    const [status, setStatus] = useState("");
+    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    const refresh = async () => {
+        try { setAmis(await ConfigService.listEngineAmis(region)); }
+        catch { /* surface quietly; the list endpoint requires AWS creds + perms */ setAmis([]); }
+    };
+    useEffect(() => { refresh(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [region]);
+    // Clear any in-flight poll on unmount to avoid a state-update-after-unmount leak.
+    useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
+
+    const bake = async () => {
+        setBaking(true); setStatus("running");
+        try {
+            const { bake_id } = await ConfigService.startEngineBake({ region, vllm_tag: vllmTag || undefined });
+            pollRef.current = setInterval(async () => {
+                try {
+                    const s = await ConfigService.pollBakeStatus(bake_id);
+                    setStatus(`${s.status}${s.message ? ": " + s.message : ""}`);
+                    if (s.status === "succeeded" || s.status === "failed") {
+                        if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+                        setBaking(false);
+                        if (s.status === "succeeded") { toast.success("Engine AMI baked"); refresh(); }
+                        else toast.error("Bake failed: " + (s.message || "unknown"));
+                    }
+                } catch {
+                    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+                    setBaking(false); setStatus("failed"); toast.error("Lost track of the bake");
+                }
+            }, 5000);
+        } catch { setBaking(false); setStatus(""); toast.error("Failed to start bake"); }
+    };
+
+    return (
+        <div className="space-y-4 border border-border rounded-lg p-4">
+            <h3 className="text-sm font-semibold">Engine Cache AMIs</h3>
+            <p className="text-xs text-muted-foreground">
+                Baked AMIs preload the vLLM engine image so cold GPU nodes skip the long image pull/extract.
+                Baking requires the one-time SSM instance profile (<code className="font-mono">INFERIA_BAKE_SSM_INSTANCE_PROFILE</code>) + IAM permissions on the AWS credentials.
+            </p>
+            <div className="flex flex-wrap gap-2 items-end">
+                <div><label className="text-xs block mb-1">Region</label><input value={region} onChange={e => setRegion(e.target.value)} className="h-9 w-36 rounded-md border border-input bg-background px-2 text-sm" /></div>
+                <div><label className="text-xs block mb-1">vLLM tag (optional)</label><input value={vllmTag} onChange={e => setVllmTag(e.target.value)} placeholder="v0.22.1" className="h-9 w-32 rounded-md border border-input bg-background px-2 text-sm" /></div>
+                <button type="button" disabled={baking} onClick={bake} className="h-9 px-3 text-xs font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50">{baking ? "Baking…" : "Bake new AMI"}</button>
+            </div>
+            {status && <p className="text-xs text-muted-foreground">Status: {status}</p>}
+            <table className="w-full text-xs">
+                <thead><tr className="text-left text-muted-foreground border-b border-border"><th className="py-1">AMI</th><th>vLLM tag</th><th>Created</th></tr></thead>
+                <tbody>
+                    {amis.map(a => (<tr key={a.ami_id} className="border-b border-border/50"><td className="py-1 font-mono">{a.ami_id}</td><td>{a.vllm_tag || "-"}</td><td>{a.created}</td></tr>))}
+                    {amis.length === 0 && <tr><td colSpan={3} className="py-2 text-muted-foreground">No baked AMIs yet.</td></tr>}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/apps/dashboard/src/pages/Settings/Providers/ProviderConfig.tsx
+++ b/apps/dashboard/src/pages/Settings/Providers/ProviderConfig.tsx
@@ -3,6 +3,7 @@ import { useEffect, useReducer } from "react";
 import { ConfigService, type ProvidersConfig, type NosanaApiKeyResponse, initialProviderConfig } from "@/services/configService";
 import { ChevronRight, Save, Loader2, Edit2, X, CheckCircle, ShieldCheck, Plus, Trash2, Key, HelpCircle } from "lucide-react";
 import { toast } from "sonner";
+import { EngineAmiSection } from "./EngineAmiSection";
 
 // Small inline "where to find" hint rendered below a credential field
 // label. The HelpCircle icon plus a one-line writeup tells the user
@@ -345,6 +346,8 @@ export default function ProviderConfigPage() {
                     </form>
                 )}
             </div>
+
+            {providerId === "aws" && <EngineAmiSection />}
 
             {showAddKeyModal && (
                 <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">

--- a/apps/dashboard/src/pages/Settings/Providers/ProviderConfig.tsx
+++ b/apps/dashboard/src/pages/Settings/Providers/ProviderConfig.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useReducer } from "react";
 import { ConfigService, type ProvidersConfig, type NosanaApiKeyResponse, initialProviderConfig } from "@/services/configService";
-import { ChevronRight, Save, Loader2, Edit2, X, CheckCircle, ShieldCheck, Plus, Trash2, Key, HelpCircle, Info } from "lucide-react";
+import { ChevronRight, Save, Loader2, Edit2, X, CheckCircle, ShieldCheck, Plus, Trash2, Key, HelpCircle } from "lucide-react";
 import { toast } from "sonner";
 
 // Small inline "where to find" hint rendered below a credential field
@@ -43,8 +43,6 @@ function clearMaskedSecrets(cfg: ProvidersConfig): ProvidersConfig {
     if (nosana && isMaskedSecret(nosana.wallet_private_key)) nosana.wallet_private_key = "";
     const akash = scrubbed.depin?.akash as any;
     if (akash && isMaskedSecret(akash.mnemonic)) akash.mnemonic = "";
-    const hf = scrubbed.huggingface as any;
-    if (hf && isMaskedSecret(hf.token)) hf.token = "";
     return scrubbed;
 }
 
@@ -447,31 +445,12 @@ export default function ProviderConfigPage() {
     );
 }
 
-// Validation regex shared with the backend AWSPoolMetadata gate.
-const AWS_PROV_RE = {
-    subnet: /^subnet-[0-9a-f]{8,17}$/,
-    sg: /^sg-[0-9a-f]{8,17}$/,
-    ami: /^ami-[0-9a-f]{8,17}$/,
-    iam: /^arn:aws:iam::\d{12}:instance-profile\/.+$/,
-};
-
 function AWSFields({ config, updateField, isConfigured }: { config: ProvidersConfig; updateField: (path: string[], value: any) => void; isConfigured?: boolean }) {
     // When the panel was loaded with stored credentials, the form starts empty
     // (masked values are stripped on load). Tell the user explicitly so they
     // don't think the existing credentials were wiped.
     const accessEmpty = !config.cloud.aws.access_key_id;
     const secretEmpty = !config.cloud.aws.secret_access_key;
-    const aws = config.cloud.aws;
-    const subnetErr = aws.subnet_id && !AWS_PROV_RE.subnet.test(aws.subnet_id)
-        ? "Must match subnet-XXXXXXXX" : "";
-    const sgErr = (aws.security_group_ids || []).find(sg => !AWS_PROV_RE.sg.test(sg))
-        ? "Each must match sg-XXXXXXXX" : "";
-    const amiErr = aws.ami_id && !AWS_PROV_RE.ami.test(aws.ami_id)
-        ? "Must match ami-XXXXXXXX" : "";
-    const iamErr = aws.iam_instance_profile && !AWS_PROV_RE.iam.test(aws.iam_instance_profile)
-        ? "Must match arn:aws:iam::ACCOUNT:instance-profile/NAME" : "";
-    const rootErr = aws.root_volume_gb && (aws.root_volume_gb < 10 || aws.root_volume_gb > 16384)
-        ? "Must be 10..16384" : "";
     return (
         <>
             {isConfigured && accessEmpty && secretEmpty && (
@@ -512,141 +491,6 @@ function AWSFields({ config, updateField, isConfigured }: { config: ProvidersCon
                     the access key. If you lost it, generate a new key pair —
                     AWS doesn't let you retrieve the secret.
                 </CredHint>
-            </div>
-            <div className="space-y-2">
-                <label htmlFor="aws-region" className="text-sm font-medium">Region</label>
-                <input
-                    id="aws-region"
-                    value={config.cloud.aws.region || "ap-south-1"}
-                    onChange={(e) => updateField(['cloud', 'aws', 'region'], e.target.value)}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                />
-                <CredHint>
-                    Any AWS region code: <code>us-east-1</code>, <code>eu-west-2</code>,
-                    <code> ap-south-1</code>… Shown top-right of the AWS Console (e.g. "Mumbai").
-                </CredHint>
-            </div>
-
-            {/* AWS Provisioning Configuration — account-wide defaults Pulumi
-                will use when creating EC2 clusters. All optional. */}
-            <div className="mt-6 pt-4 border-t border-border/60">
-                <h3 className="text-sm font-semibold">AWS Provisioning Configuration</h3>
-                <p className="text-xs text-muted-foreground mt-1 mb-4">
-                    Account-wide defaults applied to every AWS pool. Leave blank to
-                    let Pulumi pick a sensible default (auto VPC + default SG +
-                    latest Deep Learning AMI + 100 GB root volume).
-                </p>
-
-                <div className="space-y-2">
-                    <label htmlFor="aws-subnet" className="text-sm font-medium">Subnet ID <span className="text-muted-foreground text-xs">(optional)</span></label>
-                    <input
-                        id="aws-subnet"
-                        value={aws.subnet_id || ""}
-                        onChange={(e) => updateField(['cloud', 'aws', 'subnet_id'], e.target.value || undefined)}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        placeholder="subnet-0123456789abcdef0"
-                    />
-                    {subnetErr && <p className="text-xs text-red-500">{subnetErr}</p>}
-                    <CredHint>
-                        VPC Console → <strong>Subnets</strong>. Pick one in the same
-                        region as your access keys. Leave blank to let Pulumi create
-                        a fresh VPC + subnet automatically.
-                    </CredHint>
-                </div>
-
-                <div className="space-y-2 mt-3">
-                    <label htmlFor="aws-sg" className="text-sm font-medium">Security Group IDs <span className="text-muted-foreground text-xs">(optional, comma-separated)</span></label>
-                    <input
-                        id="aws-sg"
-                        value={(aws.security_group_ids || []).join(", ")}
-                        onChange={(e) => {
-                            const parts = e.target.value.split(",").map(s => s.trim()).filter(Boolean);
-                            updateField(['cloud', 'aws', 'security_group_ids'], parts.length ? parts : undefined);
-                        }}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        placeholder="sg-abc12345, sg-def67890"
-                    />
-                    {sgErr && <p className="text-xs text-red-500">{sgErr}</p>}
-                    <CredHint>
-                        EC2 Console → <strong>Security Groups</strong>. Each ID looks like
-                        <code> sg-XXXXXXXX</code>. Must allow outbound TCP 443
-                        (to reach the control plane) and inbound 8080 from the CP.
-                    </CredHint>
-                </div>
-
-                <div className="space-y-2 mt-3">
-                    <label htmlFor="aws-ami" className="text-sm font-medium">AMI ID <span className="text-muted-foreground text-xs">(optional)</span></label>
-                    <input
-                        id="aws-ami"
-                        value={aws.ami_id || ""}
-                        onChange={(e) => updateField(['cloud', 'aws', 'ami_id'], e.target.value || undefined)}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        placeholder="ami-deadbeef00000000 (auto if blank)"
-                    />
-                    {amiErr && <p className="text-xs text-red-500">{amiErr}</p>}
-                    <CredHint>
-                        EC2 Console → <strong>AMIs</strong>. Leave blank and Pulumi will
-                        auto-detect the latest AWS Deep Learning AMI (Ubuntu 22.04 +
-                        NVIDIA driver) for the selected region.
-                    </CredHint>
-                </div>
-
-                <div className="space-y-2 mt-3">
-                    <label htmlFor="aws-iam" className="text-sm font-medium">IAM Instance Profile ARN <span className="text-muted-foreground text-xs">(optional)</span></label>
-                    <input
-                        id="aws-iam"
-                        value={aws.iam_instance_profile || ""}
-                        onChange={(e) => updateField(['cloud', 'aws', 'iam_instance_profile'], e.target.value || undefined)}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        placeholder="arn:aws:iam::123456789012:instance-profile/inferia-worker"
-                    />
-                    {iamErr && <p className="text-xs text-red-500">{iamErr}</p>}
-                    <CredHint>
-                        IAM Console → <strong>Roles</strong> → your role →
-                        Trust relationships must include <code>ec2.amazonaws.com</code>.
-                        Only needed if the worker pulls from private ECR or S3.
-                    </CredHint>
-                </div>
-
-                <div className="space-y-2 mt-3">
-                    <label htmlFor="aws-root" className="text-sm font-medium">Root Volume Size (GB) <span className="text-muted-foreground text-xs">(default 100)</span></label>
-                    <input
-                        id="aws-root"
-                        type="number"
-                        min={10}
-                        max={16384}
-                        value={aws.root_volume_gb ?? ""}
-                        onChange={(e) => {
-                            const v = e.target.value;
-                            updateField(['cloud', 'aws', 'root_volume_gb'], v === "" ? undefined : parseInt(v, 10));
-                        }}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        placeholder="100"
-                    />
-                    {rootErr && <p className="text-xs text-red-500">{rootErr}</p>}
-                    <CredHint>
-                        Size of the EBS root volume in GB. 100 GB is enough for the
-                        worker image + a couple of model containers; bump higher if
-                        you'll pull large model artifacts at runtime.
-                    </CredHint>
-                </div>
-
-                <div className="space-y-2 mt-3">
-                    <label htmlFor="aws-image-tag" className="text-sm font-medium">inferia-worker Image Tag <span className="text-muted-foreground text-xs">(default "latest")</span></label>
-                    <input
-                        id="aws-image-tag"
-                        value={aws.worker_image_tag || ""}
-                        onChange={(e) => updateField(['cloud', 'aws', 'worker_image_tag'], e.target.value || undefined)}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        placeholder='v1.2.3'
-                    />
-                    <CredHint>
-                        Tag of <code>ghcr.io/inferiaai/inferia-worker</code> to pull on the
-                        EC2 instance. Pin (e.g. <code>0.1.0</code>) for reproducible
-                        deploys, or leave blank to follow the rolling default
-                        (<code>latest</code>).
-                    </CredHint>
-                </div>
             </div>
         </>
     );
@@ -907,43 +751,32 @@ function AkashFields({ config, updateField, handleAddKey }: { config: ProvidersC
     );
 }
 
-function HuggingFaceFields({
-    config,
-    updateField,
-    hfTokenFromEnv,
-}: {
-    config: ProvidersConfig;
-    updateField: (path: string[], value: any) => void;
-    hfTokenFromEnv?: boolean;
-}) {
+function HuggingFaceFields({ config, updateField }: { config: ProvidersConfig; updateField: (path: string[], value: any) => void; }) {
+    const tokens = (config.huggingface?.tokens || []) as { name: string; token: string; is_active?: boolean }[];
+    const setTokens = (next: typeof tokens) => updateField(['huggingface', 'tokens'], next);
+    const dupName = tokens.some((t, i) => t.name && tokens.findIndex(x => x.name === t.name) !== i);
     return (
         <div className="space-y-4">
-            {hfTokenFromEnv && (
-                <div className="p-3 bg-blue-50 border border-blue-100 rounded-lg flex items-start gap-2 text-xs text-blue-700">
-                    <Info className="w-3.5 h-3.5 flex-shrink-0 mt-0.5 text-blue-500" />
-                    <span>
-                        A token is configured via the <code className="font-mono font-semibold">INFERIA_HF_TOKEN</code> environment variable.
-                        Entering one here overrides it.
-                    </span>
-                </div>
-            )}
-            <div className="space-y-2">
-                <label htmlFor="hf-token" className="text-sm font-medium">Access Token</label>
-                <input
-                    id="hf-token"
-                    type="password"
-                    value={config.huggingface?.token || ""}
-                    onChange={(e) => updateField(['huggingface', 'token'], e.target.value)}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                    placeholder={hfTokenFromEnv ? "(env token active — type to override)" : "hf_..."}
-                    autoComplete="new-password"
-                />
-                <CredHint>
-                    Hugging Face → <strong>Settings</strong> → <strong>Access Tokens</strong>.
-                    Required to download gated or private models (e.g. Llama, Gemma).
-                    Starts with <code>hf_</code>.
-                </CredHint>
+            <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold">HuggingFace Tokens</h3>
+                <button type="button" onClick={() => setTokens([...tokens, { name: "", token: "", is_active: true }])}
+                    className="px-3 py-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90">+ Add Token</button>
             </div>
+            <p className="text-xs text-muted-foreground">Named tokens for gated models. Pick one by name when deploying.</p>
+            {dupName && <p className="text-xs text-destructive">Token names must be unique.</p>}
+            {tokens.map((t, i) => (
+                <div key={i} className="flex gap-2 items-start">
+                    <input value={t.name} placeholder="name (e.g. default)"
+                        onChange={e => setTokens(tokens.map((x, j) => j === i ? { ...x, name: e.target.value } : x))}
+                        className="h-10 w-1/3 rounded-md border border-input bg-background px-3 text-sm" />
+                    <input type="password" value={t.token} placeholder="hf_..." autoComplete="new-password"
+                        onChange={e => setTokens(tokens.map((x, j) => j === i ? { ...x, token: e.target.value } : x))}
+                        className="h-10 flex-1 rounded-md border border-input bg-background px-3 text-sm" />
+                    <button type="button" onClick={() => setTokens(tokens.filter((_, j) => j !== i))}
+                        className="h-10 px-3 text-xs text-destructive hover:underline">Remove</button>
+                </div>
+            ))}
+            {tokens.length === 0 && <p className="text-xs text-muted-foreground">No tokens yet. Add one for gated models.</p>}
         </div>
     );
 }
@@ -988,7 +821,7 @@ function ProviderFormFields({
         case "akash":
             return <AkashFields config={config} updateField={updateField} handleAddKey={handleAddKey} />;
         case "huggingface-token":
-            return <HuggingFaceFields config={config} updateField={updateField} hfTokenFromEnv={hfTokenFromEnv} />;
+            return <HuggingFaceFields config={config} updateField={updateField} />;
         default:
             return <div>Unknown Provider</div>;
     }

--- a/apps/dashboard/src/services/configService.ts
+++ b/apps/dashboard/src/services/configService.ts
@@ -48,7 +48,8 @@ export interface DePINConfig {
 }
 
 export interface HuggingFaceConfig {
-    token: string;
+    token?: string;
+    tokens?: { name: string; token: string; is_active?: boolean }[];
 }
 
 export interface ProvidersConfig {
@@ -66,7 +67,7 @@ export interface ProviderConfigResponse {
 export const initialProviderConfig: ProvidersConfig = {
     cloud: { aws: {}, gcp: {} },
     depin: { nosana: {}, akash: {} },
-    huggingface: { token: "" }
+    huggingface: { token: "", tokens: [] }
 };
 
 // Universal Provider Credential Types (works for ANY provider)

--- a/apps/dashboard/src/services/configService.ts
+++ b/apps/dashboard/src/services/configService.ts
@@ -1,4 +1,4 @@
-import api from "@/lib/api";
+import api, { computeApi } from "@/lib/api";
 
 export interface AWSConfig {
     access_key_id?: string;
@@ -167,5 +167,26 @@ export const ConfigService = {
 
     async deleteNosanaApiKey(name: string): Promise<void> {
         return this.deleteProviderCredential('nosana', name);
-    }
+    },
+
+    // Engine-cache AMI admin endpoints (gateway proxy → /api/v1/admin/aws/engine-ami)
+    async listEngineAmis(region: string): Promise<{ ami_id: string; vllm_tag?: string; region: string; created: string }[]> {
+        const { data } = await computeApi.get<{ amis: { ami_id: string; vllm_tag?: string; region: string; created: string }[] }>('/admin/aws/engine-ami', { params: { region } });
+        return data.amis;
+    },
+
+    async startEngineBake(body: { region: string; vllm_tag?: string }): Promise<{ bake_id: string; status: string }> {
+        const { data } = await computeApi.post<{ bake_id: string; status: string }>('/admin/aws/engine-ami/bake', body);
+        return data;
+    },
+
+    async pollBakeStatus(bakeId: string): Promise<{ status: string; message: string; ami_id?: string; region: string }> {
+        const { data } = await computeApi.get<{ status: string; message: string; ami_id?: string; region: string }>(`/admin/aws/engine-ami/bake/${bakeId}`);
+        return data;
+    },
+
+    async listHfTokenNames(): Promise<string[]> {
+        const { data } = await api.get<{ names: string[] }>('/management/config/providers/huggingface/token-names');
+        return data.names;
+    },
 };

--- a/package/src/inferia/services/api_gateway/config.py
+++ b/package/src/inferia/services/api_gateway/config.py
@@ -86,8 +86,15 @@ class DePINConfig(BaseModel):
     nosana: NosanaConfig = Field(default_factory=NosanaConfig)
 
 
+class HFTokenEntry(BaseModel):
+    name: str
+    token: str
+    is_active: bool = True
+
+
 class HuggingFaceConfig(BaseModel):
-    token: str = ""
+    token: str = ""  # legacy single token (kept as fallback "default")
+    tokens: list[HFTokenEntry] = Field(default_factory=list)
 
 
 class ProvidersConfig(BaseModel):

--- a/package/src/inferia/services/api_gateway/config.py
+++ b/package/src/inferia/services/api_gateway/config.py
@@ -18,18 +18,6 @@ logger = logging.getLogger(__name__)
 class AWSConfig(BaseModel):
     access_key_id: Optional[str] = None
     secret_access_key: Optional[str] = None
-    region: str = "us-east-1"
-    # Account-wide AWS provisioning defaults. SkyPilot uses these when
-    # spinning up pools; previously the same fields lived on each pool's
-    # compute_pools.metadata jsonb. None ⇒ SkyPilot picks a default
-    # (creates a VPC, default SG, latest Deep Learning AMI, no IAM
-    # instance profile, 100 GB root, "latest" worker image).
-    subnet_id: Optional[str] = None
-    security_group_ids: Optional[list[str]] = None
-    ami_id: Optional[str] = None
-    iam_instance_profile: Optional[str] = None
-    root_volume_gb: Optional[int] = None
-    worker_image_tag: Optional[str] = None
 
 
 class GCPConfig(BaseModel):

--- a/package/src/inferia/services/api_gateway/management/configuration.py
+++ b/package/src/inferia/services/api_gateway/management/configuration.py
@@ -47,6 +47,7 @@ from inferia.services.api_gateway.config import (
     DePINConfig,
     VectorDBConfig,
     HuggingFaceConfig,
+    HFTokenEntry,
 )
 
 router = APIRouter(tags=["Configuration"])
@@ -182,6 +183,24 @@ def _preserve_masked_secrets(incoming: dict, existing: dict) -> dict:
             hf_in["token"] = hf_ex["token"]
         else:
             hf_in.pop("token", None)
+
+    # HuggingFace named tokens list.
+    in_tokens = hf_in.get("tokens")
+    if isinstance(in_tokens, list):
+        ex_by_name = {e.get("name"): e for e in (hf_ex.get("tokens") or []) if isinstance(e, dict)}
+        kept = []
+        for ent in in_tokens:
+            if not isinstance(ent, dict):
+                continue
+            if _is_masked(ent.get("token")):
+                prior = ex_by_name.get(ent.get("name"))
+                if prior and prior.get("token"):
+                    ent = {**ent, "token": prior["token"]}
+                else:
+                    continue
+            kept.append(ent)
+        hf_in["tokens"] = kept
+
     if hf_in:
         out["huggingface"] = hf_in
 
@@ -225,6 +244,9 @@ def _mask_config(config: ProvidersConfig) -> ProvidersConfig:
     # HuggingFace — nested under .huggingface
     if masked.huggingface.token:
         masked.huggingface.token = "********"
+    for entry in masked.huggingface.tokens:
+        if entry.token:
+            entry.token = "********"
 
     return masked
 

--- a/package/src/inferia/services/api_gateway/management/configuration.py
+++ b/package/src/inferia/services/api_gateway/management/configuration.py
@@ -554,6 +554,31 @@ def _get_nosana_credentials_from_config() -> List[ProviderCredential]:
     return credentials
 
 
+class HFTokenNamesResponse(BaseModel):
+    names: List[str]
+
+
+@router.get("/config/providers/huggingface/token-names", response_model=HFTokenNamesResponse)
+async def list_hf_token_names(request: Request):
+    """
+    Return the names of active HuggingFace tokens.
+
+    Returns names only (no values) so the deploy form can populate a
+    dropdown without exposing secrets.  Requires ``deployment:list`` so
+    any deployer (not just org admins) can fetch the list.
+    """
+    user_ctx = get_current_user_context(request)
+    authz_service.require_permission(user_ctx, PermissionEnum.DEPLOYMENT_LIST)
+
+    hf = settings.providers.huggingface
+    names = [
+        t.name
+        for t in hf.tokens
+        if getattr(t, "is_active", True) and t.name
+    ]
+    return HFTokenNamesResponse(names=names)
+
+
 @router.get(
     "/config/providers/{provider}/credentials",
     response_model=ProviderCredentialListResponse,

--- a/package/src/inferia/services/api_gateway/tests/test_hf_token_names_endpoint.py
+++ b/package/src/inferia/services/api_gateway/tests/test_hf_token_names_endpoint.py
@@ -1,0 +1,151 @@
+"""Tests for GET /management/config/providers/huggingface/token-names.
+
+Verifies:
+- Active token names are returned (no token values).
+- Inactive tokens are excluded.
+- Empty list is handled gracefully.
+- Route returns 200 with a deployer-scoped permission (deployment:list).
+- An unauthenticated request returns 401.
+"""
+import pytest
+import pytest_asyncio
+from unittest.mock import patch
+
+from inferia.services.api_gateway.config import HuggingFaceConfig, HFTokenEntry
+
+
+_ENDPOINT = "/management/config/providers/huggingface/token-names"
+
+
+@pytest.mark.asyncio
+async def test_token_names_returns_active_names(client, admin_token):
+    """Active token names are returned; token values are NOT exposed."""
+    hf = HuggingFaceConfig(
+        token="hf_legacy",
+        tokens=[
+            HFTokenEntry(name="prod", token="hf_prod_secret", is_active=True),
+            HFTokenEntry(name="staging", token="hf_staging_secret", is_active=True),
+        ],
+    )
+    with patch(
+        "inferia.services.api_gateway.management.configuration.settings"
+    ) as mock_settings:
+        mock_settings.providers.huggingface = hf
+        resp = await client.get(
+            _ENDPOINT, headers={"Authorization": f"Bearer {admin_token}"}
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body["names"]) == {"prod", "staging"}
+    # No token values in the response
+    assert "hf_prod_secret" not in str(body)
+    assert "hf_staging_secret" not in str(body)
+
+
+@pytest.mark.asyncio
+async def test_token_names_excludes_inactive(client, admin_token):
+    """Inactive tokens must not appear in the names list."""
+    hf = HuggingFaceConfig(
+        tokens=[
+            HFTokenEntry(name="active", token="hf_act", is_active=True),
+            HFTokenEntry(name="inactive", token="hf_inact", is_active=False),
+        ]
+    )
+    with patch(
+        "inferia.services.api_gateway.management.configuration.settings"
+    ) as mock_settings:
+        mock_settings.providers.huggingface = hf
+        resp = await client.get(
+            _ENDPOINT, headers={"Authorization": f"Bearer {admin_token}"}
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["names"] == ["active"]
+
+
+@pytest.mark.asyncio
+async def test_token_names_empty_list(client, admin_token):
+    """No tokens configured → empty names list, not an error."""
+    hf = HuggingFaceConfig(tokens=[])
+    with patch(
+        "inferia.services.api_gateway.management.configuration.settings"
+    ) as mock_settings:
+        mock_settings.providers.huggingface = hf
+        resp = await client.get(
+            _ENDPOINT, headers={"Authorization": f"Bearer {admin_token}"}
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["names"] == []
+
+
+@pytest.mark.asyncio
+async def test_token_names_unauthenticated_returns_401(client):
+    """Request without a bearer token must be rejected with 401."""
+    resp = await client.get(_ENDPOINT)
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_token_names_deployer_scoped_permission(client, developer_token):
+    """A developer (power_user) token can call this endpoint.
+
+    The middleware mock in conftest grants admin:all to every mock role, so
+    the developer_token already has deployment:list in this test harness.
+    This verifies the route is accessible with a non-admin token type.
+    """
+    hf = HuggingFaceConfig(
+        tokens=[HFTokenEntry(name="alpha", token="hf_alpha", is_active=True)]
+    )
+    with patch(
+        "inferia.services.api_gateway.management.configuration.settings"
+    ) as mock_settings:
+        mock_settings.providers.huggingface = hf
+        resp = await client.get(
+            _ENDPOINT, headers={"Authorization": f"Bearer {developer_token}"}
+        )
+
+    assert resp.status_code == 200
+    assert "alpha" in resp.json()["names"]
+
+
+@pytest.mark.asyncio
+async def test_token_names_skips_blank_names(client, admin_token):
+    """Entries with an empty name string are skipped (guard against blank slots)."""
+    hf = HuggingFaceConfig(
+        tokens=[
+            HFTokenEntry(name="real", token="hf_r", is_active=True),
+            HFTokenEntry(name="", token="hf_blank_name", is_active=True),
+        ]
+    )
+    with patch(
+        "inferia.services.api_gateway.management.configuration.settings"
+    ) as mock_settings:
+        mock_settings.providers.huggingface = hf
+        resp = await client.get(
+            _ENDPOINT, headers={"Authorization": f"Bearer {admin_token}"}
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["names"] == ["real"]
+
+
+@pytest.mark.asyncio
+async def test_token_names_only_inactive_tokens_returns_empty(client, admin_token):
+    """When all tokens are inactive the list is empty."""
+    hf = HuggingFaceConfig(
+        tokens=[
+            HFTokenEntry(name="old", token="hf_old", is_active=False),
+        ]
+    )
+    with patch(
+        "inferia.services.api_gateway.management.configuration.settings"
+    ) as mock_settings:
+        mock_settings.providers.huggingface = hf
+        resp = await client.get(
+            _ENDPOINT, headers={"Authorization": f"Bearer {admin_token}"}
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["names"] == []

--- a/package/src/inferia/services/api_gateway/tests/test_masked_secret_guard.py
+++ b/package/src/inferia/services/api_gateway/tests/test_masked_secret_guard.py
@@ -224,6 +224,29 @@ def test_hf_non_dict_entry_skipped():
     assert out["huggingface"]["tokens"] == [{"name": "ok", "token": "hf_ok"}]
 
 
+# ---------- HuggingFace full round-trip regression ----------------------
+
+
+def test_hf_tokens_round_trip_masked_save_preserves():
+    """Simulate the dashboard cycle: GET masks tokens → user saves without
+    retyping → POST carries the masks back → _preserve_masked_secrets must
+    restore every real value, proving no wipe occurs.
+    """
+    existing = {"providers": {"huggingface": {
+        "token": "hf_legacy_real",
+        "tokens": [{"name": "default", "token": "hf_default_real", "is_active": True},
+                   {"name": "prod", "token": "hf_prod_real", "is_active": True}]}}}
+    # Dashboard GET masks → user saves without retyping → POST carries the masks
+    incoming = {"huggingface": {
+        "token": "********",
+        "tokens": [{"name": "default", "token": "********", "is_active": True},
+                   {"name": "prod", "token": "********", "is_active": True}]}}
+    out = _preserve_masked_secrets(incoming, existing)
+    assert out["huggingface"]["token"] == "hf_legacy_real"
+    assert out["huggingface"]["tokens"][0]["token"] == "hf_default_real"
+    assert out["huggingface"]["tokens"][1]["token"] == "hf_prod_real"
+
+
 # ---------- AWSConfig credentials-only model ----------------------------
 
 

--- a/package/src/inferia/services/api_gateway/tests/test_masked_secret_guard.py
+++ b/package/src/inferia/services/api_gateway/tests/test_masked_secret_guard.py
@@ -6,7 +6,13 @@ real credential in the DB with the literal mask string.
 """
 from inferia.services.api_gateway.management.configuration import (
     _is_masked,
+    _mask_config,
     _preserve_masked_secrets,
+)
+from inferia.services.api_gateway.config import (
+    HuggingFaceConfig,
+    HFTokenEntry,
+    ProvidersConfig,
 )
 
 
@@ -141,3 +147,77 @@ def test_empty_existing_handled_gracefully():
     out = _preserve_masked_secrets(incoming, {})
     # No masked fields → no transformation.
     assert out == {"cloud": {"aws": {"region": "us-east-1"}}}
+
+
+# ---------- HuggingFace multi-token model & masking ---------------------
+
+
+def test_hf_tokens_list_model():
+    hf = HuggingFaceConfig(
+        tokens=[
+            HFTokenEntry(name="default", token="hf_abc"),
+            HFTokenEntry(name="prod", token="hf_xyz", is_active=False),
+        ]
+    )
+    assert hf.tokens[0].name == "default" and hf.tokens[0].is_active is True
+    assert hf.tokens[1].is_active is False
+
+
+def test_mask_config_masks_hf_tokens_list():
+    cfg = ProvidersConfig(
+        huggingface=HuggingFaceConfig(
+            token="hf_legacy",
+            tokens=[HFTokenEntry(name="default", token="hf_secret")],
+        )
+    )
+    masked = _mask_config(cfg)
+    assert masked.huggingface.token == "********"
+    assert masked.huggingface.tokens[0].token == "********"
+    assert masked.huggingface.tokens[0].name == "default"
+
+
+def test_preserve_masked_hf_token_by_name():
+    existing = {"providers": {"huggingface": {"tokens": [{"name": "default", "token": "hf_real", "is_active": True}]}}}
+    incoming = {"huggingface": {"tokens": [{"name": "default", "token": "********", "is_active": True}]}}
+    out = _preserve_masked_secrets(incoming, existing)
+    assert out["huggingface"]["tokens"][0]["token"] == "hf_real"
+
+
+def test_preserve_drops_masked_hf_token_with_no_prior():
+    existing = {"providers": {"huggingface": {"tokens": []}}}
+    incoming = {"huggingface": {"tokens": [{"name": "new", "token": "********"}]}}
+    out = _preserve_masked_secrets(incoming, existing)
+    assert out["huggingface"]["tokens"] == []
+
+
+# ---------- HuggingFace coverage tests ----------------------------------
+
+
+def test_hf_token_unmasked_passthrough():
+    # A freshly-typed (unmasked) list token must survive preserve unchanged.
+    existing = {"providers": {"huggingface": {"tokens": []}}}
+    incoming = {"huggingface": {"tokens": [{"name": "new", "token": "hf_brandnew", "is_active": True}]}}
+    out = _preserve_masked_secrets(incoming, existing)
+    assert out["huggingface"]["tokens"][0]["token"] == "hf_brandnew"
+
+
+def test_hf_no_tokens_key_preserves_legacy():
+    # tokens absent → the tokens-list block must not run / crash; legacy token preserve still works.
+    existing = {"providers": {"huggingface": {"token": "hf_old"}}}
+    incoming = {"huggingface": {"token": "********"}}
+    out = _preserve_masked_secrets(incoming, existing)
+    assert out["huggingface"]["token"] == "hf_old"
+
+
+def test_hf_empty_tokens_list_passthrough():
+    existing = {"providers": {"huggingface": {"tokens": [{"name": "a", "token": "hf_a"}]}}}
+    incoming = {"huggingface": {"tokens": []}}
+    out = _preserve_masked_secrets(incoming, existing)
+    assert out["huggingface"]["tokens"] == []
+
+
+def test_hf_non_dict_entry_skipped():
+    existing = {"providers": {"huggingface": {"tokens": []}}}
+    incoming = {"huggingface": {"tokens": ["garbage", {"name": "ok", "token": "hf_ok"}]}}
+    out = _preserve_masked_secrets(incoming, existing)
+    assert out["huggingface"]["tokens"] == [{"name": "ok", "token": "hf_ok"}]

--- a/package/src/inferia/services/api_gateway/tests/test_masked_secret_guard.py
+++ b/package/src/inferia/services/api_gateway/tests/test_masked_secret_guard.py
@@ -10,6 +10,7 @@ from inferia.services.api_gateway.management.configuration import (
     _preserve_masked_secrets,
 )
 from inferia.services.api_gateway.config import (
+    AWSConfig,
     HuggingFaceConfig,
     HFTokenEntry,
     ProvidersConfig,
@@ -221,3 +222,41 @@ def test_hf_non_dict_entry_skipped():
     incoming = {"huggingface": {"tokens": ["garbage", {"name": "ok", "token": "hf_ok"}]}}
     out = _preserve_masked_secrets(incoming, existing)
     assert out["huggingface"]["tokens"] == [{"name": "ok", "token": "hf_ok"}]
+
+
+# ---------- AWSConfig credentials-only model ----------------------------
+
+
+def test_aws_config_creds_only():
+    """AWSConfig must contain only access_key_id and secret_access_key.
+
+    region + provisioning-default fields (subnet_id, security_group_ids,
+    ami_id, iam_instance_profile, root_volume_gb, worker_image_tag) were
+    removed; provisioning reads region exclusively from the pool's
+    region_constraint.
+    """
+    aws = AWSConfig(access_key_id="AKIA", secret_access_key="s")
+    for gone in (
+        "region",
+        "subnet_id",
+        "security_group_ids",
+        "ami_id",
+        "iam_instance_profile",
+        "root_volume_gb",
+        "worker_image_tag",
+    ):
+        assert not hasattr(aws, gone), f"{gone} should be removed from AWSConfig"
+
+
+def test_aws_config_accepts_only_creds():
+    """AWSConfig with just credentials is valid; extra fields are rejected."""
+    aws = AWSConfig(access_key_id="AKIAIOSFODNN7EXAMPLE", secret_access_key="wJalrXUtnFEMI")
+    assert aws.access_key_id == "AKIAIOSFODNN7EXAMPLE"
+    assert aws.secret_access_key == "wJalrXUtnFEMI"
+
+
+def test_aws_config_defaults_to_none():
+    """Both credential fields default to None when not provided."""
+    aws = AWSConfig()
+    assert aws.access_key_id is None
+    assert aws.secret_access_key is None

--- a/package/src/inferia/services/orchestration/api/nodes.py
+++ b/package/src/inferia/services/orchestration/api/nodes.py
@@ -582,7 +582,56 @@ async def get_ec2_console(
         return EC2ConsoleResponse(
             logs=[], fetched_at=datetime.now(timezone.utc).isoformat(),
         )
-    result = await adapter.get_logs(provider_instance_id=instance_id)
+
+    # Resolve the node's actual AWS region so get_logs scopes the boto3
+    # EC2 client correctly (get_console_output is region-scoped).
+    # Priority: job spec → job pulumi_stack_outputs → node metadata → pool
+    # region_constraint[0].  Any failure in the chain is silently skipped;
+    # get_logs falls back to us-east-1 when region=None is passed.
+    node_region: str | None = None
+    try:
+        job = None
+        if _deps.provisioning_repo is not None and hasattr(
+            _deps.provisioning_repo, "get_by_node"
+        ):
+            try:
+                node_uuid = uuid.UUID(str(node_id))
+            except (ValueError, TypeError):
+                node_uuid = None
+            if node_uuid is not None:
+                job = await _deps.provisioning_repo.get_by_node(node_id=node_uuid)
+        if job is not None:
+            spec = getattr(job, "spec", None) or {}
+            outs = getattr(job, "pulumi_stack_outputs", None) or {}
+            node_region = spec.get("region") or outs.get("region") or None
+        if not node_region:
+            metadata = row.get("metadata") or {}
+            if isinstance(metadata, str):
+                import json as _json
+                try:
+                    metadata = _json.loads(metadata)
+                except Exception:
+                    metadata = {}
+            node_region = (metadata or {}).get("region") or None
+        if not node_region:
+            pool_id = row.get("pool_id")
+            if pool_id and _deps.pool_repo is not None and hasattr(
+                _deps.pool_repo, "get"
+            ):
+                try:
+                    pool = await _deps.pool_repo.get(pool_id)
+                    if pool:
+                        rc = pool.get("region_constraint") if hasattr(pool, "get") else (
+                            getattr(pool, "region_constraint", None)
+                        )
+                        if rc:
+                            node_region = rc[0] if isinstance(rc, (list, tuple)) and rc else None
+                except Exception:
+                    pass
+    except Exception:
+        node_region = None
+
+    result = await adapter.get_logs(provider_instance_id=instance_id, region=node_region)
     return EC2ConsoleResponse(
         logs=result.get("logs", []),
         fetched_at=datetime.now(timezone.utc).isoformat(),

--- a/package/src/inferia/services/orchestration/api/tests/test_nodes_provisioning_endpoints.py
+++ b/package/src/inferia/services/orchestration/api/tests/test_nodes_provisioning_endpoints.py
@@ -7,12 +7,28 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 from datetime import datetime, timezone
+import json
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
-from inferia.services.orchestration.api import nodes as nodes_api
+# Repo-wide version skew: starlette 0.35.1 still passes ``app=`` to
+# ``httpx.Client``, which httpx 0.28+ removed. Patch the httpx Client
+# constructor to drop the ``app`` kwarg for the duration of this test
+# module so the existing sync TestClient-based tests keep working.
+import httpx as _httpx
+_orig_client_init = _httpx.Client.__init__
+
+
+def _patched_client_init(self, *args, **kwargs):
+    kwargs.pop("app", None)
+    return _orig_client_init(self, *args, **kwargs)
+
+
+_httpx.Client.__init__ = _patched_client_init  # type: ignore[assignment]
+from fastapi.testclient import TestClient  # noqa: E402
+
+from inferia.services.orchestration.api import nodes as nodes_api  # noqa: E402
 
 
 def _user_ctx_header():
@@ -185,3 +201,244 @@ def test_provisioning_routes_registered():
     assert any(p.endswith("/provisioning") for p in paths)
     assert any(p.endswith("/provisioning-logs") for p in paths)
     assert any(p.endswith("/ec2-console") for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# Region-resolution tests for get_ec2_console (Task 3 coverage).
+#
+# Each test exercises one tier of the priority chain:
+#   T1: job.spec["region"]            (highest priority)
+#   T2: job.pulumi_stack_outputs["region"]
+#   T3: node metadata["region"] (dict)
+#   T4: node metadata["region"] (JSON string — parse path)
+#   T5: pool region_constraint[0]
+#   T6: no region anywhere → region=None
+#
+# All tests assert get_logs.await_args.kwargs["region"] explicitly so that
+# a future typo in the kwarg name is caught even though AsyncMock accepts
+# any kwarg without raising (AsyncMock-signature-blindness trap).
+# ---------------------------------------------------------------------------
+
+
+def _make_job(spec_region=None, outputs_region=None):
+    """Return a MagicMock that looks like a ProvisioningJob row."""
+    job = MagicMock()
+    job.spec = {"region": spec_region} if spec_region else {}
+    job.pulumi_stack_outputs = {"region": outputs_region} if outputs_region else {}
+    return job
+
+
+def _build_region_app(
+    *,
+    node_row_extra=None,
+    job=None,
+    pool_row=None,
+):
+    """Build a minimal FastAPI app for region-resolution tests.
+
+    ``node_row_extra`` is merged into the default node dict so callers can
+    override ``metadata``, etc.  ``job`` is returned by
+    ``provisioning_repo.get_by_node``.  ``pool_row`` is returned by
+    ``pool_repo.get``; if it is a plain dict it is used as-is (the real code
+    calls ``pool.get("region_constraint")``).
+    """
+    pool_id = uuid4()
+    node_row = {
+        "id": uuid4(),
+        "pool_id": pool_id,
+        "node_name": "n-region",
+        "agent_kind": None,
+        "provider": "aws",
+        "state": "ready",
+        "labels": {},
+        "advertise_url": None,
+        "expose_url": None,
+        "gpu_total": 0,
+        "gpu_allocated": 0,
+        "vcpu_total": 0,
+        "vcpu_allocated": 0,
+        "ram_gb_total": 0,
+        "ram_gb_allocated": 0,
+        "last_heartbeat": None,
+        # Real instance ID so the placeholder-skip branch is not taken.
+        "provider_instance_id": "i-region123",
+        "metadata": {},
+    }
+    if node_row_extra:
+        node_row.update(node_row_extra)
+
+    inv = MagicMock()
+    inv.get_node = AsyncMock(return_value=node_row)
+
+    prov = MagicMock()
+    prov.get_by_node = AsyncMock(return_value=job)
+    # Legacy node_events_repo methods (used by other endpoints; not exercised
+    # by ec2-console but needed so configure() doesn't choke).
+    prov.summarize_phases = AsyncMock(return_value=[])
+    prov.list_events_after = AsyncMock(return_value=[])
+    prov.current_phase = AsyncMock(return_value=None)
+
+    pool_repo_mock = MagicMock()
+    pool_repo_mock.get = AsyncMock(return_value=pool_row)
+
+    aws_adapter = MagicMock()
+    aws_adapter.get_logs = AsyncMock(return_value={"logs": ["line1"]})
+
+    app = FastAPI()
+    nodes_api.configure(
+        inventory_repo=inv,
+        pool_repo=pool_repo_mock,
+        worker_auth=MagicMock(),
+        control_plane_external_url="",
+        adapters={"aws": aws_adapter},
+        require_permission=lambda _: (lambda: True),
+        provisioning_repo=prov,
+    )
+    app.include_router(nodes_api.router)
+    return app, node_row, aws_adapter
+
+
+def test_region_from_job_spec(app_and_deps):
+    """Tier 1: job.spec['region'] is used when present."""
+    _, _, prov, aws_adapter, node_row = app_and_deps
+    node_row["provider_instance_id"] = "i-spec-region"
+
+    job = _make_job(spec_region="eu-west-1")
+    prov.get_by_node = AsyncMock(return_value=job)
+
+    app = FastAPI()
+    nodes_api.configure(
+        inventory_repo=MagicMock(**{"get_node": AsyncMock(return_value=node_row)}),
+        pool_repo=MagicMock(),
+        worker_auth=MagicMock(),
+        control_plane_external_url="",
+        adapters={"aws": aws_adapter},
+        require_permission=lambda _: (lambda: True),
+        provisioning_repo=prov,
+    )
+    app.include_router(nodes_api.router)
+
+    client = TestClient(app)
+    r = client.get(
+        f"/v1/nodes/{node_row['id']}/ec2-console",
+        headers=_user_ctx_header(),
+    )
+    assert r.status_code == 200
+    assert aws_adapter.get_logs.await_args.kwargs["region"] == "eu-west-1"
+
+
+def test_region_from_job_pulumi_outputs():
+    """Tier 2: job.pulumi_stack_outputs['region'] when spec has no region."""
+    job = _make_job(spec_region=None, outputs_region="ap-southeast-1")
+    app, node_row, aws_adapter = _build_region_app(job=job)
+
+    client = TestClient(app)
+    r = client.get(
+        f"/v1/nodes/{node_row['id']}/ec2-console",
+        headers=_user_ctx_header(),
+    )
+    assert r.status_code == 200
+    assert aws_adapter.get_logs.await_args.kwargs["region"] == "ap-southeast-1"
+
+
+def test_region_from_node_metadata_dict():
+    """Tier 3: node metadata dict has 'region' when no job region."""
+    app, node_row, aws_adapter = _build_region_app(
+        node_row_extra={"metadata": {"region": "us-west-2"}},
+        job=None,
+    )
+
+    client = TestClient(app)
+    r = client.get(
+        f"/v1/nodes/{node_row['id']}/ec2-console",
+        headers=_user_ctx_header(),
+    )
+    assert r.status_code == 200
+    assert aws_adapter.get_logs.await_args.kwargs["region"] == "us-west-2"
+
+
+def test_region_from_node_metadata_json_string():
+    """Tier 3 parse path: metadata is a JSON string (asyncpg text column)."""
+    metadata_str = json.dumps({"region": "ca-central-1"})
+    app, node_row, aws_adapter = _build_region_app(
+        node_row_extra={"metadata": metadata_str},
+        job=None,
+    )
+
+    client = TestClient(app)
+    r = client.get(
+        f"/v1/nodes/{node_row['id']}/ec2-console",
+        headers=_user_ctx_header(),
+    )
+    assert r.status_code == 200
+    assert aws_adapter.get_logs.await_args.kwargs["region"] == "ca-central-1"
+
+
+def test_region_from_pool_region_constraint():
+    """Tier 4: pool.region_constraint[0] when job + metadata have no region."""
+    pool_row = {"region_constraint": ["eu-central-1", "eu-west-1"]}
+    app, node_row, aws_adapter = _build_region_app(
+        node_row_extra={"metadata": {}},
+        job=None,
+        pool_row=pool_row,
+    )
+
+    client = TestClient(app)
+    r = client.get(
+        f"/v1/nodes/{node_row['id']}/ec2-console",
+        headers=_user_ctx_header(),
+    )
+    assert r.status_code == 200
+    assert aws_adapter.get_logs.await_args.kwargs["region"] == "eu-central-1"
+
+
+def test_region_none_when_no_source_available():
+    """Tier fallback: region=None is passed to get_logs when all sources are empty."""
+    app, node_row, aws_adapter = _build_region_app(
+        node_row_extra={"metadata": {}},
+        job=None,
+        pool_row={"region_constraint": []},
+    )
+
+    client = TestClient(app)
+    r = client.get(
+        f"/v1/nodes/{node_row['id']}/ec2-console",
+        headers=_user_ctx_header(),
+    )
+    assert r.status_code == 200
+    assert aws_adapter.get_logs.await_args.kwargs["region"] is None
+
+
+def test_region_job_spec_takes_priority_over_metadata():
+    """Tier 1 wins even when metadata also has a (different) region."""
+    job = _make_job(spec_region="us-east-1")
+    app, node_row, aws_adapter = _build_region_app(
+        node_row_extra={"metadata": {"region": "us-west-2"}},
+        job=job,
+    )
+
+    client = TestClient(app)
+    r = client.get(
+        f"/v1/nodes/{node_row['id']}/ec2-console",
+        headers=_user_ctx_header(),
+    )
+    assert r.status_code == 200
+    assert aws_adapter.get_logs.await_args.kwargs["region"] == "us-east-1"
+
+
+def test_region_metadata_takes_priority_over_pool():
+    """Tier 3 wins over tier 4: metadata region beats pool constraint."""
+    pool_row = {"region_constraint": ["sa-east-1"]}
+    app, node_row, aws_adapter = _build_region_app(
+        node_row_extra={"metadata": {"region": "ap-northeast-1"}},
+        job=None,
+        pool_row=pool_row,
+    )
+
+    client = TestClient(app)
+    r = client.get(
+        f"/v1/nodes/{node_row['id']}/ec2-console",
+        headers=_user_ctx_header(),
+    )
+    assert r.status_code == 200
+    assert aws_adapter.get_logs.await_args.kwargs["region"] == "ap-northeast-1"

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/credentials.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/credentials.py
@@ -48,16 +48,19 @@ def _require(value: str | None, field_name: str) -> str:
 
 
 def resolve_aws_env(cfg: ProvidersConfig) -> dict[str, str]:
-    """Return env vars Pulumi-AWS will inherit. AWS_DEFAULT_REGION
-    falls back to us-east-1 when the config has no region."""
+    """Return env vars Pulumi-AWS will inherit.
+
+    AWS_DEFAULT_REGION is fixed to us-east-1 — the STS endpoint is global
+    and us-east-1 always resolves. Pool-specific regions come from
+    region_constraint at pool creation, not from the account-wide config.
+    """
     aws = cfg.cloud.aws
     key = _require(aws.access_key_id, "access_key_id")
     secret = _require(aws.secret_access_key, "secret_access_key")
-    region = aws.region or "us-east-1"
     return {
         "AWS_ACCESS_KEY_ID": key,
         "AWS_SECRET_ACCESS_KEY": secret,
-        "AWS_DEFAULT_REGION": region,
+        "AWS_DEFAULT_REGION": "us-east-1",
     }
 
 

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/pulumi_aws_adapter.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/pulumi_aws_adapter.py
@@ -639,13 +639,18 @@ class PulumiAWSAdapter(PulumiProvisioningBase, ProviderAdapter):
         *,
         provider_instance_id: str,
         provider_credential_name: Optional[str] = None,
+        region: Optional[str] = None,
     ) -> Dict[str, Any]:
         import boto3
         cfg = await load_providers_config()
         env_vars = resolve_aws_env(cfg)
+        # Use the node's actual region when provided; fall back to the
+        # account-wide default (us-east-1) so the endpoint never crashes
+        # for legacy / region-less rows.
+        effective_region = region or env_vars["AWS_DEFAULT_REGION"]
         ec2 = boto3.client(
             "ec2",
-            region_name=env_vars["AWS_DEFAULT_REGION"],
+            region_name=effective_region,
             aws_access_key_id=env_vars["AWS_ACCESS_KEY_ID"],
             aws_secret_access_key=env_vars["AWS_SECRET_ACCESS_KEY"],
         )

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/test_credentials.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/test_credentials.py
@@ -28,24 +28,23 @@ def test_resolve_aws_env_happy():
     cfg = _aws_cfg(
         access_key_id="AKIAREALKEY1234XYZ8",
         secret_access_key="real-secret-not-mask",
-        region="us-west-2",
     )
     env = resolve_aws_env(cfg)
     assert env == {
         "AWS_ACCESS_KEY_ID": "AKIAREALKEY1234XYZ8",
         "AWS_SECRET_ACCESS_KEY": "real-secret-not-mask",
-        "AWS_DEFAULT_REGION": "us-west-2",
+        "AWS_DEFAULT_REGION": "us-east-1",
     }
 
 
 def test_resolve_aws_env_missing_key_raises():
-    cfg = _aws_cfg(secret_access_key="x", region="us-east-1")
+    cfg = _aws_cfg(secret_access_key="x")
     with pytest.raises(MissingCredentialsError):
         resolve_aws_env(cfg)
 
 
 def test_resolve_aws_env_missing_secret_raises():
-    cfg = _aws_cfg(access_key_id="AKIA", region="us-east-1")
+    cfg = _aws_cfg(access_key_id="AKIA")
     with pytest.raises(MissingCredentialsError):
         resolve_aws_env(cfg)
 
@@ -54,7 +53,6 @@ def test_resolve_aws_env_masked_key_rejected():
     cfg = _aws_cfg(
         access_key_id="AKIA...XYZ8",  # masked
         secret_access_key="real",
-        region="us-east-1",
     )
     with pytest.raises(MissingCredentialsError):
         resolve_aws_env(cfg)
@@ -64,17 +62,16 @@ def test_resolve_aws_env_masked_secret_rejected():
     cfg = _aws_cfg(
         access_key_id="AKIAREALKEY1234XYZ8",
         secret_access_key="********",  # masked
-        region="us-east-1",
     )
     with pytest.raises(MissingCredentialsError):
         resolve_aws_env(cfg)
 
 
-def test_resolve_aws_env_default_region_when_blank():
+def test_resolve_aws_env_region_always_us_east_1():
+    """AWS_DEFAULT_REGION is always us-east-1; region was removed from AWSConfig."""
     cfg = _aws_cfg(
         access_key_id="AKIAREALKEY1234XYZ8",
         secret_access_key="real-secret-not-mask",
-        region="",
     )
     env = resolve_aws_env(cfg)
     assert env["AWS_DEFAULT_REGION"] == "us-east-1"

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/test_pulumi_aws_adapter.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/pulumi/test_pulumi_aws_adapter.py
@@ -520,6 +520,111 @@ async def test_get_logs_error_returns_empty(fake_db, aws_config, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Region-aware get_logs: the EC2 client must be built with the node's actual
+# region, not the hardcoded us-east-1 fallback from resolve_aws_env.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_logs_uses_explicit_region_for_ec2_client(fake_db, aws_config, tmp_path):
+    """When a node region is passed, boto3.client is called with that region,
+    NOT the hardcoded us-east-1 default from resolve_aws_env."""
+    mock_ec2 = MagicMock()
+    mock_ec2.get_console_output.return_value = {"Output": "boot log"}
+    captured: dict = {}
+
+    def fake_boto3_client(service, **kw):
+        captured["region"] = kw.get("region_name")
+        return mock_ec2
+
+    with patch("boto3.client", side_effect=fake_boto3_client), patch(
+        "inferia.services.orchestration.services.adapter_engine.adapters.pulumi.pulumi_aws_adapter."
+        "load_providers_config",
+        return_value=aws_config,
+    ):
+        adapter = PulumiAWSAdapter(db=fake_db, state_dir=str(tmp_path))
+        logs = await adapter.get_logs(provider_instance_id="i-eu", region="eu-west-1")
+
+    assert captured["region"] == "eu-west-1", (
+        f"Expected eu-west-1, got {captured['region']!r} — region not passed to EC2 client"
+    )
+    assert logs == {"logs": ["boot log"]}
+
+
+@pytest.mark.asyncio
+async def test_get_logs_falls_back_to_us_east_1_when_region_not_passed(
+    fake_db, aws_config, tmp_path
+):
+    """When no region is passed (node region unresolvable), the EC2 client
+    falls back to us-east-1 — the hardcoded default from resolve_aws_env."""
+    mock_ec2 = MagicMock()
+    mock_ec2.get_console_output.return_value = {"Output": ""}
+    captured: dict = {}
+
+    def fake_boto3_client(service, **kw):
+        captured["region"] = kw.get("region_name")
+        return mock_ec2
+
+    with patch("boto3.client", side_effect=fake_boto3_client), patch(
+        "inferia.services.orchestration.services.adapter_engine.adapters.pulumi.pulumi_aws_adapter."
+        "load_providers_config",
+        return_value=aws_config,
+    ):
+        adapter = PulumiAWSAdapter(db=fake_db, state_dir=str(tmp_path))
+        await adapter.get_logs(provider_instance_id="i-no-region")
+
+    assert captured["region"] == "us-east-1", (
+        f"Expected us-east-1 fallback, got {captured['region']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_logs_region_none_falls_back_to_us_east_1(fake_db, aws_config, tmp_path):
+    """Explicitly passing region=None falls back to us-east-1, identical to
+    not passing the argument (regression guard for the optional parameter)."""
+    mock_ec2 = MagicMock()
+    mock_ec2.get_console_output.return_value = {"Output": ""}
+    captured: dict = {}
+
+    def fake_boto3_client(service, **kw):
+        captured["region"] = kw.get("region_name")
+        return mock_ec2
+
+    with patch("boto3.client", side_effect=fake_boto3_client), patch(
+        "inferia.services.orchestration.services.adapter_engine.adapters.pulumi.pulumi_aws_adapter."
+        "load_providers_config",
+        return_value=aws_config,
+    ):
+        adapter = PulumiAWSAdapter(db=fake_db, state_dir=str(tmp_path))
+        await adapter.get_logs(provider_instance_id="i-none", region=None)
+
+    assert captured["region"] == "us-east-1"
+
+
+@pytest.mark.asyncio
+async def test_get_logs_non_us_east_region_is_not_overridden(fake_db, aws_config, tmp_path):
+    """A node in ap-southeast-1 gets ap-southeast-1, NOT us-east-1."""
+    mock_ec2 = MagicMock()
+    mock_ec2.get_console_output.return_value = {"Output": "ap-log"}
+    captured: dict = {}
+
+    def fake_boto3_client(service, **kw):
+        captured["region"] = kw.get("region_name")
+        return mock_ec2
+
+    with patch("boto3.client", side_effect=fake_boto3_client), patch(
+        "inferia.services.orchestration.services.adapter_engine.adapters.pulumi.pulumi_aws_adapter."
+        "load_providers_config",
+        return_value=aws_config,
+    ):
+        adapter = PulumiAWSAdapter(db=fake_db, state_dir=str(tmp_path))
+        logs = await adapter.get_logs(provider_instance_id="i-ap", region="ap-southeast-1")
+
+    assert captured["region"] == "ap-southeast-1"
+    assert logs == {"logs": ["ap-log"]}
+
+
+# ---------------------------------------------------------------------------
 # Stale pulumi-lock recovery: a prior pulumi process dying mid-run under host
 # memory pressure leaves a file-backend lock. The next reconciler retry hits a
 # ConcurrentUpdateError. Both run_pulumi_up_sync and run_pulumi_destroy_sync

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_linker.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_linker.py
@@ -87,7 +87,7 @@ def _spec_from_pending(deploy: dict, gpu_required: int) -> dict:
         "config": cfg.get("config") or {},
         "gpu_indices": gpu_indices,
         "port": 0,
-        "env": {},
+        "env": dict(cfg.get("env") or {}),
     }
 
     return spec

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
@@ -815,7 +815,7 @@ async def deployment_preflight(req: PreflightRequest):
         from inferia.services.orchestration.services.model_deployment.hf_token_resolver import (
             resolve_hf_token,
         )
-        _hf_token = resolve_hf_token(req.hf_token_name)
+        _hf_token = await resolve_hf_token(req.hf_token_name)
 
     # Skip HF checks for external engines
     external_engines = {"openai", "anthropic", "gemini", "groq", "cerebras", "mistral", "deepseek", "custom"}
@@ -1479,7 +1479,7 @@ async def deploy_model(req: DeployModelRequest, request: Request):
         from inferia.services.orchestration.services.model_deployment.hf_token_resolver import (
             resolve_hf_token,
         )
-        _tok = resolve_hf_token(req.hf_token_name)
+        _tok = await resolve_hf_token(req.hf_token_name)
         if _tok:
             cfg = dict(req.configuration or {})
             env = dict(cfg.get("env") or {})

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
@@ -536,6 +536,7 @@ class DeployModelRequest(BaseModel):
 class PreflightRequest(BaseModel):
     model_id: str
     hf_token: str | None = None
+    hf_token_name: str | None = None
     engine: str | None = None
     gpu_per_replica: int = 1
     gpu_vram_gb: float = 24.0
@@ -808,6 +809,14 @@ async def deployment_preflight(req: PreflightRequest):
 
     checks = []
 
+    # Resolve HF token: prefer explicit raw token; fall back to named token from store
+    _hf_token = req.hf_token
+    if not _hf_token and req.hf_token_name:
+        from inferia.services.orchestration.services.model_deployment.hf_token_resolver import (
+            resolve_hf_token,
+        )
+        _hf_token = resolve_hf_token(req.hf_token_name)
+
     # Skip HF checks for external engines
     external_engines = {"openai", "anthropic", "gemini", "groq", "cerebras", "mistral", "deepseek", "custom"}
     is_external = req.engine and req.engine.lower() in external_engines
@@ -820,7 +829,7 @@ async def deployment_preflight(req: PreflightRequest):
 
     if not is_external and not uses_own_registry and req.model_id:
         # Check 1: Model accessibility
-        result = await check_model_accessibility(req.model_id, req.hf_token)
+        result = await check_model_accessibility(req.model_id, _hf_token)
         if result.skipped:
             checks.append(PreflightCheckResult(
                 check="model_accessible",
@@ -843,11 +852,11 @@ async def deployment_preflight(req: PreflightRequest):
 
         # Fetch full HF metadata once (used by checks 2-5)
         if result.accessible and not result.skipped:
-            hf_info = await fetch_hf_model_info(req.model_id, req.hf_token)
+            hf_info = await fetch_hf_model_info(req.model_id, _hf_token)
 
         # Check 2: Model format compatibility
         if hf_info and req.engine:
-            fmt = await check_model_format(req.model_id, req.engine, req.hf_token)
+            fmt = await check_model_format(req.model_id, req.engine, _hf_token)
             if fmt.skipped:
                 checks.append(PreflightCheckResult(
                     check="model_format",

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
@@ -2298,7 +2298,17 @@ async def create_pool(req: CreatePoolRequest, request: Request):
         except _ValidationError as e:
             raise HTTPException(status_code=422, detail={"errors": e.errors()})
 
-    # 2b. Validate AWS region(s) at the boundary. A malformed code (e.g.
+    # 2b. Require region_constraint for AWS pools. Since the account-wide AWS
+    #     region was removed (Task 3), region MUST come from the pool. Accepting
+    #     a region-less AWS pool would let it through to deploy time where it
+    #     fails with an opaque internal error instead of a clear early rejection.
+    if req.provider == "aws" and not req.region_constraint:
+        raise HTTPException(
+            status_code=422,
+            detail="region_constraint is required for AWS pools",
+        )
+
+    # Validate AWS region(s) at the boundary. A malformed code (e.g.
     #     "us-east1" missing the second hyphen) is otherwise persisted and only
     #     fails much later at preflight with an opaque
     #     "DLAMI lookup failed: EndpointConnectionError" (boto3 can't build an

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
@@ -1466,7 +1466,14 @@ async def deploy_model(req: DeployModelRequest, request: Request):
             detail="ami_id is required for vLLM deployments",
         )
 
-    # 1c. Resolve a named HF token server-side and inject HF_TOKEN into the
+    # 1c. Persist ami_id into configuration so the /start resume path can
+    # reuse the operator's selected AMI instead of falling back to resolve_ami.
+    if req.ami_id:
+        cfg = dict(req.configuration or {})
+        cfg["ami_id"] = req.ami_id
+        req.configuration = cfg
+
+    # 1d. Resolve a named HF token server-side and inject HF_TOKEN into the
     # worker config.  The client sends only the *name*, never the raw value.
     if req.hf_token_name:
         from inferia.services.orchestration.services.model_deployment.hf_token_resolver import (
@@ -2071,6 +2078,17 @@ async def _start_deployment_impl(
             await deploys.set_state(deploy_uuid, "CREATED", tx=conn)
 
     # 5. Re-run the shared place+provision core.
+    # Read back the persisted ami_id from the deployment row's configuration so
+    # the operator's AMI selection is honoured on resume instead of falling back
+    # to resolve_ami's auto-pick.
+    _resume_cfg = _source_field(row, "configuration")
+    if isinstance(_resume_cfg, str):
+        try:
+            _resume_cfg = json.loads(_resume_cfg)
+        except (ValueError, TypeError):
+            _resume_cfg = {}
+    _resume_ami = _resume_cfg.get("ami_id") if isinstance(_resume_cfg, dict) else None
+
     deps = SimpleNamespace(
         db_pool=db_pool,
         controller=controller,
@@ -2089,7 +2107,7 @@ async def _start_deployment_impl(
         engine=_source_field(row, "engine"),
         load_spec_source=row,
         deps=deps,
-        ami_id=None,  # resume path: ami_id not stored on the row; use pool default
+        ami_id=_resume_ami,
     )
     return body, status
 

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
@@ -337,8 +337,7 @@ async def _build_provisioning_spec(
         provider_pool_id, or pool_meta.instance_type)
       - instance_class: derived from the AWS instance catalog (single source
         of truth — never trust a separately-stored value)
-      - region: pool.region_constraint[0] -> pool_meta.region -> account-wide
-        ProvidersConfig.cloud.aws.region
+      - region: pool.region_constraint[0] -> pool_meta.region (required; 422 if absent)
       - optional per-pool overrides (subnet/SG/IAM/AMI/root volume/image tag)
 
     Raises HTTPException(422) when instance_type / instance_class / region
@@ -388,23 +387,15 @@ async def _build_provisioning_spec(
         )
     instance_class = it.cls
 
+    region = None
     rc = pool_row.get("region_constraint")
-    region = (rc[0] if rc else None) or pool_meta.get("region")
-    if not region:
-        # Fall back to the account-wide AWS region (Settings -> Providers).
-        try:
-            from inferia.services.orchestration.services.adapter_engine.adapters.pulumi.pulumi_aws_adapter import (
-                load_providers_config,
-            )
-            cfg = await load_providers_config()
-            region = cfg.cloud.aws.region
-        except Exception:
-            region = None
+    if rc:
+        region = (rc[0] if isinstance(rc, (list, tuple)) else rc) or None
+    region = region or pool_meta.get("region")
     if not region:
         raise HTTPException(
             status_code=422,
-            detail=(f"AWS pool for {instance_type} has no region configured; "
-                    f"set a region on the pool or in Settings -> Providers -> AWS"),
+            detail="AWS pool has no region (set region_constraint at pool creation)",
         )
 
     spec = {

--- a/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/deployment_server.py
@@ -327,7 +327,7 @@ def _model_spec_from_request(req: "DeployModelRequest") -> dict:
 
 
 async def _build_provisioning_spec(
-    *, pool_row, pool_meta: dict, decision, org_id,
+    *, pool_row, pool_meta: dict, decision, org_id, ami_id: str | None = None,
 ) -> dict:
     """Build the provisioning-job spec for a ColdStart enqueue.
 
@@ -415,6 +415,10 @@ async def _build_provisioning_spec(
         val = pool_meta.get(key)
         if val not in (None, "", []):
             spec[key] = val
+    # Per-deploy ami_id override (from DeployModelRequest.ami_id, required for
+    # vLLM). Takes priority over pool_meta.ami_id set above (deploy-level wins).
+    if ami_id:
+        spec["ami_id"] = ami_id
     # Root volume: GPU classes boot a Deep Learning AMI whose backing
     # snapshot is ~75GB+, so the build_program default of 50GB fails with
     # InvalidBlockDeviceMapping ("Volume ... smaller than snapshot, expect
@@ -525,6 +529,8 @@ class DeployModelRequest(BaseModel):
     policies: dict | None = None
     inference_model: str | None = None
     model_type: str = "inference"  # inference, embedding, image_generation, etc.
+    ami_id: str | None = None
+    hf_token_name: str | None = None
 
 
 class PreflightRequest(BaseModel):
@@ -1002,6 +1008,7 @@ async def place_and_provision(
     engine,
     load_spec_source,
     deps,
+    ami_id: str | None = None,
 ) -> tuple[dict, int]:
     """Place a deployment on a pool and provision compute for it.
 
@@ -1132,6 +1139,7 @@ async def place_and_provision(
                                     "spec": await _build_provisioning_spec(
                                         pool_row=pool_row, pool_meta=pool_meta,
                                         decision=decision, org_id=org_id,
+                                        ami_id=ami_id,
                                     ),
                                 }
                     else:
@@ -1189,6 +1197,7 @@ async def place_and_provision(
                             "spec": await _build_provisioning_spec(
                                 pool_row=pool_row, pool_meta=pool_meta,
                                 decision=decision, org_id=org_id,
+                                ami_id=ami_id,
                             ),
                         }
 
@@ -1254,7 +1263,9 @@ async def place_and_provision(
                 "config": _cfg.get("config") or {},
                 "gpu_indices": list(range(gpu_per_replica or 0)),
                 "port": 0,
-                "env": {},
+                # Propagate configuration.env (e.g. HF_TOKEN injected by the
+                # deploy handler for hf_token_name) to the warm-path load spec.
+                "env": dict(_cfg.get("env") or {}),
             }
             try:
                 from inferia.services.orchestration.config import settings as _s
@@ -1438,6 +1449,28 @@ async def deploy_model(req: DeployModelRequest, request: Request):
                 ),
             )
 
+    # 1b. vLLM requires an explicit ami_id (the DLAMI to boot); reject early
+    # so the operator sees an actionable 422 instead of a provisioning failure.
+    if (req.engine or "").lower() == "vllm" and not req.ami_id:
+        raise HTTPException(
+            status_code=422,
+            detail="ami_id is required for vLLM deployments",
+        )
+
+    # 1c. Resolve a named HF token server-side and inject HF_TOKEN into the
+    # worker config.  The client sends only the *name*, never the raw value.
+    if req.hf_token_name:
+        from inferia.services.orchestration.services.model_deployment.hf_token_resolver import (
+            resolve_hf_token,
+        )
+        _tok = resolve_hf_token(req.hf_token_name)
+        if _tok:
+            cfg = dict(req.configuration or {})
+            env = dict(cfg.get("env") or {})
+            env.setdefault("HF_TOKEN", _tok)  # don't clobber an explicit one
+            cfg["env"] = env
+            req.configuration = cfg
+
     # 2. Create deployment row (CREATED state, target_pool_id=pool_id)
     deploy_id = uuid4()
     policies_val = req.policies
@@ -1511,6 +1544,7 @@ async def deploy_model(req: DeployModelRequest, request: Request):
         engine=req.engine,
         load_spec_source=req,
         deps=deps,
+        ami_id=req.ami_id,
     )
 
     from fastapi.responses import JSONResponse
@@ -2046,6 +2080,7 @@ async def _start_deployment_impl(
         engine=_source_field(row, "engine"),
         load_spec_source=row,
         deps=deps,
+        ami_id=None,  # resume path: ami_id not stored on the row; use pool default
     )
     return body, status
 

--- a/package/src/inferia/services/orchestration/services/model_deployment/hf_token_resolver.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/hf_token_resolver.py
@@ -1,6 +1,11 @@
-"""Resolve a HuggingFace token by name from the persisted providers config,
-with legacy-token + INFERIA_HF_TOKEN env fallbacks (priority: active named →
-legacy → env). Used by the deploy path to inject HF_TOKEN for the worker.
+"""Resolve a HuggingFace token by name from the authoritative DB-decrypted
+providers config, with legacy-token + INFERIA_HF_TOKEN env fallbacks.
+
+Priority: active named → legacy huggingface.token → INFERIA_HF_TOKEN env.
+
+Async: reads the DB on the event loop via load_providers_config (the same
+accessor used by the AWS provisioning path). The in-memory settings.providers
+copy is NOT kept live in the orchestration call path and must not be used here.
 """
 from __future__ import annotations
 
@@ -11,19 +16,26 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
-def _load_providers_dict() -> dict:
-    """Return the in-memory providers config dict kept live by the api_gateway
-    config_manager poller (same object the token-names endpoint reads). Pure
-    sync / main-thread-safe — resolve_hf_token runs inside the async /deploy
-    handler, where asyncio.run() raises and asyncpg sessions are loop-bound."""
+async def _load_hf_config():
+    """Return the decrypted providers.huggingface config object, best-effort
+    (returns an empty HuggingFaceConfig on failure). Extracted as a
+    module-level function so tests can monkeypatch it with an AsyncMock."""
     try:
-        from inferia.services.api_gateway.config import settings
-        return settings.providers.model_dump()
-    except Exception:  # noqa: BLE001
-        return {}
+        from inferia.services.orchestration.services.adapter_engine.adapters.pulumi.pulumi_aws_adapter import (
+            load_providers_config,
+        )
+        cfg = await load_providers_config()
+        return cfg.huggingface
+    except Exception:  # noqa: BLE001 — best-effort
+        # Return a minimal object with empty fields so the caller never crashes.
+        try:
+            from inferia.services.api_gateway.config import HuggingFaceConfig
+            return HuggingFaceConfig()
+        except Exception:  # noqa: BLE001
+            return None
 
 
-def resolve_hf_token(name: Optional[str]) -> Optional[str]:
+async def resolve_hf_token(name: Optional[str]) -> Optional[str]:
     """Return the HuggingFace token value for *name*.
 
     Resolution order:
@@ -34,27 +46,35 @@ def resolve_hf_token(name: Optional[str]) -> Optional[str]:
     3. Fall back to the ``INFERIA_HF_TOKEN`` environment variable.
     4. Return ``None`` if all three sources are absent.
 
-    Failures in ``_load_providers_dict`` (DB unreachable, etc.) are swallowed;
+    Reads the DB-decrypted providers config via load_providers_config (async,
+    on the loop). The in-memory settings.providers copy is stale in the
+    orchestration call path and is not used.
+
+    Failures in ``_load_hf_config`` (DB unreachable, etc.) are swallowed;
     the function proceeds directly to env fallback.
     """
     try:
-        providers = _load_providers_dict()
+        hf = await _load_hf_config()
     except Exception:  # noqa: BLE001
-        providers = {}
+        hf = None
 
-    hf = (providers.get("huggingface") or {}) if isinstance(providers, dict) else {}
-    tokens = hf.get("tokens") or []
+    if hf is not None:
+        # Support both Pydantic-object form (attribute access) and dict form
+        # (defensively, in case a test monkeypatches with a plain dict).
+        tokens = (hf.get("tokens") if isinstance(hf, dict) else getattr(hf, "tokens", None)) or []
+        legacy = (hf.get("token") if isinstance(hf, dict) else getattr(hf, "token", None)) or ""
+    else:
+        tokens = []
+        legacy = ""
 
     if name:
         for ent in tokens:
-            if not isinstance(ent, dict):
-                continue
-            if ent.get("name") == name and ent.get("is_active", True):
-                tok = ent.get("token")
-                if tok:
-                    return tok
+            ename = ent.get("name") if isinstance(ent, dict) else getattr(ent, "name", None)
+            eact = ent.get("is_active", True) if isinstance(ent, dict) else getattr(ent, "is_active", True)
+            etok = ent.get("token") if isinstance(ent, dict) else getattr(ent, "token", None)
+            if ename == name and eact and etok:
+                return etok
 
-    legacy = hf.get("token")
     if legacy:
         return legacy
 

--- a/package/src/inferia/services/orchestration/services/model_deployment/hf_token_resolver.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/hf_token_resolver.py
@@ -1,0 +1,61 @@
+"""Resolve a HuggingFace token by name from the persisted providers config,
+with legacy-token + INFERIA_HF_TOKEN env fallbacks (priority: active named →
+legacy → env). Used by the deploy path to inject HF_TOKEN for the worker.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _load_providers_dict() -> dict:
+    """Return the in-memory providers config dict kept live by the api_gateway
+    config_manager poller (same object the token-names endpoint reads). Pure
+    sync / main-thread-safe — resolve_hf_token runs inside the async /deploy
+    handler, where asyncio.run() raises and asyncpg sessions are loop-bound."""
+    try:
+        from inferia.services.api_gateway.config import settings
+        return settings.providers.model_dump()
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def resolve_hf_token(name: Optional[str]) -> Optional[str]:
+    """Return the HuggingFace token value for *name*.
+
+    Resolution order:
+    1. If *name* is given, find the first entry in ``huggingface.tokens`` whose
+       ``name`` matches *name*, ``is_active`` is True (default True), and
+       ``token`` is non-empty.
+    2. Fall back to the legacy scalar ``huggingface.token``.
+    3. Fall back to the ``INFERIA_HF_TOKEN`` environment variable.
+    4. Return ``None`` if all three sources are absent.
+
+    Failures in ``_load_providers_dict`` (DB unreachable, etc.) are swallowed;
+    the function proceeds directly to env fallback.
+    """
+    try:
+        providers = _load_providers_dict()
+    except Exception:  # noqa: BLE001
+        providers = {}
+
+    hf = (providers.get("huggingface") or {}) if isinstance(providers, dict) else {}
+    tokens = hf.get("tokens") or []
+
+    if name:
+        for ent in tokens:
+            if not isinstance(ent, dict):
+                continue
+            if ent.get("name") == name and ent.get("is_active", True):
+                tok = ent.get("token")
+                if tok:
+                    return tok
+
+    legacy = hf.get("token")
+    if legacy:
+        return legacy
+
+    return os.environ.get("INFERIA_HF_TOKEN") or None

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_createpool_metadata_only.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_createpool_metadata_only.py
@@ -111,6 +111,7 @@ async def test_createpool_aws_does_not_provision(app_and_pool):
     """
     app, pool = app_and_pool
     payload = _createpool_payload(provider="aws")
+    payload["region_constraint"] = ["us-east-1"]
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -227,6 +228,7 @@ async def test_createpool_persists_metadata(app_and_pool):
         "agent_kind": "worker",
     }
     payload = _createpool_payload(provider="aws", metadata=meta)
+    payload["region_constraint"] = ["us-east-1"]
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -263,6 +265,7 @@ async def test_createpool_duplicate_returns_409(app_and_pool):
     payload = _createpool_payload(
         provider="aws", pool_name=pool_name, owner_id=owner_id
     )
+    payload["region_constraint"] = ["us-east-1"]
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -289,3 +292,92 @@ async def test_createpool_invalid_provider_returns_400(app_and_pool):
     assert resp.status_code == 400, (
         f"Expected 400 for invalid provider, got {resp.status_code}: {resp.text}"
     )
+
+
+# ---------------------------------------------------------------------------
+# T4: region_constraint required for AWS pools
+# ---------------------------------------------------------------------------
+
+async def test_createpool_aws_no_region_returns_422(app_and_pool):
+    """POST /createpool with provider=aws and NO region_constraint must be
+    rejected with 422 and a detail mentioning 'region'.
+
+    Since Task 3 removed the account-wide AWS region, the pool-level
+    region_constraint is now the only source of region for provisioning.
+    Accepting a region-less AWS pool would let it slip through to deploy
+    time where it fails with an opaque internal error instead of a clear
+    early rejection.
+    """
+    app, _ = app_and_pool
+    # Case 1: region_constraint omitted entirely
+    payload_omitted = _createpool_payload(provider="aws")
+    # Ensure region_constraint key is absent (default _createpool_payload does not include it)
+    payload_omitted.pop("region_constraint", None)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/deployment/createpool", json=payload_omitted)
+
+    assert resp.status_code == 422, (
+        f"Expected 422 for AWS pool with no region, got {resp.status_code}: {resp.text}"
+    )
+    assert "region" in resp.text.lower(), (
+        f"Expected 'region' in 422 detail, got: {resp.text}"
+    )
+
+    # Case 2: region_constraint is explicitly an empty list
+    payload_empty = _createpool_payload(provider="aws")
+    payload_empty["region_constraint"] = []
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp2 = await client.post("/deployment/createpool", json=payload_empty)
+
+    assert resp2.status_code == 422, (
+        f"Expected 422 for AWS pool with empty region list, got {resp2.status_code}: {resp2.text}"
+    )
+    assert "region" in resp2.text.lower(), (
+        f"Expected 'region' in 422 detail, got: {resp2.text}"
+    )
+
+
+async def test_createpool_aws_with_region_returns_200(app_and_pool):
+    """POST /createpool with provider=aws and a valid region_constraint must
+    succeed with HTTP 200 and return a pool_id.
+    """
+    app, _ = app_and_pool
+    payload = _createpool_payload(provider="aws")
+    payload["region_constraint"] = ["us-east-1"]
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/deployment/createpool", json=payload)
+
+    assert resp.status_code == 200, (
+        f"Expected 200 for AWS pool with valid region, got {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    assert "pool_id" in body
+    assert body["status"] == "CREATED"
+
+
+async def test_createpool_non_aws_without_region_returns_200(app_and_pool):
+    """POST /createpool with a non-AWS provider (nosana) and NO region_constraint
+    must still succeed with HTTP 200 — the region guard must only apply to AWS.
+    """
+    app, _ = app_and_pool
+    payload = _createpool_payload(provider="nosana")
+    payload.pop("region_constraint", None)  # no region
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/deployment/createpool", json=payload)
+
+    assert resp.status_code == 200, (
+        f"Expected 200 for non-AWS pool without region, got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["status"] == "CREATED"

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_deploy_endpoint_pool_first.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_deploy_endpoint_pool_first.py
@@ -154,6 +154,8 @@ def _deploy_payload(pool_id: UUID, *, gpu_per_replica: int = 1) -> dict:
         "gpu_per_replica": gpu_per_replica,
         "pool_id": str(pool_id),
         "engine": "vllm",
+        # ami_id is required for vLLM deployments.
+        "ami_id": "ami-0123456789abcdef0",
         # model_name doubles as artifact_uri fallback; provide explicit
         # configuration.artifact_uri so the spec helper can resolve it.
         "configuration": {"artifact_uri": "hf://test-model"},
@@ -322,6 +324,7 @@ async def test_deploy_duplicate_model_name_in_org_returns_409(app_and_pool):
             "pool_id": str(pool_id),
             "engine": "vllm",
             "org_id": org_id,
+            "ami_id": "ami-0123456789abcdef0",
             "configuration": {"artifact_uri": "hf://qwen3"},
         })
         assert r1.status_code == 200, r1.text
@@ -335,6 +338,7 @@ async def test_deploy_duplicate_model_name_in_org_returns_409(app_and_pool):
             "pool_id": str(pool_id),
             "engine": "vllm",
             "org_id": org_id,
+            "ami_id": "ami-0123456789abcdef0",
             "configuration": {"artifact_uri": "hf://qwen3"},
         })
         assert r2.status_code == 409, r2.text
@@ -468,3 +472,283 @@ async def test_build_spec_aws_falls_back_to_pool_meta_region():
         pool_row=pool_row, pool_meta={"region": "eu-west-1"}, decision=decision, org_id="o"
     )
     assert spec["region"] == "eu-west-1"
+
+
+# ---------------------------------------------------------------------------
+# Tests for ami_id + hf_token_name (T5 provider-config-ux)
+# ---------------------------------------------------------------------------
+
+
+async def test_deploy_vllm_requires_ami_id(app_and_pool):
+    """vLLM deploy without ami_id → 422 with 'ami_id' in the message."""
+    app, pool = app_and_pool
+    pool_id = await _seed_pool(pool)
+    org_id = str(uuid4())
+
+    body = {
+        "model_name": "vllm-model",
+        "model_version": "latest",
+        "replicas": 1,
+        "gpu_per_replica": 1,
+        "pool_id": str(pool_id),
+        "engine": "vllm",
+        "org_id": org_id,
+        # ami_id intentionally absent
+        "configuration": {"artifact_uri": "hf://vllm-model"},
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.post("/deployment/deploy", json=body)
+
+    assert r.status_code == 422, r.text
+    assert "ami_id" in r.text.lower()
+
+
+async def test_deploy_vllm_with_ami_id_succeeds(app_and_pool):
+    """vLLM deploy WITH ami_id proceeds past validation (PENDING_NODE on empty pool)."""
+    app, pool = app_and_pool
+    pool_id = await _seed_pool(pool)
+    org_id = str(uuid4())
+
+    body = {
+        "model_name": "vllm-model-ami",
+        "model_version": "latest",
+        "replicas": 1,
+        "gpu_per_replica": 1,
+        "pool_id": str(pool_id),
+        "engine": "vllm",
+        "org_id": org_id,
+        "ami_id": "ami-0123456789abcdef0",
+        "configuration": {"artifact_uri": "hf://vllm-model-ami"},
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.post("/deployment/deploy", json=body)
+
+    # ColdStart path → 202 PENDING_NODE (ami_id validation passed)
+    assert r.status_code == 202, r.text
+    assert r.json()["state"] == "PENDING_NODE"
+
+
+async def test_deploy_non_vllm_engine_no_ami_id_allowed(app_and_pool):
+    """Non-vLLM engines (ollama) do not require ami_id."""
+    app, pool = app_and_pool
+    pool_id = await _seed_pool(pool)
+    org_id = str(uuid4())
+
+    body = {
+        "model_name": "ollama-model",
+        "model_version": "latest",
+        "replicas": 1,
+        "gpu_per_replica": 1,
+        "pool_id": str(pool_id),
+        "engine": "ollama",
+        "org_id": org_id,
+        # no ami_id — must be accepted for non-vLLM
+        "configuration": {"artifact_uri": "ollama://llama3"},
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.post("/deployment/deploy", json=body)
+
+    # Any non-422 means we passed ami_id validation (real result may vary)
+    assert r.status_code != 422, r.text
+
+
+async def test_build_provisioning_spec_ami_id_override():
+    """ami_id kwarg takes precedence over pool_meta.ami_id in the spec."""
+    pool_row = {
+        "id": uuid4(),
+        "allowed_gpu_types": ["g6.xlarge"],
+        "provider_pool_id": "aws/g6.xlarge",
+        "region_constraint": ["us-east-1"],
+    }
+    # pool_meta has a stale pool-level ami_id
+    meta = {"ami_id": "ami-pool-level"}
+    spec = await deployment_server._build_provisioning_spec(
+        pool_row=pool_row,
+        pool_meta=meta,
+        decision=_Decision(),
+        org_id="o",
+        ami_id="ami-deploy-level",
+    )
+    # deploy-level ami_id wins
+    assert spec["ami_id"] == "ami-deploy-level"
+
+
+async def test_build_provisioning_spec_ami_id_absent_when_none():
+    """When ami_id is None and pool_meta has no ami_id, the key is absent
+    from the spec so resolve_ami's auto-pick still applies."""
+    pool_row = {
+        "id": uuid4(),
+        "allowed_gpu_types": ["g6.xlarge"],
+        "provider_pool_id": "aws/g6.xlarge",
+        "region_constraint": ["us-east-1"],
+    }
+    spec = await deployment_server._build_provisioning_spec(
+        pool_row=pool_row,
+        pool_meta={},
+        decision=_Decision(),
+        org_id="o",
+        ami_id=None,
+    )
+    assert "ami_id" not in spec
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for HF token injection in deploy_model
+# ---------------------------------------------------------------------------
+
+async def test_deploy_hf_token_name_injects_hf_token(app_and_pool):
+    """hf_token_name resolves server-side and injects HF_TOKEN into
+    configuration.env for the worker. The raw token never leaves the server."""
+    app, pool = app_and_pool
+    pool_id = await _seed_pool(pool)
+    org_id = str(uuid4())
+
+    # Seed a ready node so we get a warm-path DEPLOYING and can introspect
+    # the load_model call's spec.env for HF_TOKEN.
+    node_id = await _seed_ready_node(pool, pool_id, gpu_total=4)
+
+    from inferia.services.orchestration.services.worker_controller.protocol import (
+        CommandResultBody,
+    )
+    app.state.worker_controller.load_model.return_value = CommandResultBody(
+        in_reply_to="x", status="ok", detail="",
+        endpoint_url="http://127.0.0.1:9001",
+    )
+
+    # Patch resolve_hf_token so no real provider config is needed.
+    import inferia.services.orchestration.services.model_deployment.deployment_server as ds
+    from unittest.mock import patch
+
+    with patch(
+        "inferia.services.orchestration.services.model_deployment"
+        ".hf_token_resolver.resolve_hf_token",
+        return_value="hf_secret_tok",
+    ):
+        body_payload = {
+            "model_name": "hf-model-inject",
+            "model_version": "v1",
+            "replicas": 1,
+            "gpu_per_replica": 1,
+            "pool_id": str(pool_id),
+            "engine": "vllm",
+            "org_id": org_id,
+            "ami_id": "ami-0abc",
+            "hf_token_name": "prod-token",
+            "configuration": {"artifact_uri": "hf://gated-model"},
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            r = await client.post("/deployment/deploy", json=body_payload)
+
+    assert r.status_code == 200, r.text
+    # Confirm load_model was called with HF_TOKEN in spec.env
+    call_kwargs = app.state.worker_controller.load_model.await_args.kwargs
+    spec_env = call_kwargs["spec"].get("env", {})
+    assert spec_env.get("HF_TOKEN") == "hf_secret_tok", (
+        f"HF_TOKEN not injected; env was: {spec_env}"
+    )
+
+
+async def test_deploy_hf_token_name_does_not_clobber_explicit_hf_token(app_and_pool):
+    """If configuration.env already carries HF_TOKEN, hf_token_name must not
+    overwrite it (setdefault semantics)."""
+    app, pool = app_and_pool
+    pool_id = await _seed_pool(pool)
+    org_id = str(uuid4())
+    await _seed_ready_node(pool, pool_id, gpu_total=4)
+
+    from inferia.services.orchestration.services.worker_controller.protocol import (
+        CommandResultBody,
+    )
+    app.state.worker_controller.load_model.return_value = CommandResultBody(
+        in_reply_to="x", status="ok", detail="",
+        endpoint_url="http://127.0.0.1:9002",
+    )
+
+    from unittest.mock import patch
+
+    with patch(
+        "inferia.services.orchestration.services.model_deployment"
+        ".hf_token_resolver.resolve_hf_token",
+        return_value="hf_from_name",
+    ):
+        body_payload = {
+            "model_name": "hf-model-noclobber",
+            "model_version": "v1",
+            "replicas": 1,
+            "gpu_per_replica": 1,
+            "pool_id": str(pool_id),
+            "engine": "vllm",
+            "org_id": org_id,
+            "ami_id": "ami-0abc",
+            "hf_token_name": "prod-token",
+            # Explicit HF_TOKEN in env — must NOT be replaced by the resolver
+            "configuration": {
+                "artifact_uri": "hf://gated-model",
+                "env": {"HF_TOKEN": "hf_explicit"},
+            },
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            r = await client.post("/deployment/deploy", json=body_payload)
+
+    assert r.status_code == 200, r.text
+    call_kwargs = app.state.worker_controller.load_model.await_args.kwargs
+    spec_env = call_kwargs["spec"].get("env", {})
+    assert spec_env.get("HF_TOKEN") == "hf_explicit", (
+        f"Explicit HF_TOKEN was clobbered; env: {spec_env}"
+    )
+
+
+async def test_deploy_hf_token_name_not_found_no_injection(app_and_pool):
+    """If resolve_hf_token returns None (token not found), no HF_TOKEN is
+    injected — the deploy proceeds normally without it."""
+    app, pool = app_and_pool
+    pool_id = await _seed_pool(pool)
+    org_id = str(uuid4())
+    await _seed_ready_node(pool, pool_id, gpu_total=4)
+
+    from inferia.services.orchestration.services.worker_controller.protocol import (
+        CommandResultBody,
+    )
+    app.state.worker_controller.load_model.return_value = CommandResultBody(
+        in_reply_to="x", status="ok", detail="",
+        endpoint_url="http://127.0.0.1:9003",
+    )
+
+    from unittest.mock import patch
+
+    with patch(
+        "inferia.services.orchestration.services.model_deployment"
+        ".hf_token_resolver.resolve_hf_token",
+        return_value=None,
+    ):
+        body_payload = {
+            "model_name": "hf-model-notfound",
+            "model_version": "v1",
+            "replicas": 1,
+            "gpu_per_replica": 1,
+            "pool_id": str(pool_id),
+            "engine": "vllm",
+            "org_id": org_id,
+            "ami_id": "ami-0abc",
+            "hf_token_name": "nonexistent-token",
+            "configuration": {"artifact_uri": "hf://public-model"},
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            r = await client.post("/deployment/deploy", json=body_payload)
+
+    assert r.status_code == 200, r.text
+    call_kwargs = app.state.worker_controller.load_model.await_args.kwargs
+    spec_env = call_kwargs["spec"].get("env", {})
+    assert "HF_TOKEN" not in spec_env

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_deploy_endpoint_pool_first.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_deploy_endpoint_pool_first.py
@@ -752,3 +752,113 @@ async def test_deploy_hf_token_name_not_found_no_injection(app_and_pool):
     call_kwargs = app.state.worker_controller.load_model.await_args.kwargs
     spec_env = call_kwargs["spec"].get("env", {})
     assert "HF_TOKEN" not in spec_env
+
+
+# ---------------------------------------------------------------------------
+# Tests for ami_id persistence in configuration (completeness fix)
+# ---------------------------------------------------------------------------
+
+
+async def test_deploy_vllm_ami_id_persisted_in_configuration(app_and_pool):
+    """ami_id is stashed in configuration at deploy time so /start resume can
+    reuse the operator-selected AMI instead of falling back to resolve_ami.
+
+    Verify: after a successful /deploy with ami_id='ami-x', the DB row's
+    configuration jsonb contains ``ami_id == 'ami-x'``.
+    """
+    app, pool = app_and_pool
+    pool_id = await _seed_pool(pool)
+    org_id = str(uuid4())
+
+    body_payload = {
+        "model_name": "ami-persist-test",
+        "model_version": "v1",
+        "replicas": 1,
+        "gpu_per_replica": 1,
+        "pool_id": str(pool_id),
+        "engine": "vllm",
+        "org_id": org_id,
+        "ami_id": "ami-persist123",
+        "configuration": {"artifact_uri": "hf://ami-persist-model"},
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.post("/deployment/deploy", json=body_payload)
+
+    # ColdStart => 202 PENDING_NODE
+    assert r.status_code == 202, r.text
+    deploy_id = UUID(r.json()["deployment_id"])
+
+    async with pool.acquire() as c:
+        raw_cfg = await c.fetchval(
+            "SELECT configuration FROM model_deployments WHERE deployment_id=$1",
+            deploy_id,
+        )
+
+    import json as _json
+    cfg = _json.loads(raw_cfg) if isinstance(raw_cfg, str) else raw_cfg
+    assert isinstance(cfg, dict), f"configuration is not a dict: {cfg!r}"
+    assert cfg.get("ami_id") == "ami-persist123", (
+        f"ami_id not persisted in configuration; got: {cfg}"
+    )
+
+
+async def test_deploy_vllm_ami_id_in_configuration_alongside_hf_token(app_and_pool):
+    """When both ami_id and hf_token_name are provided, both land in
+    configuration: configuration['ami_id'] == req.ami_id and
+    configuration['env']['HF_TOKEN'] == resolved token."""
+    app, pool = app_and_pool
+    pool_id = await _seed_pool(pool)
+    org_id = str(uuid4())
+    await _seed_ready_node(pool, pool_id, gpu_total=4)
+
+    from inferia.services.orchestration.services.worker_controller.protocol import (
+        CommandResultBody,
+    )
+    app.state.worker_controller.load_model.return_value = CommandResultBody(
+        in_reply_to="x", status="ok", detail="",
+        endpoint_url="http://127.0.0.1:9010",
+    )
+
+    from unittest.mock import patch
+
+    with patch(
+        "inferia.services.orchestration.services.model_deployment"
+        ".hf_token_resolver.resolve_hf_token",
+        return_value="hf_combined_tok",
+    ):
+        body_payload = {
+            "model_name": "ami-hf-combined",
+            "model_version": "v1",
+            "replicas": 1,
+            "gpu_per_replica": 1,
+            "pool_id": str(pool_id),
+            "engine": "vllm",
+            "org_id": org_id,
+            "ami_id": "ami-combined456",
+            "hf_token_name": "prod-token",
+            "configuration": {"artifact_uri": "hf://gated-combined"},
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            r = await client.post("/deployment/deploy", json=body_payload)
+
+    assert r.status_code == 200, r.text
+    deploy_id = UUID(r.json()["deployment_id"])
+
+    import json as _json
+    async with pool.acquire() as c:
+        raw_cfg = await c.fetchval(
+            "SELECT configuration FROM model_deployments WHERE deployment_id=$1",
+            deploy_id,
+        )
+    cfg = _json.loads(raw_cfg) if isinstance(raw_cfg, str) else raw_cfg
+    assert isinstance(cfg, dict)
+    assert cfg.get("ami_id") == "ami-combined456", (
+        f"ami_id not persisted; configuration={cfg}"
+    )
+    assert cfg.get("env", {}).get("HF_TOKEN") == "hf_combined_tok", (
+        f"HF_TOKEN not persisted alongside ami_id; configuration={cfg}"
+    )

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_deploy_endpoint_pool_first.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_deploy_endpoint_pool_first.py
@@ -408,3 +408,63 @@ async def test_build_provisioning_spec_includes_pool_metadata_overrides():
     assert spec["security_group_ids"] == ["sg-123"]
     assert spec["iam_instance_profile"].endswith("/x")
     assert spec["root_volume_gb"] == 200  # explicit override wins over GPU default
+
+
+async def test_build_spec_aws_requires_region():
+    """_build_provisioning_spec raises 422 when pool has no region at all.
+
+    region_constraint=None + empty pool_meta means no account-wide fallback
+    is available (that fallback was removed); must surface a clear 422 so
+    the operator knows to set region_constraint at pool creation.
+    """
+    from fastapi import HTTPException
+
+    decision = _Decision(provider="aws", gpu_total_per_node=1)
+
+    # No region_constraint, no pool_meta.region — no fallback remains.
+    pool_row = {
+        "id": uuid4(),
+        "allowed_gpu_types": ["g6.xlarge"],
+        "provider_pool_id": "aws/g6.xlarge",
+        "region_constraint": None,
+    }
+    with pytest.raises(HTTPException) as ei:
+        await deployment_server._build_provisioning_spec(
+            pool_row=pool_row, pool_meta={}, decision=decision, org_id=None
+        )
+    assert ei.value.status_code == 422
+    assert "region" in str(ei.value.detail).lower()
+
+
+async def test_build_spec_aws_requires_region_empty_list():
+    """region_constraint=[] (empty list) is treated the same as None."""
+    from fastapi import HTTPException
+
+    decision = _Decision(provider="aws", gpu_total_per_node=1)
+    pool_row = {
+        "id": uuid4(),
+        "allowed_gpu_types": ["g6.xlarge"],
+        "provider_pool_id": "aws/g6.xlarge",
+        "region_constraint": [],
+    }
+    with pytest.raises(HTTPException) as ei:
+        await deployment_server._build_provisioning_spec(
+            pool_row=pool_row, pool_meta={}, decision=decision, org_id=None
+        )
+    assert ei.value.status_code == 422
+    assert "region" in str(ei.value.detail).lower()
+
+
+async def test_build_spec_aws_falls_back_to_pool_meta_region():
+    """pool_meta.region is used when region_constraint is absent."""
+    decision = _Decision(provider="aws", gpu_total_per_node=1)
+    pool_row = {
+        "id": uuid4(),
+        "allowed_gpu_types": ["g6.xlarge"],
+        "provider_pool_id": "aws/g6.xlarge",
+        "region_constraint": None,
+    }
+    spec = await deployment_server._build_provisioning_spec(
+        pool_row=pool_row, pool_meta={"region": "eu-west-1"}, decision=decision, org_id="o"
+    )
+    assert spec["region"] == "eu-west-1"

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_deploy_endpoint_pool_first.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_deploy_endpoint_pool_first.py
@@ -625,9 +625,11 @@ async def test_deploy_hf_token_name_injects_hf_token(app_and_pool):
     import inferia.services.orchestration.services.model_deployment.deployment_server as ds
     from unittest.mock import patch
 
+    from unittest.mock import AsyncMock as _AsyncMock
     with patch(
         "inferia.services.orchestration.services.model_deployment"
         ".hf_token_resolver.resolve_hf_token",
+        new_callable=_AsyncMock,
         return_value="hf_secret_tok",
     ):
         body_payload = {
@@ -674,9 +676,11 @@ async def test_deploy_hf_token_name_does_not_clobber_explicit_hf_token(app_and_p
 
     from unittest.mock import patch
 
+    from unittest.mock import AsyncMock as _AsyncMock
     with patch(
         "inferia.services.orchestration.services.model_deployment"
         ".hf_token_resolver.resolve_hf_token",
+        new_callable=_AsyncMock,
         return_value="hf_from_name",
     ):
         body_payload = {
@@ -726,9 +730,11 @@ async def test_deploy_hf_token_name_not_found_no_injection(app_and_pool):
 
     from unittest.mock import patch
 
+    from unittest.mock import AsyncMock as _AsyncMock
     with patch(
         "inferia.services.orchestration.services.model_deployment"
         ".hf_token_resolver.resolve_hf_token",
+        new_callable=_AsyncMock,
         return_value=None,
     ):
         body_payload = {
@@ -823,9 +829,11 @@ async def test_deploy_vllm_ami_id_in_configuration_alongside_hf_token(app_and_po
 
     from unittest.mock import patch
 
+    from unittest.mock import AsyncMock as _AsyncMock
     with patch(
         "inferia.services.orchestration.services.model_deployment"
         ".hf_token_resolver.resolve_hf_token",
+        new_callable=_AsyncMock,
         return_value="hf_combined_tok",
     ):
         body_payload = {

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_hf_token_resolver.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_hf_token_resolver.py
@@ -1,0 +1,108 @@
+"""Tests for hf_token_resolver — resolve a HF token name → value.
+
+Priority: active named token → legacy huggingface.token → INFERIA_HF_TOKEN env.
+"""
+from inferia.services.orchestration.services.model_deployment import hf_token_resolver as r
+
+
+def test_resolve_named(monkeypatch):
+    cfg = {"huggingface": {"token": "hf_legacy", "tokens": [{"name": "prod", "token": "hf_prod", "is_active": True}]}}
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token("prod") == "hf_prod"
+
+
+def test_resolve_inactive_skipped_falls_back_legacy(monkeypatch):
+    cfg = {"huggingface": {"token": "hf_legacy", "tokens": [{"name": "prod", "token": "hf_prod", "is_active": False}]}}
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token("prod") == "hf_legacy"
+
+
+def test_resolve_none_uses_legacy_then_env(monkeypatch):
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: {"huggingface": {"token": "", "tokens": []}})
+    monkeypatch.setattr(r.os, "environ", {"INFERIA_HF_TOKEN": "hf_env"})
+    assert r.resolve_hf_token(None) == "hf_env"
+
+
+def test_resolve_unknown_name_falls_back(monkeypatch):
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: {"huggingface": {"token": "hf_legacy", "tokens": []}})
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token("nope") == "hf_legacy"
+
+
+def test_resolve_first_active_match_when_duplicate_names(monkeypatch):
+    cfg = {"huggingface": {"tokens": [{"name": "d", "token": "hf_1", "is_active": True}, {"name": "d", "token": "hf_2", "is_active": True}]}}
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token("d") == "hf_1"  # first match wins
+
+
+# ---------- extra edge-case coverage ------------------------------------
+
+
+def test_resolve_no_providers_at_all_returns_none(monkeypatch):
+    """Empty providers dict + no env → None."""
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: {})
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token(None) is None
+
+
+def test_resolve_none_name_with_active_legacy(monkeypatch):
+    """name=None skips the tokens list and goes straight to legacy."""
+    cfg = {"huggingface": {"token": "hf_leg", "tokens": [{"name": "prod", "token": "hf_prod", "is_active": True}]}}
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token(None) == "hf_leg"
+
+
+def test_resolve_named_no_legacy_no_env_returns_none(monkeypatch):
+    """Named token not found, no legacy, no env → None."""
+    cfg = {"huggingface": {"token": "", "tokens": []}}
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token("missing") is None
+
+
+def test_resolve_load_failure_falls_back_to_env(monkeypatch):
+    """If _load_providers_dict raises, resolve_hf_token must not propagate."""
+    def _boom():
+        raise RuntimeError("db unreachable")
+    monkeypatch.setattr(r, "_load_providers_dict", _boom)
+    monkeypatch.setattr(r.os, "environ", {"INFERIA_HF_TOKEN": "hf_fallback"})
+    assert r.resolve_hf_token("any") == "hf_fallback"
+
+
+def test_resolve_empty_token_string_not_returned(monkeypatch):
+    """An active entry with token='' is treated as missing."""
+    cfg = {"huggingface": {"token": "hf_leg", "tokens": [{"name": "x", "token": "", "is_active": True}]}}
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token("x") == "hf_leg"
+
+
+def test_resolve_env_not_used_when_legacy_present(monkeypatch):
+    """Legacy token takes priority over INFERIA_HF_TOKEN."""
+    cfg = {"huggingface": {"token": "hf_legacy", "tokens": []}}
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r.os, "environ", {"INFERIA_HF_TOKEN": "hf_env"})
+    assert r.resolve_hf_token(None) == "hf_legacy"
+
+
+def test_resolve_malformed_providers_dict(monkeypatch):
+    """Non-dict return from _load_providers_dict must not crash."""
+    monkeypatch.setattr(r, "_load_providers_dict", lambda: None)
+    monkeypatch.setattr(r.os, "environ", {})
+    assert r.resolve_hf_token("x") is None
+
+
+def test_load_providers_dict_safe_in_running_loop():
+    # The real _load_providers_dict must be callable from within a running loop
+    # (resolve_hf_token runs inside the async /deploy handler) without raising.
+    import asyncio as _aio
+
+    async def _main():
+        return r._load_providers_dict()
+
+    out = _aio.run(_main())
+    assert isinstance(out, dict)  # returns a dict, no RuntimeError

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_hf_token_resolver.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_hf_token_resolver.py
@@ -1,108 +1,165 @@
 """Tests for hf_token_resolver — resolve a HF token name → value.
 
 Priority: active named token → legacy huggingface.token → INFERIA_HF_TOKEN env.
+
+All tests are async because resolve_hf_token is now async (reads the DB via
+load_providers_config on the event loop). _load_hf_config is monkeypatched
+with an AsyncMock returning the huggingface config (object or dict).
 """
+from __future__ import annotations
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
 from inferia.services.orchestration.services.model_deployment import hf_token_resolver as r
 
+pytestmark = pytest.mark.asyncio
 
-def test_resolve_named(monkeypatch):
-    cfg = {"huggingface": {"token": "hf_legacy", "tokens": [{"name": "prod", "token": "hf_prod", "is_active": True}]}}
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+
+def _hf_cfg(token="", tokens=None):
+    """Build a minimal HuggingFaceConfig-like dict for monkeypatching."""
+    return {"token": token, "tokens": tokens or []}
+
+
+# ---------------------------------------------------------------------------
+# Core priority tests
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_named(monkeypatch):
+    cfg = _hf_cfg(token="hf_legacy", tokens=[{"name": "prod", "token": "hf_prod", "is_active": True}])
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=cfg))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token("prod") == "hf_prod"
+    assert await r.resolve_hf_token("prod") == "hf_prod"
 
 
-def test_resolve_inactive_skipped_falls_back_legacy(monkeypatch):
-    cfg = {"huggingface": {"token": "hf_legacy", "tokens": [{"name": "prod", "token": "hf_prod", "is_active": False}]}}
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+async def test_resolve_inactive_skipped_falls_back_legacy(monkeypatch):
+    cfg = _hf_cfg(token="hf_legacy", tokens=[{"name": "prod", "token": "hf_prod", "is_active": False}])
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=cfg))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token("prod") == "hf_legacy"
+    assert await r.resolve_hf_token("prod") == "hf_legacy"
 
 
-def test_resolve_none_uses_legacy_then_env(monkeypatch):
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: {"huggingface": {"token": "", "tokens": []}})
+async def test_resolve_none_uses_legacy_then_env(monkeypatch):
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=_hf_cfg(token="", tokens=[])))
     monkeypatch.setattr(r.os, "environ", {"INFERIA_HF_TOKEN": "hf_env"})
-    assert r.resolve_hf_token(None) == "hf_env"
+    assert await r.resolve_hf_token(None) == "hf_env"
 
 
-def test_resolve_unknown_name_falls_back(monkeypatch):
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: {"huggingface": {"token": "hf_legacy", "tokens": []}})
+async def test_resolve_unknown_name_falls_back(monkeypatch):
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=_hf_cfg(token="hf_legacy", tokens=[])))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token("nope") == "hf_legacy"
+    assert await r.resolve_hf_token("nope") == "hf_legacy"
 
 
-def test_resolve_first_active_match_when_duplicate_names(monkeypatch):
-    cfg = {"huggingface": {"tokens": [{"name": "d", "token": "hf_1", "is_active": True}, {"name": "d", "token": "hf_2", "is_active": True}]}}
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+async def test_resolve_first_active_match_when_duplicate_names(monkeypatch):
+    cfg = _hf_cfg(tokens=[
+        {"name": "d", "token": "hf_1", "is_active": True},
+        {"name": "d", "token": "hf_2", "is_active": True},
+    ])
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=cfg))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token("d") == "hf_1"  # first match wins
+    assert await r.resolve_hf_token("d") == "hf_1"  # first match wins
 
 
-# ---------- extra edge-case coverage ------------------------------------
+# ---------------------------------------------------------------------------
+# Edge-case coverage
+# ---------------------------------------------------------------------------
 
 
-def test_resolve_no_providers_at_all_returns_none(monkeypatch):
+async def test_resolve_no_providers_at_all_returns_none(monkeypatch):
     """Empty providers dict + no env → None."""
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: {})
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=_hf_cfg()))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token(None) is None
+    assert await r.resolve_hf_token(None) is None
 
 
-def test_resolve_none_name_with_active_legacy(monkeypatch):
+async def test_resolve_none_name_with_active_legacy(monkeypatch):
     """name=None skips the tokens list and goes straight to legacy."""
-    cfg = {"huggingface": {"token": "hf_leg", "tokens": [{"name": "prod", "token": "hf_prod", "is_active": True}]}}
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    cfg = _hf_cfg(token="hf_leg", tokens=[{"name": "prod", "token": "hf_prod", "is_active": True}])
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=cfg))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token(None) == "hf_leg"
+    assert await r.resolve_hf_token(None) == "hf_leg"
 
 
-def test_resolve_named_no_legacy_no_env_returns_none(monkeypatch):
+async def test_resolve_named_no_legacy_no_env_returns_none(monkeypatch):
     """Named token not found, no legacy, no env → None."""
-    cfg = {"huggingface": {"token": "", "tokens": []}}
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=_hf_cfg(token="", tokens=[])))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token("missing") is None
+    assert await r.resolve_hf_token("missing") is None
 
 
-def test_resolve_load_failure_falls_back_to_env(monkeypatch):
-    """If _load_providers_dict raises, resolve_hf_token must not propagate."""
-    def _boom():
+async def test_resolve_load_failure_falls_back_to_env(monkeypatch):
+    """If _load_hf_config raises, resolve_hf_token must not propagate."""
+    async def _boom():
         raise RuntimeError("db unreachable")
-    monkeypatch.setattr(r, "_load_providers_dict", _boom)
+    monkeypatch.setattr(r, "_load_hf_config", _boom)
     monkeypatch.setattr(r.os, "environ", {"INFERIA_HF_TOKEN": "hf_fallback"})
-    assert r.resolve_hf_token("any") == "hf_fallback"
+    assert await r.resolve_hf_token("any") == "hf_fallback"
 
 
-def test_resolve_empty_token_string_not_returned(monkeypatch):
+async def test_resolve_empty_token_string_not_returned(monkeypatch):
     """An active entry with token='' is treated as missing."""
-    cfg = {"huggingface": {"token": "hf_leg", "tokens": [{"name": "x", "token": "", "is_active": True}]}}
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    cfg = _hf_cfg(token="hf_leg", tokens=[{"name": "x", "token": "", "is_active": True}])
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=cfg))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token("x") == "hf_leg"
+    assert await r.resolve_hf_token("x") == "hf_leg"
 
 
-def test_resolve_env_not_used_when_legacy_present(monkeypatch):
+async def test_resolve_env_not_used_when_legacy_present(monkeypatch):
     """Legacy token takes priority over INFERIA_HF_TOKEN."""
-    cfg = {"huggingface": {"token": "hf_legacy", "tokens": []}}
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: cfg)
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=_hf_cfg(token="hf_legacy")))
     monkeypatch.setattr(r.os, "environ", {"INFERIA_HF_TOKEN": "hf_env"})
-    assert r.resolve_hf_token(None) == "hf_legacy"
+    assert await r.resolve_hf_token(None) == "hf_legacy"
 
 
-def test_resolve_malformed_providers_dict(monkeypatch):
-    """Non-dict return from _load_providers_dict must not crash."""
-    monkeypatch.setattr(r, "_load_providers_dict", lambda: None)
+async def test_resolve_hf_config_returns_none_falls_back_to_env(monkeypatch):
+    """_load_hf_config returning None must not crash (uses env fallback)."""
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(r.os, "environ", {"INFERIA_HF_TOKEN": "hf_env2"})
+    assert await r.resolve_hf_token("x") == "hf_env2"
+
+
+async def test_resolve_pydantic_object_form(monkeypatch):
+    """resolve_hf_token works when _load_hf_config returns a Pydantic object (not dict)."""
+    from inferia.services.api_gateway.config import HuggingFaceConfig, HFTokenEntry
+    hf = HuggingFaceConfig(
+        token="hf_legacy_pydantic",
+        tokens=[HFTokenEntry(name="p", token="hf_pydantic", is_active=True)],
+    )
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=hf))
     monkeypatch.setattr(r.os, "environ", {})
-    assert r.resolve_hf_token("x") is None
+    assert await r.resolve_hf_token("p") == "hf_pydantic"
+    assert await r.resolve_hf_token(None) == "hf_legacy_pydantic"
 
 
-def test_load_providers_dict_safe_in_running_loop():
-    # The real _load_providers_dict must be callable from within a running loop
-    # (resolve_hf_token runs inside the async /deploy handler) without raising.
-    import asyncio as _aio
+async def test_resolve_pydantic_inactive_falls_back(monkeypatch):
+    """Inactive Pydantic HFTokenEntry falls back to legacy token."""
+    from inferia.services.api_gateway.config import HuggingFaceConfig, HFTokenEntry
+    hf = HuggingFaceConfig(
+        token="hf_leg_pb",
+        tokens=[HFTokenEntry(name="p", token="hf_pb", is_active=False)],
+    )
+    monkeypatch.setattr(r, "_load_hf_config", AsyncMock(return_value=hf))
+    monkeypatch.setattr(r.os, "environ", {})
+    assert await r.resolve_hf_token("p") == "hf_leg_pb"
 
-    async def _main():
-        return r._load_providers_dict()
 
-    out = _aio.run(_main())
-    assert isinstance(out, dict)  # returns a dict, no RuntimeError
+# ---------------------------------------------------------------------------
+# Loop-safety: _load_hf_config is awaitable + returns object-or-dict
+# (smoke-test only — no live DB needed in inferia-test)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_hf_config_is_awaitable_and_returns_object_or_none():
+    """The real _load_hf_config must be awaitable and return a HuggingFaceConfig
+    object (or None / HuggingFaceConfig() on DB failure) without raising.
+    Runs inside an async test to confirm loop-safety."""
+    result = await r._load_hf_config()
+    # In the test environment there may be no DB, so result is either a
+    # HuggingFaceConfig or None.  Either is fine — just must not raise.
+    from inferia.services.api_gateway.config import HuggingFaceConfig
+    assert result is None or isinstance(result, HuggingFaceConfig), (
+        f"_load_hf_config returned unexpected type: {type(result)!r}"
+    )

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_place_and_provision.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_place_and_provision.py
@@ -133,7 +133,7 @@ async def test_coldstart_non_worker_pool_creates_placeholder_and_enqueues_one_jo
     # instance catalog. We only care that exactly one job is enqueued.
     fake_spec = {"provider": "aws", "instance_type": "g6.xlarge"}
 
-    async def _fake_build_spec(*, pool_row, pool_meta, decision, org_id):
+    async def _fake_build_spec(*, pool_row, pool_meta, decision, org_id, ami_id=None):
         return fake_spec
 
     monkeypatch.setattr(

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_preflight_hf_token_name.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_preflight_hf_token_name.py
@@ -83,6 +83,7 @@ async def test_preflight_named_token_resolved_and_passed_to_checks(app):
     with (
         patch(
             "inferia.services.orchestration.services.model_deployment.hf_token_resolver.resolve_hf_token",
+            new_callable=AsyncMock,
             return_value=resolved,
         ) as mock_resolve,
         patch(
@@ -212,6 +213,7 @@ async def test_preflight_named_token_not_found_runs_without_token(app):
     with (
         patch(
             "inferia.services.orchestration.services.model_deployment.hf_token_resolver.resolve_hf_token",
+            new_callable=AsyncMock,
             return_value=None,
         ) as mock_resolve,
         patch(

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_preflight_hf_token_name.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_preflight_hf_token_name.py
@@ -1,0 +1,305 @@
+"""Tests for /preflight hf_token_name resolution (T10).
+
+These tests run entirely with mocked preflight helpers — no DB or network.
+They assert that:
+  1. hf_token_name is resolved to the raw token value and passed to
+     check_model_accessibility / fetch_hf_model_info / check_model_format.
+  2. An explicit hf_token takes precedence over hf_token_name.
+  3. When hf_token_name resolves to None (token not found) the checks still
+     run but with no token (same behaviour as before this change).
+  4. PreflightRequest correctly accepts the new field.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from inferia.services.orchestration.services.model_deployment import deployment_server
+from inferia.services.orchestration.services.model_deployment.deployment_server import (
+    PreflightRequest,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def app():
+    """Minimal FastAPI app with the deployment router (no DB needed for preflight)."""
+    _app = FastAPI()
+    _app.state.pool = None  # preflight doesn't hit the DB
+    _app.state.worker_controller = AsyncMock()
+    _app.state.event_bus = None
+    _app.include_router(deployment_server.router)
+    return _app
+
+
+def _make_accessibility(accessible=True, skipped=False, needs_token=False, error=None):
+    r = MagicMock()
+    r.accessible = accessible
+    r.skipped = skipped
+    r.needs_token = needs_token
+    r.error = error
+    return r
+
+
+def _make_hf_info():
+    r = MagicMock()
+    r.parameter_count = None  # skip VRAM check
+    r.pipeline_tag = "text-generation"
+    return r
+
+
+def _make_fmt(compatible=True, skipped=False, error=None):
+    r = MagicMock()
+    r.compatible = compatible
+    r.skipped = skipped
+    r.error = error
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_request_accepts_hf_token_name():
+    """PreflightRequest.hf_token_name is an accepted optional field."""
+    req = PreflightRequest(model_id="meta-llama/Llama-3-8B", hf_token_name="my-token")
+    assert req.hf_token_name == "my-token"
+    assert req.hf_token is None
+
+
+async def test_preflight_named_token_resolved_and_passed_to_checks(app):
+    """hf_token_name is resolved and the resolved value reaches check_model_accessibility."""
+    resolved = "hf_resolved_secret"
+
+    with (
+        patch(
+            "inferia.services.orchestration.services.model_deployment.hf_token_resolver.resolve_hf_token",
+            return_value=resolved,
+        ) as mock_resolve,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_model_accessibility",
+            new_callable=AsyncMock,
+            return_value=_make_accessibility(accessible=True),
+        ) as mock_access,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.fetch_hf_model_info",
+            new_callable=AsyncMock,
+            return_value=_make_hf_info(),
+        ) as mock_info,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_model_format",
+            new_callable=AsyncMock,
+            return_value=_make_fmt(),
+        ) as mock_fmt,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_vram_fit",
+            return_value=MagicMock(skipped=True),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_pipeline_compatibility",
+            return_value=MagicMock(skipped=True),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_docker_image_exists",
+            new_callable=AsyncMock,
+            return_value=MagicMock(exists=True, skipped=False),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_duplicate_deployment",
+            new_callable=AsyncMock,
+            return_value=MagicMock(is_duplicate=False),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/deployment/preflight",
+                json={
+                    "model_id": "meta-llama/Llama-3-8B",
+                    "engine": "vllm",
+                    "hf_token_name": "my-prod-token",
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    mock_resolve.assert_called_once_with("my-prod-token")
+    # The resolved value must be forwarded, not the raw req.hf_token (None)
+    mock_access.assert_called_once()
+    assert mock_access.call_args.args[1] == resolved, (
+        f"check_model_accessibility received {mock_access.call_args.args[1]!r}, "
+        f"expected resolved token {resolved!r}"
+    )
+    mock_info.assert_called_once()
+    assert mock_info.call_args.args[1] == resolved
+    mock_fmt.assert_called_once()
+    assert mock_fmt.call_args.args[2] == resolved
+
+
+async def test_preflight_explicit_hf_token_takes_priority_over_name(app):
+    """When both hf_token and hf_token_name are supplied, hf_token wins (no resolve call)."""
+    explicit = "hf_explicit"
+
+    with (
+        patch(
+            "inferia.services.orchestration.services.model_deployment.hf_token_resolver.resolve_hf_token",
+        ) as mock_resolve,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_model_accessibility",
+            new_callable=AsyncMock,
+            return_value=_make_accessibility(accessible=True),
+        ) as mock_access,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.fetch_hf_model_info",
+            new_callable=AsyncMock,
+            return_value=_make_hf_info(),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_model_format",
+            new_callable=AsyncMock,
+            return_value=_make_fmt(),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_vram_fit",
+            return_value=MagicMock(skipped=True),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_pipeline_compatibility",
+            return_value=MagicMock(skipped=True),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_docker_image_exists",
+            new_callable=AsyncMock,
+            return_value=MagicMock(exists=True, skipped=False),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_duplicate_deployment",
+            new_callable=AsyncMock,
+            return_value=MagicMock(is_duplicate=False),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/deployment/preflight",
+                json={
+                    "model_id": "meta-llama/Llama-3-8B",
+                    "engine": "vllm",
+                    "hf_token": explicit,
+                    "hf_token_name": "should-be-ignored",
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    mock_resolve.assert_not_called()
+    # Explicit token must be forwarded
+    mock_access.assert_called_once()
+    assert mock_access.call_args.args[1] == explicit
+
+
+async def test_preflight_named_token_not_found_runs_without_token(app):
+    """When hf_token_name resolves to None, checks still run (with token=None)."""
+    with (
+        patch(
+            "inferia.services.orchestration.services.model_deployment.hf_token_resolver.resolve_hf_token",
+            return_value=None,
+        ) as mock_resolve,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_model_accessibility",
+            new_callable=AsyncMock,
+            return_value=_make_accessibility(
+                accessible=False, needs_token=True, error="requires token"
+            ),
+        ) as mock_access,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_docker_image_exists",
+            new_callable=AsyncMock,
+            return_value=MagicMock(exists=True, skipped=False),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_duplicate_deployment",
+            new_callable=AsyncMock,
+            return_value=MagicMock(is_duplicate=False),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/deployment/preflight",
+                json={
+                    "model_id": "meta-llama/gated-model",
+                    "engine": "vllm",
+                    "hf_token_name": "nonexistent",
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ready"] is False
+    mock_resolve.assert_called_once_with("nonexistent")
+    # check_model_accessibility called with None (resolved value)
+    mock_access.assert_called_once()
+    assert mock_access.call_args.args[1] is None
+
+
+async def test_preflight_no_token_fields_runs_normally(app):
+    """No hf_token or hf_token_name → resolve_hf_token never called, runs as before."""
+    with (
+        patch(
+            "inferia.services.orchestration.services.model_deployment.hf_token_resolver.resolve_hf_token",
+        ) as mock_resolve,
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_model_accessibility",
+            new_callable=AsyncMock,
+            return_value=_make_accessibility(accessible=True),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.fetch_hf_model_info",
+            new_callable=AsyncMock,
+            return_value=_make_hf_info(),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_model_format",
+            new_callable=AsyncMock,
+            return_value=_make_fmt(),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_vram_fit",
+            return_value=MagicMock(skipped=True),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_pipeline_compatibility",
+            return_value=MagicMock(skipped=True),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_docker_image_exists",
+            new_callable=AsyncMock,
+            return_value=MagicMock(exists=True, skipped=False),
+        ),
+        patch(
+            "inferia.services.orchestration.services.model_deployment.preflight.check_duplicate_deployment",
+            new_callable=AsyncMock,
+            return_value=MagicMock(is_duplicate=False),
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/deployment/preflight",
+                json={"model_id": "meta-llama/Llama-3-8B", "engine": "vllm"},
+            )
+
+    assert resp.status_code == 200, resp.text
+    mock_resolve.assert_not_called()

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_spec_injection.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_spec_injection.py
@@ -21,11 +21,38 @@ class _FakeRepo:
 
 def test_spec_from_pending_has_no_inline_injection():
     """_spec_from_pending now builds a plain spec; mirror injection is applied
-    separately by resolve_and_apply_mirror in on_worker_ready."""
+    separately by resolve_and_apply_mirror in on_worker_ready.
+    No env configured → empty env dict (cold path: no HF_TOKEN drop)."""
     spec = _spec_from_pending(_vllm_deploy(), 1)
     assert "HF_ENDPOINT" not in spec.get("env", {})
+    # No env in configuration → empty env (explicit: empty config yields empty env)
     assert spec["env"] == {}
     assert spec["model"]["artifact_uri"] == "hf://Qwen/Qwen3-0.6B"
+
+
+def test_spec_from_pending_propagates_env_cold_path():
+    """Cold path (_spec_from_pending) must copy configuration.env to spec["env"].
+
+    Task-5 injects HF_TOKEN into configuration["env"] at deploy time.
+    Previously "env": {} hardcoded — gated vLLM cold deploys 401'd on the worker's
+    HF pull because HF_TOKEN was silently dropped. This test locks in the fix.
+    """
+    deploy = {
+        "id": "d3",
+        "engine": "vllm",
+        "inference_model": "meta-llama/Llama-3-8B-Instruct",
+        "model_name": "meta-llama/Llama-3-8B-Instruct",
+        "gpu_per_replica": 1,
+        "configuration": {
+            "env": {"HF_TOKEN": "hf_x", "FOO": "bar"},
+        },
+    }
+    spec = _spec_from_pending(deploy, 1)
+    # Full env propagation: both keys must survive to the cold-path spec.
+    assert spec["env"]["HF_TOKEN"] == "hf_x"
+    assert spec["env"]["FOO"] == "bar"
+    # resolve_and_apply_mirror uses setdefault → won't clobber pre-set keys.
+    assert spec["model"]["artifact_uri"] == "hf://meta-llama/Llama-3-8B-Instruct"
 
 
 @pytest.mark.asyncio

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_start_resume.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_start_resume.py
@@ -461,7 +461,7 @@ async def test_resume_impl_unbinds_and_places(monkeypatch):
     node_id = uuid4()
     org_id = str(uuid4())
 
-    async def _fake_build_spec(*, pool_row, pool_meta, decision, org_id):
+    async def _fake_build_spec(*, pool_row, pool_meta, decision, org_id, ami_id=None):
         return {"provider": "aws", "instance_type": "g6.xlarge"}
 
     monkeypatch.setattr(

--- a/package/src/inferia/services/orchestration/services/model_deployment/tests/test_start_resume.py
+++ b/package/src/inferia/services/orchestration/services/model_deployment/tests/test_start_resume.py
@@ -549,3 +549,341 @@ async def test_resume_impl_unbinds_and_places(monkeypatch):
 
     # Legacy worker event never fired.
     assert "model.deploy.requested" not in event_bus.topics()
+
+
+async def test_resume_reads_ami_id_from_configuration(monkeypatch):
+    """_start_deployment_impl reads the persisted ami_id from the deployment
+    row's configuration and passes it to place_and_provision (via
+    _build_provisioning_spec's ami_id kwarg).
+
+    Guards against AsyncMock-blindness: we capture the ami_id kwarg passed to
+    _build_provisioning_spec (which place_and_provision calls internally) and
+    assert it equals the value stored in configuration, not None.
+    """
+    from inferia.services.orchestration.services.model_deployment.pool_placer import (
+        PoolPlacer, ColdStart,
+    )
+    from inferia.services.orchestration.repositories.inventory_repo import (
+        InventoryRepository,
+    )
+    from inferia.services.orchestration.repositories.model_deployment_repo import (
+        ModelDeploymentRepository,
+    )
+    from inferia.services.orchestration.repositories.pool_repo import (
+        ComputePoolRepository,
+    )
+    from inferia.services.orchestration.services.provisioning.jobs.repository import (
+        ProvisioningJobRepository,
+    )
+
+    deploy_id = uuid4()
+    pool_id = uuid4()
+    node_id = uuid4()
+    org_id = str(uuid4())
+
+    # Track ami_id values that reach _build_provisioning_spec
+    captured_ami_ids: list[str | None] = []
+
+    async def _spy_build_spec(*, pool_row, pool_meta, decision, org_id, ami_id=None):
+        captured_ami_ids.append(ami_id)
+        return {"provider": "aws", "instance_type": "g6.xlarge"}
+
+    monkeypatch.setattr(
+        deployment_server, "_build_provisioning_spec", _spy_build_spec
+    )
+
+    # --- transaction-capable conn / db_pool (mirrors test_resume_impl_unbinds_and_places)
+    class _TxCtx:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _AcquireCtx:
+        def __init__(self, conn):
+            self._conn = conn
+
+        async def __aenter__(self):
+            return self._conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    conn = MagicMock(name="conn")
+    conn.transaction = MagicMock(return_value=_TxCtx())
+    db_pool = MagicMock(name="db_pool")
+    db_pool.acquire = MagicMock(return_value=_AcquireCtx(conn))
+
+    placer = AsyncMock(spec=PoolPlacer)
+    placer.place.return_value = ColdStart(gpu_total_per_node=1, provider="aws")
+    inventory = AsyncMock(spec=InventoryRepository)
+    inventory.create_placeholder.return_value = node_id
+    deploys = AsyncMock(spec=ModelDeploymentRepository)
+
+    # Deployment row carries ami_id in configuration (persisted by /deploy)
+    persisted_ami = "ami-resume-y"
+    deploys.get.return_value = {
+        "deployment_id": deploy_id,
+        "state": "TERMINATED",
+        "configuration": {"model": {"artifact_uri": "hf://m"}, "ami_id": persisted_ami},
+        "pool_id": pool_id,
+        "target_pool_id": pool_id,
+        "target_node_id": uuid4(),  # stale
+        "gpu_per_replica": 1,
+        "org_id": org_id,
+        "engine": "vllm",
+        "model_name": "m",
+        "inference_model": None,
+    }
+    pool_repo = AsyncMock(spec=ComputePoolRepository)
+    pool_repo.get.return_value = {
+        "id": pool_id,
+        "lifecycle_state": "running",
+        "metadata": {},
+        "allowed_gpu_types": ["g6.xlarge"],
+        "region_constraint": ["us-east-1"],
+        "provider_pool_id": "aws/g6.xlarge",
+    }
+    jobs_repo = AsyncMock(spec=ProvisioningJobRepository)
+    controller = AsyncMock(spec=WorkerController)
+
+    body, status = await deployment_server._start_deployment_impl(
+        deployment_id=str(deploy_id),
+        db_pool=db_pool,
+        controller=controller,
+        pool_repo=pool_repo,
+        inventory=inventory,
+        deploys=deploys,
+        placer=placer,
+        jobs_repo=jobs_repo,
+    )
+
+    assert status in (200, 202)
+    assert body["state"] in ("PENDING_NODE", "DEPLOYING")
+
+    # The persisted ami_id must have been forwarded to _build_provisioning_spec
+    assert len(captured_ami_ids) >= 1, "_build_provisioning_spec was never called"
+    assert captured_ami_ids[0] == persisted_ami, (
+        f"Expected ami_id={persisted_ami!r} forwarded on resume, "
+        f"got {captured_ami_ids[0]!r}"
+    )
+
+
+async def test_resume_ami_id_from_configuration_json_string(monkeypatch):
+    """configuration stored as a JSON string (asyncpg jsonb->str) is decoded
+    and ami_id extracted correctly on resume."""
+    from inferia.services.orchestration.services.model_deployment.pool_placer import (
+        PoolPlacer, ColdStart,
+    )
+    from inferia.services.orchestration.repositories.inventory_repo import (
+        InventoryRepository,
+    )
+    from inferia.services.orchestration.repositories.model_deployment_repo import (
+        ModelDeploymentRepository,
+    )
+    from inferia.services.orchestration.repositories.pool_repo import (
+        ComputePoolRepository,
+    )
+    from inferia.services.orchestration.services.provisioning.jobs.repository import (
+        ProvisioningJobRepository,
+    )
+
+    deploy_id = uuid4()
+    pool_id = uuid4()
+    node_id = uuid4()
+    org_id = str(uuid4())
+
+    captured_ami_ids: list[str | None] = []
+
+    async def _spy_build_spec(*, pool_row, pool_meta, decision, org_id, ami_id=None):
+        captured_ami_ids.append(ami_id)
+        return {"provider": "aws", "instance_type": "g6.xlarge"}
+
+    monkeypatch.setattr(
+        deployment_server, "_build_provisioning_spec", _spy_build_spec
+    )
+
+    class _TxCtx:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _AcquireCtx:
+        def __init__(self, conn):
+            self._conn = conn
+
+        async def __aenter__(self):
+            return self._conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    conn = MagicMock(name="conn")
+    conn.transaction = MagicMock(return_value=_TxCtx())
+    db_pool = MagicMock(name="db_pool")
+    db_pool.acquire = MagicMock(return_value=_AcquireCtx(conn))
+
+    placer = AsyncMock(spec=PoolPlacer)
+    placer.place.return_value = ColdStart(gpu_total_per_node=1, provider="aws")
+    inventory = AsyncMock(spec=InventoryRepository)
+    inventory.create_placeholder.return_value = node_id
+    deploys = AsyncMock(spec=ModelDeploymentRepository)
+
+    # configuration arrives as a JSON string (asyncpg jsonb->str scenario)
+    persisted_ami = "ami-str-encoded-z"
+    deploys.get.return_value = {
+        "deployment_id": deploy_id,
+        "state": "FAILED",
+        "configuration": json.dumps({
+            "model": {"artifact_uri": "hf://m"},
+            "ami_id": persisted_ami,
+        }),
+        "pool_id": pool_id,
+        "target_pool_id": pool_id,
+        "target_node_id": None,
+        "gpu_per_replica": 1,
+        "org_id": org_id,
+        "engine": "vllm",
+        "model_name": "m",
+        "inference_model": None,
+    }
+    pool_repo = AsyncMock(spec=ComputePoolRepository)
+    pool_repo.get.return_value = {
+        "id": pool_id,
+        "lifecycle_state": "running",
+        "metadata": {},
+        "allowed_gpu_types": ["g6.xlarge"],
+        "region_constraint": ["us-east-1"],
+        "provider_pool_id": "aws/g6.xlarge",
+    }
+    jobs_repo = AsyncMock(spec=ProvisioningJobRepository)
+    controller = AsyncMock(spec=WorkerController)
+
+    body, status = await deployment_server._start_deployment_impl(
+        deployment_id=str(deploy_id),
+        db_pool=db_pool,
+        controller=controller,
+        pool_repo=pool_repo,
+        inventory=inventory,
+        deploys=deploys,
+        placer=placer,
+        jobs_repo=jobs_repo,
+    )
+
+    assert status in (200, 202)
+    assert len(captured_ami_ids) >= 1
+    assert captured_ami_ids[0] == persisted_ami, (
+        f"Expected ami_id={persisted_ami!r} from JSON-string configuration, "
+        f"got {captured_ami_ids[0]!r}"
+    )
+
+
+async def test_resume_no_ami_id_in_configuration_passes_none(monkeypatch):
+    """When configuration has no ami_id (older rows, non-vLLM engines),
+    place_and_provision is called with ami_id=None so resolve_ami's auto-pick
+    still applies — no regression."""
+    from inferia.services.orchestration.services.model_deployment.pool_placer import (
+        PoolPlacer, ColdStart,
+    )
+    from inferia.services.orchestration.repositories.inventory_repo import (
+        InventoryRepository,
+    )
+    from inferia.services.orchestration.repositories.model_deployment_repo import (
+        ModelDeploymentRepository,
+    )
+    from inferia.services.orchestration.repositories.pool_repo import (
+        ComputePoolRepository,
+    )
+    from inferia.services.orchestration.services.provisioning.jobs.repository import (
+        ProvisioningJobRepository,
+    )
+
+    deploy_id = uuid4()
+    pool_id = uuid4()
+    node_id = uuid4()
+    org_id = str(uuid4())
+
+    captured_ami_ids: list[str | None] = []
+
+    async def _spy_build_spec(*, pool_row, pool_meta, decision, org_id, ami_id=None):
+        captured_ami_ids.append(ami_id)
+        return {"provider": "aws", "instance_type": "g6.xlarge"}
+
+    monkeypatch.setattr(
+        deployment_server, "_build_provisioning_spec", _spy_build_spec
+    )
+
+    class _TxCtx:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _AcquireCtx:
+        def __init__(self, conn):
+            self._conn = conn
+
+        async def __aenter__(self):
+            return self._conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    conn = MagicMock(name="conn")
+    conn.transaction = MagicMock(return_value=_TxCtx())
+    db_pool = MagicMock(name="db_pool")
+    db_pool.acquire = MagicMock(return_value=_AcquireCtx(conn))
+
+    placer = AsyncMock(spec=PoolPlacer)
+    placer.place.return_value = ColdStart(gpu_total_per_node=1, provider="aws")
+    inventory = AsyncMock(spec=InventoryRepository)
+    inventory.create_placeholder.return_value = node_id
+    deploys = AsyncMock(spec=ModelDeploymentRepository)
+
+    # configuration has no ami_id key (older row / ollama / non-vLLM)
+    deploys.get.return_value = {
+        "deployment_id": deploy_id,
+        "state": "STOPPED",
+        "configuration": {"model": {"artifact_uri": "hf://m"}},
+        "pool_id": pool_id,
+        "target_pool_id": pool_id,
+        "target_node_id": None,
+        "gpu_per_replica": 1,
+        "org_id": org_id,
+        "engine": "ollama",
+        "model_name": "m",
+        "inference_model": None,
+    }
+    pool_repo = AsyncMock(spec=ComputePoolRepository)
+    pool_repo.get.return_value = {
+        "id": pool_id,
+        "lifecycle_state": "running",
+        "metadata": {},
+        "allowed_gpu_types": ["g6.xlarge"],
+        "region_constraint": ["us-east-1"],
+        "provider_pool_id": "aws/g6.xlarge",
+    }
+    jobs_repo = AsyncMock(spec=ProvisioningJobRepository)
+    controller = AsyncMock(spec=WorkerController)
+
+    body, status = await deployment_server._start_deployment_impl(
+        deployment_id=str(deploy_id),
+        db_pool=db_pool,
+        controller=controller,
+        pool_repo=pool_repo,
+        inventory=inventory,
+        deploys=deploys,
+        placer=placer,
+        jobs_repo=jobs_repo,
+    )
+
+    assert status in (200, 202)
+    # ami_id=None must be passed — no regression for non-vLLM or older rows
+    assert len(captured_ami_ids) >= 1
+    assert captured_ami_ids[0] is None, (
+        f"Expected ami_id=None for row without ami_id, got {captured_ami_ids[0]!r}"
+    )

--- a/package/src/inferia/services/orchestration/services/provisioning/phases/preflight.py
+++ b/package/src/inferia/services/orchestration/services/provisioning/phases/preflight.py
@@ -156,13 +156,17 @@ class PreflightHandler:
         if sg := spec.get("security_group_id"):
             verify_security_group_exists(region=region, sg_id=sg, creds=creds)
 
-        # 8. AMI resolves.
-        try:
-            ami = resolve_ami(region=region, instance_class=instance_class, creds=creds)
-        except Exception as e:
-            raise AMINotFoundError(
-                f"no AMI available for {instance_class} in {region}: {e}"
-            ) from e
+        # 8. AMI resolves (explicit spec.ami_id wins; fallback to SSM lookup).
+        explicit_ami = spec.get("ami_id")
+        if explicit_ami:
+            ami = explicit_ami
+        else:
+            try:
+                ami = resolve_ami(region=region, instance_class=instance_class, creds=creds)
+            except Exception as e:
+                raise AMINotFoundError(
+                    f"no AMI available for {instance_class} in {region}: {e}"
+                ) from e
         await ctx.emit_event(
             pool_id=job.pool_id, node_id=job.node_id, phase=Phase.PREFLIGHT,
             status="log", message=f"AMI resolved: {ami}",

--- a/package/src/inferia/services/orchestration/services/provisioning/phases/tests/test_preflight.py
+++ b/package/src/inferia/services/orchestration/services/provisioning/phases/tests/test_preflight.py
@@ -245,3 +245,62 @@ async def test_ami_check_failure_raises():
         ):
         with pytest.raises(AMINotFoundError):
             await PreflightHandler().run(_job(), _ctx())
+
+
+# ---------------------------------------------------------------------------
+# T5 provider-config-ux: explicit spec.ami_id skips resolve_ami
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_preflight_prefers_spec_ami_id(monkeypatch):
+    """When spec carries an explicit ami_id, resolve_ami must NOT be called.
+
+    This ensures that a deploy-time ami_id (required for vLLM) is used
+    verbatim by the preflight phase instead of triggering an SSM lookup
+    that may look up a different AMI or fail in non-standard regions.
+    """
+    import inferia.services.orchestration.services.provisioning.phases.preflight as pf
+
+    def _must_not_call(**_k):
+        raise AssertionError("resolve_ami must NOT be called when spec has ami_id")
+
+    monkeypatch.setattr(pf, "resolve_ami", _must_not_call)
+
+    job = _job(spec={
+        "instance_class": "normal_gpu",
+        "instance_type": "g6.xlarge",
+        "region": "us-east-1",
+        "ami_id": "ami-explicit0123",
+    })
+
+    with patch("shutil.which", return_value="/usr/local/bin/pulumi"), \
+         patch(
+            "inferia.services.orchestration.services.provisioning.phases."
+            "preflight.verify_credentials",
+            return_value={"Account": "123"},
+        ):
+        ctx = _ctx()
+        result = await PreflightHandler().run(job, ctx)
+
+    assert result.outputs["ami_id"] == "ami-explicit0123"
+    assert result.next_phase == Phase.PROVISIONING
+
+
+@pytest.mark.asyncio
+async def test_preflight_falls_back_to_resolve_ami_when_spec_has_no_ami_id():
+    """When spec.ami_id is absent, resolve_ami is still called (existing behaviour)."""
+    with patch("shutil.which", return_value="/usr/local/bin/pulumi"), \
+         patch(
+            "inferia.services.orchestration.services.provisioning.phases."
+            "preflight.verify_credentials",
+            return_value={"Account": "123"},
+        ), \
+         patch(
+            "inferia.services.orchestration.services.provisioning.phases."
+            "preflight.resolve_ami",
+            return_value="ami-auto-pick",
+        ) as mock_resolve:
+        result = await PreflightHandler().run(_job(), _ctx())
+
+    mock_resolve.assert_called_once()
+    assert result.outputs["ami_id"] == "ami-auto-pick"


### PR DESCRIPTION
Four cohesive UX changes (12 commits, all reviewed two-stage + a final holistic review):
- AWS provider config trimmed to access key + secret; region now required at AWS pool creation.
- Multiple named HuggingFace tokens (encrypted + masked, by-name round-trip preserve, deployer-scoped names endpoint); deploy form selects a token by name (raw token never leaves the browser).
- Engine-cache AMI section in the AWS config page (bake/status/list) wiring the existing admin endpoints.
- Deploy form drops the vLLM image/CUDA/advanced block; adds a required engine-AMI dropdown + HF-token dropdown; DeployModelRequest gains ami_id (required for vLLM) + hf_token_name, threaded into the provisioning spec (PreflightHandler prefers it) and persisted so /start resume reuses it; /preflight resolves the named token.

Reviews caught + fixed real bugs: an async-context no-op in the token resolver, a cold-path HF_TOKEN drop (gated vLLM cold deploys), a masked-save token-wipe round-trip, a get_logs region regression, and (via live smoke) the resolver reading a stale in-memory config. 185+ backend tests; dashboard build clean.