### PR TITLE
feat(aws): live AMI-bake progress + dynamic region/instance-type discovery in pool creation

### DIFF
--- a/apps/dashboard/src/hooks/useInstanceCatalog.test.tsx
+++ b/apps/dashboard/src/hooks/useInstanceCatalog.test.tsx
@@ -2,21 +2,50 @@
  * Tests for the useInstanceCatalog hook.
  *
  * Scope:
- *   - Calls the correct endpoint (/api/v1/providers/aws/instance-catalog).
+ *   - No-arg call: fetches the curated catalog via computeApi.get (axios, NOT fetch).
  *   - Returns the catalog grouped by class with the price_per_hour wire field.
  *   - Surfaces network/HTTP errors via the query's `error` state instead of
  *     swallowing them silently.
+ *   - Region-aware: when region provided + live returns real data (fallback=false),
+ *     use grouped live catalog (gpu_ram_gb/price_per_hour default to 0).
+ *   - Fallback: when live call returns fallback=true or empty list, falls back to curated.
+ *   - No-region path still works unchanged (backward-compat).
+ *   - queryKey isolation: different regions produce distinct cached results.
+ *
+ * Mock strategy:
+ *   The hook uses `computeApi.get(...)` (axios-based), NOT `globalThis.fetch`.
+ *   We therefore module-mock `@/lib/api` and drive `computeApi.get` as a vi.fn().
+ *   ConfigService.listAwsInstanceTypes is spied on via vi.spyOn for the live path.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
+// ---------------------------------------------------------------------------
+// Module mock — intercepts the curated path (computeApi.get)
+// ---------------------------------------------------------------------------
+// Must appear before any imports that transitively touch @/lib/api.
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    // Override only the clients the hook touches; keep everything else real.
+    computeApi: { get: vi.fn() },
+    default: { get: vi.fn(), post: vi.fn() },
+  };
+});
+
+import { computeApi } from "@/lib/api";
 import { useInstanceCatalog } from "./useInstanceCatalog";
+import * as configServiceModule from "@/services/configService";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function makeWrapper() {
-  // Disable retries so a single failed fetch surfaces immediately
-  // (the default 3-retry loop would slow the error test to a crawl).
+  // Disable retries so a single failed fetch surfaces immediately.
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
@@ -25,7 +54,11 @@ function makeWrapper() {
   };
 }
 
-const FIXTURE = {
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CURATED_FIXTURE = {
   normal_gpu: [
     {
       name: "g6.xlarge",
@@ -53,15 +86,43 @@ const FIXTURE = {
   ],
 };
 
+// A second fixture with different price values, used for the queryKey isolation test.
+const CURATED_FIXTURE_ALT = {
+  normal_gpu: [
+    {
+      name: "g5.xlarge",
+      cls: "normal_gpu",
+      vcpu: 4,
+      ram_gb: 16,
+      gpu_count: 1,
+      gpu_model: "NVIDIA A10G",
+      gpu_ram_gb: 24,
+      price_per_hour: 1.006,
+    },
+  ],
+  heavy_gpu: [],
+  cpu: [],
+};
+
+const LIVE_TYPES = [
+  { instance_type: "g6.xlarge", vcpus: 4, memory_gb: 16, gpu_count: 1, gpu_model: "NVIDIA L4", is_gpu: true },
+  { instance_type: "p4d.24xlarge", vcpus: 96, memory_gb: 1152, gpu_count: 8, gpu_model: "NVIDIA A100", is_gpu: true },
+  { instance_type: "c6i.xlarge", vcpus: 4, memory_gb: 8, gpu_count: 0, gpu_model: null, is_gpu: false },
+];
+
 afterEach(() => {
   vi.restoreAllMocks();
+  // Reset the computeApi mock between tests so state doesn't bleed.
+  vi.mocked(computeApi.get).mockReset();
 });
 
-describe("useInstanceCatalog", () => {
+// ---------------------------------------------------------------------------
+// Curated path (no region)
+// ---------------------------------------------------------------------------
+
+describe("useInstanceCatalog (no-arg / curated path)", () => {
   it("fetches and groups by class", async () => {
-    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(FIXTURE), { status: 200 }),
-    );
+    vi.mocked(computeApi.get).mockResolvedValue({ data: CURATED_FIXTURE });
 
     const { result } = renderHook(() => useInstanceCatalog(), {
       wrapper: makeWrapper(),
@@ -69,7 +130,7 @@ describe("useInstanceCatalog", () => {
 
     await waitFor(() => expect(result.current.data).toBeDefined());
 
-    expect(fetchSpy).toHaveBeenCalledWith("/api/v1/providers/aws/instance-catalog");
+    expect(computeApi.get).toHaveBeenCalledWith("/providers/aws/instance-catalog");
     expect(result.current.data?.normal_gpu[0].name).toBe("g6.xlarge");
     expect(result.current.data?.normal_gpu[0].price_per_hour).toBe(0.8);
     expect(result.current.data?.cpu[0].gpu_count).toBe(0);
@@ -78,27 +139,179 @@ describe("useInstanceCatalog", () => {
   });
 
   it("surfaces HTTP errors as query errors (not silently swallowed)", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response("server boom", { status: 500 }),
-    );
+    // Axios rejects on non-2xx; the rejection propagates through useQuery.
+    const axiosError = Object.assign(new Error("Request failed with status code 500"), {
+      response: { status: 500, data: "server boom" },
+    });
+    vi.mocked(computeApi.get).mockRejectedValue(axiosError);
 
     const { result } = renderHook(() => useInstanceCatalog(), {
       wrapper: makeWrapper(),
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect((result.current.error as Error).message).toMatch(/catalog fetch failed: 500/);
+    // The error object is the axios error itself — assert it is an Error instance
+    // and that it carries a recognisable status indicator.
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as any).response?.status).toBe(500);
     expect(result.current.data).toBeUndefined();
   });
 
-  it("surfaces network failures (fetch rejects) as query errors", async () => {
-    vi.spyOn(global, "fetch").mockRejectedValue(new TypeError("offline"));
+  it("surfaces network failures (computeApi.get rejects) as query errors", async () => {
+    // Simulate axios network-level failure (no response object).
+    const netError = Object.assign(new Error("Network Error"), { code: "ERR_NETWORK" });
+    vi.mocked(computeApi.get).mockRejectedValue(netError);
 
     const { result } = renderHook(() => useInstanceCatalog(), {
       wrapper: makeWrapper(),
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect((result.current.error as Error).message).toMatch(/offline/);
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toMatch(/Network Error/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Region-aware live path
+// ---------------------------------------------------------------------------
+
+describe("useInstanceCatalog (region-aware live path)", () => {
+  it("uses live catalog when region provided and fallback=false with data", async () => {
+    vi.spyOn(configServiceModule.ConfigService, "listAwsInstanceTypes").mockResolvedValue({
+      instance_types: LIVE_TYPES,
+      fallback: false,
+    });
+
+    const { result } = renderHook(() => useInstanceCatalog("us-east-1"), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    // single-GPU → normal_gpu
+    expect(result.current.data?.normal_gpu).toHaveLength(1);
+    expect(result.current.data?.normal_gpu[0].name).toBe("g6.xlarge");
+    expect(result.current.data?.normal_gpu[0].gpu_count).toBe(1);
+    expect(result.current.data?.normal_gpu[0].gpu_model).toBe("NVIDIA L4");
+    // live discovery has no pricing/VRAM
+    expect(result.current.data?.normal_gpu[0].gpu_ram_gb).toBe(0);
+    expect(result.current.data?.normal_gpu[0].price_per_hour).toBe(0);
+
+    // multi-GPU → heavy_gpu
+    expect(result.current.data?.heavy_gpu).toHaveLength(1);
+    expect(result.current.data?.heavy_gpu[0].name).toBe("p4d.24xlarge");
+    expect(result.current.data?.heavy_gpu[0].gpu_count).toBe(8);
+
+    // no-GPU → cpu
+    expect(result.current.data?.cpu).toHaveLength(1);
+    expect(result.current.data?.cpu[0].name).toBe("c6i.xlarge");
+    expect(result.current.data?.cpu[0].gpu_count).toBe(0);
+    expect(result.current.data?.cpu[0].gpu_model).toBeNull();
+
+    // curated endpoint must NOT have been called when live succeeds
+    expect(computeApi.get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to curated when live returns fallback=true", async () => {
+    vi.spyOn(configServiceModule.ConfigService, "listAwsInstanceTypes").mockResolvedValue({
+      instance_types: LIVE_TYPES,
+      fallback: true,
+    });
+    vi.mocked(computeApi.get).mockResolvedValue({ data: CURATED_FIXTURE });
+
+    const { result } = renderHook(() => useInstanceCatalog("eu-west-1"), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    // curated catalog has price_per_hour values; live doesn't
+    expect(result.current.data?.normal_gpu[0].price_per_hour).toBe(0.8);
+    expect(computeApi.get).toHaveBeenCalledWith("/providers/aws/instance-catalog");
+  });
+
+  it("falls back to curated when live returns empty list", async () => {
+    vi.spyOn(configServiceModule.ConfigService, "listAwsInstanceTypes").mockResolvedValue({
+      instance_types: [],
+      fallback: false,
+    });
+    vi.mocked(computeApi.get).mockResolvedValue({ data: CURATED_FIXTURE });
+
+    const { result } = renderHook(() => useInstanceCatalog("ap-southeast-1"), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(result.current.data?.normal_gpu[0].price_per_hour).toBe(0.8);
+    expect(computeApi.get).toHaveBeenCalledWith("/providers/aws/instance-catalog");
+  });
+
+  it("does NOT call ConfigService when no region supplied (backward-compat)", async () => {
+    const listSpy = vi.spyOn(configServiceModule.ConfigService, "listAwsInstanceTypes");
+    vi.mocked(computeApi.get).mockResolvedValue({ data: CURATED_FIXTURE });
+
+    const { result } = renderHook(() => useInstanceCatalog(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(listSpy).not.toHaveBeenCalled();
+    expect(computeApi.get).toHaveBeenCalledWith("/providers/aws/instance-catalog");
+    // curated catalog price values are present
+    expect(result.current.data?.normal_gpu[0].price_per_hour).toBe(0.8);
+  });
+
+  it("queryKey includes region so different regions return distinct cached data", async () => {
+    // Two hooks share one QueryClient but different regions → different query keys
+    // → TanStack Query keeps them in separate cache slots.
+    const listSpy = vi
+      .spyOn(configServiceModule.ConfigService, "listAwsInstanceTypes")
+      .mockImplementation(async (region: string) => {
+        // Return distinct live types per region so data differs.
+        if (region === "us-east-1") {
+          return {
+            instance_types: [
+              { instance_type: "g6.xlarge", vcpus: 4, memory_gb: 16, gpu_count: 1, gpu_model: "NVIDIA L4", is_gpu: true },
+            ],
+            fallback: false,
+          };
+        }
+        // us-west-2 → fallback=true so it hits computeApi (curated path).
+        return { instance_types: [], fallback: true };
+      });
+
+    // us-west-2 fallback path will call computeApi.get → return the alt fixture.
+    vi.mocked(computeApi.get).mockResolvedValue({ data: CURATED_FIXTURE_ALT });
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result: r1 } = renderHook(() => useInstanceCatalog("us-east-1"), { wrapper });
+    const { result: r2 } = renderHook(() => useInstanceCatalog("us-west-2"), { wrapper });
+
+    await waitFor(() => {
+      expect(r1.current.data).toBeDefined();
+      expect(r2.current.data).toBeDefined();
+    });
+
+    // us-east-1 → live path → price_per_hour is 0 (live discovery has no pricing)
+    expect(r1.current.data?.normal_gpu[0].name).toBe("g6.xlarge");
+    expect(r1.current.data?.normal_gpu[0].price_per_hour).toBe(0);
+
+    // us-west-2 → curated fallback → alt fixture → g5.xlarge with price 1.006
+    expect(r2.current.data?.normal_gpu[0].name).toBe("g5.xlarge");
+    expect(r2.current.data?.normal_gpu[0].price_per_hour).toBe(1.006);
+
+    // Confirm both spies/mocks were exercised
+    expect(listSpy).toHaveBeenCalledWith("us-east-1");
+    expect(listSpy).toHaveBeenCalledWith("us-west-2");
+    expect(computeApi.get).toHaveBeenCalledWith("/providers/aws/instance-catalog");
   });
 });

--- a/apps/dashboard/src/hooks/useInstanceCatalog.test.tsx
+++ b/apps/dashboard/src/hooks/useInstanceCatalog.test.tsx
@@ -264,6 +264,25 @@ describe("useInstanceCatalog (region-aware live path)", () => {
     expect(result.current.data?.normal_gpu[0].price_per_hour).toBe(0.8);
   });
 
+  it("falls back to curated when live call throws (network/5xx/auth error)", async () => {
+    vi.spyOn(configServiceModule.ConfigService, "listAwsInstanceTypes").mockRejectedValue(
+      new Error("boom"),
+    );
+    vi.mocked(computeApi.get).mockResolvedValue({ data: CURATED_FIXTURE });
+
+    const { result } = renderHook(() => useInstanceCatalog("us-east-1"), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    // query must not be in error state — the throw was swallowed
+    expect(result.current.isError).toBe(false);
+    // curated catalog should have been returned instead
+    expect(result.current.data).toEqual(CURATED_FIXTURE);
+    expect(computeApi.get).toHaveBeenCalledWith("/providers/aws/instance-catalog");
+  });
+
   it("queryKey includes region so different regions return distinct cached data", async () => {
     // Two hooks share one QueryClient but different regions → different query keys
     // → TanStack Query keeps them in separate cache slots.

--- a/apps/dashboard/src/hooks/useInstanceCatalog.ts
+++ b/apps/dashboard/src/hooks/useInstanceCatalog.ts
@@ -1,6 +1,13 @@
 /**
- * useInstanceCatalog — TanStack Query hook that fetches the curated
- * AWS EC2 catalog from the orchestration service.
+ * useInstanceCatalog — TanStack Query hook that fetches the AWS EC2 instance
+ * catalog, now region-aware with curated fallback.
+ *
+ * When a `region` is provided the hook first attempts a live AWS discovery
+ * call via ConfigService.listAwsInstanceTypes(region). If the live call
+ * returns real data (fallback === false and a non-empty list) the live
+ * catalog is used, grouped by class. Otherwise — or when no region is
+ * supplied — it falls back to the static curated catalog served by
+ * /providers/aws/instance-catalog.
  *
  * The endpoint groups instances by class:
  *   - normal_gpu  → single-GPU instances for routine inference
@@ -14,12 +21,13 @@
  * apps/dashboard/src/pages/Compute/NewPool.tsx). We use that wire name
  * here so consumers do not have to remember the rename.
  *
- * The catalog rarely changes (it lives in a static Python module on
- * the backend), so we cache it for 5 minutes — switching tier tabs or
- * navigating away and back never re-fetches in that window.
+ * The catalog is cached for 5 minutes per (region | "curated") key —
+ * switching regions or navigating away and back never re-fetches in
+ * that window unless the key changes.
  */
 import { useQuery } from "@tanstack/react-query";
 import { computeApi } from "@/lib/api";
+import { ConfigService, type AwsInstanceType } from "@/services/configService";
 
 export type InstanceClass = "normal_gpu" | "heavy_gpu" | "cpu";
 
@@ -38,10 +46,36 @@ export type InstanceType = {
 
 export type InstanceCatalog = Record<InstanceClass, InstanceType[]>;
 
-export function useInstanceCatalog() {
+function groupLiveTypes(types: AwsInstanceType[]): InstanceCatalog {
+  const out: InstanceCatalog = { normal_gpu: [], heavy_gpu: [], cpu: [] };
+  for (const t of types) {
+    const cls: InstanceClass =
+      t.gpu_count > 1 ? "heavy_gpu" : t.gpu_count === 1 ? "normal_gpu" : "cpu";
+    out[cls].push({
+      name: t.instance_type,
+      cls,
+      vcpu: t.vcpus,
+      ram_gb: t.memory_gb,
+      gpu_count: t.gpu_count,
+      gpu_model: t.gpu_model,
+      gpu_ram_gb: 0,       // live discovery doesn't expose per-GPU VRAM
+      price_per_hour: 0,   // live discovery has no pricing
+    });
+  }
+  return out;
+}
+
+export function useInstanceCatalog(region?: string) {
   return useQuery<InstanceCatalog>({
-    queryKey: ["aws-instance-catalog"],
+    queryKey: ["aws-instance-catalog", region ?? "curated"],
     queryFn: async () => {
+      if (region) {
+        const live = await ConfigService.listAwsInstanceTypes(region);
+        if (!live.fallback && live.instance_types.length) {
+          return groupLiveTypes(live.instance_types);
+        }
+      }
+      // No region given, or live returned fallback/empty — use curated catalog.
       // Use the authenticated axios client so the JWT goes through. Raw
       // fetch() skips the interceptor → gateway returns 401 → empty
       // catalog → no GPU types in NewPool's instance selector.

--- a/apps/dashboard/src/hooks/useInstanceCatalog.ts
+++ b/apps/dashboard/src/hooks/useInstanceCatalog.ts
@@ -70,9 +70,13 @@ export function useInstanceCatalog(region?: string) {
     queryKey: ["aws-instance-catalog", region ?? "curated"],
     queryFn: async () => {
       if (region) {
-        const live = await ConfigService.listAwsInstanceTypes(region);
-        if (!live.fallback && live.instance_types.length) {
-          return groupLiveTypes(live.instance_types);
+        try {
+          const live = await ConfigService.listAwsInstanceTypes(region);
+          if (!live.fallback && live.instance_types.length) {
+            return groupLiveTypes(live.instance_types);
+          }
+        } catch {
+          // live discovery failed (network / 5xx / auth) — fall through to curated
         }
       }
       // No region given, or live returned fallback/empty — use curated catalog.

--- a/apps/dashboard/src/pages/Compute/NewPool.test.tsx
+++ b/apps/dashboard/src/pages/Compute/NewPool.test.tsx
@@ -117,6 +117,10 @@ vi.mock("@/services/configService", () => ({
             depin: {},
         }),
         listProviderCredentials: vi.fn().mockResolvedValue([]),
+        // Return fallback:true so the static awsRegions list is used,
+        // keeping every existing region-selector assertion unchanged.
+        listAwsRegions: vi.fn().mockResolvedValue({ regions: [], fallback: true }),
+        listAwsInstanceTypes: vi.fn().mockResolvedValue({ instance_types: [], fallback: true }),
     },
 }));
 
@@ -190,22 +194,15 @@ beforeEach(() => {
                 },
             });
         }
+        // The curated instance catalog is consumed via computeApi.get (axios),
+        // not global.fetch. Return the fixture so the instance buttons render.
+        if (url.includes("/providers/aws/instance-catalog")) {
+            return Promise.resolve({ data: CATALOG_FIXTURE });
+        }
         // /deployment/provider/resources is only consumed by the non-cluster
         // path, but the effect calls it for AWS too; return an empty list so
         // the loading spinner can resolve.
         return Promise.resolve({ data: { resources: [] } });
-    });
-
-    // Stub global fetch — the catalog hook uses native fetch, not the
-    // axios-backed computeApi. Any non-catalog fetch returns an empty JSON
-    // body so unrelated calls (if any are added later) won't break the
-    // tests silently.
-    vi.spyOn(global, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/api/v1/providers/aws/instance-catalog")) {
-            return new Response(JSON.stringify(CATALOG_FIXTURE), { status: 200 });
-        }
-        return new Response("{}", { status: 200 });
     });
 });
 
@@ -302,8 +299,9 @@ describe("AWS Instance Tier selector (useInstanceCatalog)", () => {
         await user.click(screen.getByTestId("tier-btn-cpu"));
         // Pick the cheapest CPU instance (c6i.xlarge, 0.170)
         await user.click(screen.getByTestId("aws-inst-c6i.xlarge"));
-        // Pick a region (any will do — the summary needs both)
-        await user.click(screen.getByRole("button", { name: /Iowa/i }));
+        // Pick a region (any will do — the summary needs both).
+        // "N. Virginia" is the first entry in the static awsRegions list.
+        await user.click(screen.getByRole("button", { name: /N\. Virginia/i }));
 
         // Summary block uses the instance type (not the gpu_type "(none)")
         const summary = await screen.findByText(/Summary: 1x c6i\.xlarge/i);
@@ -323,7 +321,8 @@ describe("AWS Instance Tier selector (useInstanceCatalog)", () => {
         await screen.findByTestId("aws-inst-g5.xlarge");
 
         // Select region + a Normal-tier instance first.
-        await user.click(screen.getByRole("button", { name: /Iowa/i }));
+        // "N. Virginia" is the first entry in the static awsRegions list.
+        await user.click(screen.getByRole("button", { name: /N\. Virginia/i }));
         await user.click(screen.getByTestId("aws-inst-g5.xlarge"));
 
         // Continue should now be enabled.
@@ -407,7 +406,8 @@ describe("AWS Instance Tier selector (useInstanceCatalog)", () => {
         const user = await gotoStep2("aws");
         await screen.findByTestId("aws-inst-g6.xlarge");
 
-        await user.click(screen.getByRole("button", { name: /Iowa/i }));
+        // "N. Virginia" is the first entry in the static awsRegions list.
+        await user.click(screen.getByRole("button", { name: /N\. Virginia/i }));
         await user.click(screen.getByTestId("aws-inst-g6.xlarge"));
 
         // Pre-spot: 0.805 * 1 → "$0.81/hr" when rounded to two decimals
@@ -443,20 +443,33 @@ describe("AWS Instance Tier selector (useInstanceCatalog)", () => {
         // If the rendering really comes from the API, this name will be
         // visible; if it falls back to a stale local constant, the test
         // will fail.
-        (global.fetch as ReturnType<typeof vi.spyOn>).mockImplementation(async (input: RequestInfo | URL) => {
-            const url = typeof input === "string" ? input : input.toString();
-            if (url.includes("/api/v1/providers/aws/instance-catalog")) {
-                return new Response(JSON.stringify({
-                    normal_gpu: [{
-                        name: "totally-made-up.xl", cls: "normal_gpu",
-                        vcpu: 4, ram_gb: 16, gpu_count: 1,
-                        gpu_model: "FAKE GPU", gpu_ram_gb: 24,
-                        price_per_hour: 0.42,
-                    }],
-                    heavy_gpu: [], cpu: [],
-                }), { status: 200 });
+        // Override computeApiGet for this test only — the catalog hook uses
+        // computeApi.get (axios), not global.fetch.
+        computeApiGet.mockImplementation((url: string) => {
+            if (url.includes("/inventory/providers")) {
+                return Promise.resolve({
+                    data: {
+                        providers: {
+                            aws: { adapter_type: "cloud", capabilities: { supports_cluster_mode: true, pricing_model: "fixed" } },
+                            gcp: { adapter_type: "cloud", capabilities: { supports_cluster_mode: true, pricing_model: "fixed" } },
+                        },
+                    },
+                });
             }
-            return new Response("{}", { status: 200 });
+            if (url.includes("/providers/aws/instance-catalog")) {
+                return Promise.resolve({
+                    data: {
+                        normal_gpu: [{
+                            name: "totally-made-up.xl", cls: "normal_gpu",
+                            vcpu: 4, ram_gb: 16, gpu_count: 1,
+                            gpu_model: "FAKE GPU", gpu_ram_gb: 24,
+                            price_per_hour: 0.42,
+                        }],
+                        heavy_gpu: [], cpu: [],
+                    },
+                });
+            }
+            return Promise.resolve({ data: { resources: [] } });
         });
 
         await gotoStep2("aws");

--- a/apps/dashboard/src/pages/Compute/NewPool.tsx
+++ b/apps/dashboard/src/pages/Compute/NewPool.tsx
@@ -302,8 +302,35 @@ export default function NewPool() {
     // catalog change with no frontend edit. The fetch is cheap and the
     // hook caches for 5 minutes, so this is safe to call unconditionally
     // (the catalog block is only rendered when selectedProvider === 'aws'
-    // anyway).
-    const { data: awsCatalog, isLoading: loadingAwsCatalog } = useInstanceCatalog()
+    // anyway). Region-aware: when a region is selected the hook tries the
+    // live discover endpoint for that region (with curated fallback).
+    const { data: awsCatalog, isLoading: loadingAwsCatalog } = useInstanceCatalog(
+        selectedProvider === "aws" ? selectedRegion : undefined,
+    )
+
+    // Fetch live AWS regions from the orchestration service. Falls back to
+    // the static awsRegions list when the endpoint is unavailable or returns
+    // fallback:true. Enabled only when the user is on the AWS path to avoid
+    // unnecessary requests on GCP / worker pools.
+    const { data: liveRegions } = useQuery({
+        queryKey: ["aws-regions"],
+        queryFn: () => ConfigService.listAwsRegions(),
+        staleTime: 60 * 60 * 1000,
+        enabled: selectedProvider === "aws",
+    })
+
+    // Compute the region option list: prefer live regions when available and
+    // not a fallback response, else fall back to the static awsRegions array.
+    // For known region IDs we preserve the human-readable name from the static
+    // list; unknown IDs (returned only by live discovery) use the raw id as
+    // the display name.
+    const awsRegionOptions =
+        liveRegions && !liveRegions.fallback && liveRegions.regions.length
+            ? liveRegions.regions.map((id) => {
+                const known = awsRegions.find((r) => r.id === id);
+                return { id, name: known ? known.name : id, available: true };
+              })
+            : awsRegions;
 
     // NEW: Fetch registered providers dynamically from API
     const { data: providersData, isLoading: loadingProviders } = useQuery({
@@ -875,7 +902,7 @@ export default function NewPool() {
                         <div className="mb-6">
                             <label className="text-sm font-medium mb-2 block">Select Region</label>
                             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-                                {(selectedProvider === "aws" ? awsRegions : gcpRegions).map((region) => (
+                                {(selectedProvider === "aws" ? awsRegionOptions : gcpRegions).map((region) => (
                                     <button
                                         key={region.id}
                                         onClick={() => dispatch({ type: "SET_REGION", payload: region.id })}

--- a/apps/dashboard/src/pages/Settings/Providers/EngineAmiSection.tsx
+++ b/apps/dashboard/src/pages/Settings/Providers/EngineAmiSection.tsx
@@ -4,13 +4,28 @@ import { toast } from "sonner";
 
 type Ami = { ami_id: string; vllm_tag?: string; region: string; created: string };
 
+const PHASE_LABELS: Record<string, string> = {
+    "starting": "Starting…",
+    "launching-builder": "Launching builder…",
+    "waiting-for-ssm": "Waiting for builder…",
+    "installing-and-pulling": "Installing + pulling vLLM image…",
+    "stopping-builder": "Stopping builder…",
+    "creating-ami": "Creating AMI…",
+    "waiting-for-ami": "Waiting for AMI to become available…",
+    "done": "Done",
+    "failed": "Failed",
+};
+
 export function EngineAmiSection() {
     const [region, setRegion] = useState("us-east-1");
     const [amis, setAmis] = useState<Ami[]>([]);
     const [vllmTag, setVllmTag] = useState("");
     const [baking, setBaking] = useState(false);
     const [status, setStatus] = useState("");
+    const [bakePhase, setBakePhase] = useState("");
+    const [bakeLog, setBakeLog] = useState<string[]>([]);
     const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const logContainerRef = useRef<HTMLDivElement | null>(null);
 
     const refresh = async () => {
         try { setAmis(await ConfigService.listEngineAmis(region)); }
@@ -20,14 +35,23 @@ export function EngineAmiSection() {
     // Clear any in-flight poll on unmount to avoid a state-update-after-unmount leak.
     useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
 
+    // Auto-scroll the log pane to the bottom whenever new lines arrive.
+    useEffect(() => {
+        if (logContainerRef.current) {
+            logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight;
+        }
+    }, [bakeLog]);
+
     const bake = async () => {
-        setBaking(true); setStatus("running");
+        setBaking(true); setStatus("running"); setBakePhase(""); setBakeLog([]);
         try {
             const { bake_id } = await ConfigService.startEngineBake({ region, vllm_tag: vllmTag || undefined });
             pollRef.current = setInterval(async () => {
                 try {
                     const s = await ConfigService.pollBakeStatus(bake_id);
                     setStatus(`${s.status}${s.message ? ": " + s.message : ""}`);
+                    setBakePhase(s.phase ?? "");
+                    setBakeLog(s.log ?? []);
                     if (s.status === "succeeded" || s.status === "failed") {
                         if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
                         setBaking(false);
@@ -42,6 +66,8 @@ export function EngineAmiSection() {
         } catch { setBaking(false); setStatus(""); toast.error("Failed to start bake"); }
     };
 
+    const isBakeActive = baking;
+
     return (
         <div className="space-y-4 border border-border rounded-lg p-4">
             <h3 className="text-sm font-semibold">Engine Cache AMIs</h3>
@@ -55,6 +81,27 @@ export function EngineAmiSection() {
                 <button type="button" disabled={baking} onClick={bake} className="h-9 px-3 text-xs font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50">{baking ? "Baking…" : "Bake new AMI"}</button>
             </div>
             {status && <p className="text-xs text-muted-foreground">Status: {status}</p>}
+            {isBakeActive && (
+                <div className="space-y-2">
+                    {bakePhase && (
+                        <div className="flex items-center gap-2">
+                            <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-primary/10 text-primary border border-primary/20">
+                                {PHASE_LABELS[bakePhase] ?? bakePhase}
+                            </span>
+                        </div>
+                    )}
+                    {bakeLog.length > 0 && (
+                        <div
+                            ref={logContainerRef}
+                            className="max-h-64 overflow-y-auto rounded-md border border-border bg-muted/50 p-2"
+                        >
+                            <pre className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-all">
+                                {bakeLog.slice(-200).join("\n")}
+                            </pre>
+                        </div>
+                    )}
+                </div>
+            )}
             <table className="w-full text-xs">
                 <thead><tr className="text-left text-muted-foreground border-b border-border"><th className="py-1">AMI</th><th>vLLM tag</th><th>Created</th></tr></thead>
                 <tbody>

--- a/apps/dashboard/src/services/configService.ts
+++ b/apps/dashboard/src/services/configService.ts
@@ -102,6 +102,13 @@ export interface HfTokenResponse {
     created_at?: string;
 }
 
+export interface AwsRegionsResponse { regions: string[]; fallback: boolean; }
+export interface AwsInstanceType {
+    instance_type: string; vcpus: number; memory_gb: number;
+    gpu_count: number; gpu_model: string | null; is_gpu: boolean;
+}
+export interface AwsInstanceTypesResponse { instance_types: AwsInstanceType[]; fallback: boolean; }
+
 export const ConfigService = {
     async getProviderConfig(): Promise<ProvidersConfig> {
         const { data } = await api.get<ProviderConfigResponse>('/management/config/providers');
@@ -210,8 +217,17 @@ export const ConfigService = {
         return data;
     },
 
-    async pollBakeStatus(bakeId: string): Promise<{ status: string; message: string; ami_id?: string; region: string }> {
-        const { data } = await computeApi.get<{ status: string; message: string; ami_id?: string; region: string }>(`/admin/aws/engine-ami/bake/${bakeId}`);
+    async pollBakeStatus(bakeId: string): Promise<{ status: string; phase?: string; message?: string; ami_id?: string; region: string; log?: string[]; started_at?: string }> {
+        const { data } = await computeApi.get(`/admin/aws/engine-ami/bake/${bakeId}`);
+        return data;
+    },
+
+    async listAwsRegions(): Promise<AwsRegionsResponse> {
+        const { data } = await computeApi.get<AwsRegionsResponse>('/admin/aws/regions');
+        return data;
+    },
+    async listAwsInstanceTypes(region: string): Promise<AwsInstanceTypesResponse> {
+        const { data } = await computeApi.get<AwsInstanceTypesResponse>('/admin/aws/instance-types', { params: { region } });
         return data;
     },
 

--- a/package/src/inferia/services/api_gateway/gateway/proxy_routes.py
+++ b/package/src/inferia/services/api_gateway/gateway/proxy_routes.py
@@ -816,3 +816,30 @@ async def proxy_admin_engine_ami(
         target_url=ORCHESTRATION_URL,
         user_context=user_context,
     )
+
+
+@router.api_route("/admin/aws/regions", methods=["GET"])
+@router.api_route("/admin/aws/instance-types", methods=["GET"])
+async def proxy_admin_aws_discovery(
+    request: Request,
+    user_context: UserContext = Depends(get_current_user_from_request),
+):
+    """Proxy live AWS discovery (regions + instance types) to orchestration.
+    GET only → DEPLOYMENT_LIST (any deployer populates the pool form).
+
+    The gateway router prefix is /api/v1, so request.url.path is e.g.
+    /api/v1/admin/aws/regions. Strip the leading /api/ to get the orchestration
+    path: v1/admin/aws/regions.
+    """
+    authz_service.require_permission(user_context, PermissionEnum.DEPLOYMENT_LIST)
+    # request.url.path = /api/v1/admin/aws/... → strip "/api/" prefix
+    upstream_path = request.url.path.lstrip("/")  # api/v1/admin/aws/...
+    if upstream_path.startswith("api/"):
+        upstream_path = upstream_path[len("api/"):]  # v1/admin/aws/...
+    return await proxy_request(
+        method=request.method,
+        path=upstream_path,
+        request=request,
+        target_url=ORCHESTRATION_URL,
+        user_context=user_context,
+    )

--- a/package/src/inferia/services/api_gateway/tests/test_admin_aws_discovery_proxy.py
+++ b/package/src/inferia/services/api_gateway/tests/test_admin_aws_discovery_proxy.py
@@ -1,0 +1,17 @@
+"""Route-registration guard for the AWS discovery proxy endpoints.
+
+The gateway router has prefix /api/v1, so the registered paths are
+/api/v1/admin/aws/regions and /api/v1/admin/aws/instance-types.
+"""
+
+
+def test_discovery_routes_registered():
+    from app import app
+    paths = {r.path for r in app.routes}
+    # Gateway router prefix is /api/v1; full registered paths include it.
+    assert "/api/v1/admin/aws/regions" in paths, (
+        f"missing /api/v1/admin/aws/regions in {[p for p in paths if 'admin/aws' in p]}"
+    )
+    assert "/api/v1/admin/aws/instance-types" in paths, (
+        f"missing /api/v1/admin/aws/instance-types in {[p for p in paths if 'admin/aws' in p]}"
+    )

--- a/package/src/inferia/services/orchestration/api/admin_aws_discovery.py
+++ b/package/src/inferia/services/orchestration/api/admin_aws_discovery.py
@@ -1,0 +1,68 @@
+"""Dashboard-facing admin router for live AWS account discovery (regions +
+instance types). Same _need_perm/configure pattern as admin_engine_ami.py;
+RBAC is enforced at the gateway proxy. Each route degrades to fallback=True
+(empty list) when AWS can't be queried so the pool form keeps working."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+
+from inferia.services.orchestration.services.adapter_engine.adapters.aws.aws_discovery import (
+    AwsDiscoveryUnavailable, list_instance_types, list_regions,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/admin/aws")
+
+
+class _Deps:
+    require_permission: Optional[Callable[[str], Any]] = None
+
+
+_deps = _Deps()
+
+
+def configure(*, require_permission: Callable[[str], Any]) -> None:
+    _deps.require_permission = require_permission
+
+
+def _need_perm(perm: str):
+    async def _dep(authorization: str | None = Header(default=None)):
+        if _deps.require_permission is None:
+            raise HTTPException(503, "RBAC dependency not configured")
+        check = _deps.require_permission(perm)
+        try:
+            result = check(authorization)
+        except TypeError:
+            result = check()
+        if hasattr(result, "__await__"):
+            result = await result
+        return result
+    return _dep
+
+
+@router.get("/regions")
+async def get_regions(_granted: bool = Depends(_need_perm("deployment:list"))):
+    try:
+        return {"regions": await list_regions(), "fallback": False}
+    except AwsDiscoveryUnavailable as e:
+        logger.info("regions discovery unavailable, returning fallback: %s", e)
+        return {"regions": [], "fallback": True}
+
+
+@router.get("/instance-types")
+async def get_instance_types(
+    region: str = Query(..., min_length=1),
+    _granted: bool = Depends(_need_perm("deployment:list")),
+):
+    try:
+        infos = await list_instance_types(region)
+        return {"instance_types": [i.to_dict() for i in infos], "fallback": False}
+    except AwsDiscoveryUnavailable as e:
+        logger.info("instance-type discovery unavailable, returning fallback: %s", e)
+        return {"instance_types": [], "fallback": True}
+
+
+__all__ = ["router", "configure"]

--- a/package/src/inferia/services/orchestration/api/admin_engine_ami.py
+++ b/package/src/inferia/services/orchestration/api/admin_engine_ami.py
@@ -20,6 +20,23 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/admin/aws/engine-ami")
 
+_LOG_CAP = 2000
+
+
+def _make_progress(bake_id: str):
+    def _cb(phase: str, line: str = "") -> None:
+        rec = _BAKES.get(bake_id)
+        if rec is None:
+            return
+        if phase:
+            rec["phase"] = phase
+        if line:
+            log = rec.setdefault("log", [])
+            log.append(line)
+            if len(log) > _LOG_CAP:
+                del log[: len(log) - _LOG_CAP]
+    return _cb
+
 
 class _Deps:
     require_permission: Optional[Callable[[str], Any]] = None
@@ -125,7 +142,8 @@ def _default_start_bake(
     )
 
     bake_id = str(uuid.uuid4())
-    _BAKES[bake_id] = {"status": "running", "message": "", "ami_id": None, "region": region}
+    _BAKES[bake_id] = {"status": "running", "phase": "starting", "message": "",
+                       "ami_id": None, "region": region, "log": []}
     worker_ref = _worker_image_ref() if include_worker_image else None
 
     async def _run():
@@ -142,12 +160,16 @@ def _default_start_bake(
                 aws_env=aws_env,
                 worker_image_ref=worker_ref,
                 ssm_instance_profile=_ssm_instance_profile(),
+                progress=_make_progress(bake_id),
                 **kw,
             )
-            _BAKES[bake_id] = {"status": "succeeded", "message": "", "ami_id": res.ami_id, "region": res.region}
+            rec = _BAKES[bake_id]
+            rec.update({"status": "succeeded", "phase": "done", "ami_id": res.ami_id, "region": res.region})
         except Exception as e:  # noqa: BLE001 — surface as best-effort status
             logger.warning("engine-ami bake %s failed: %s", bake_id, e)
-            _BAKES[bake_id] = {"status": "failed", "message": str(e), "ami_id": None, "region": region}
+            rec = _BAKES.get(bake_id, {})
+            rec.update({"status": "failed", "phase": "failed", "message": str(e), "ami_id": None, "region": region})
+            _BAKES[bake_id] = rec
 
     asyncio.create_task(_run())
     return bake_id

--- a/package/src/inferia/services/orchestration/api/test_admin_aws_discovery.py
+++ b/package/src/inferia/services/orchestration/api/test_admin_aws_discovery.py
@@ -1,0 +1,125 @@
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+from inferia.services.orchestration.api import admin_aws_discovery as mod
+
+
+def _app():
+    mod.configure(require_permission=lambda perm: (lambda *a, **k: True))
+    app = FastAPI()
+    app.include_router(mod.router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_regions_ok():
+    with mod.__builtins__ if False else __import__("contextlib").nullcontext():
+        pass
+    app = _app()
+    # list_regions is async; patch with AsyncMock so `await list_regions()` works
+    with __import__("unittest.mock", fromlist=["patch"]).patch.object(
+        mod, "list_regions", new=AsyncMock(return_value=["us-east-1", "us-west-2"])
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.get("/v1/admin/aws/regions")
+    assert r.status_code == 200
+    assert r.json() == {"regions": ["us-east-1", "us-west-2"], "fallback": False}
+
+
+@pytest.mark.asyncio
+async def test_regions_fallback_on_unavailable():
+    from inferia.services.orchestration.services.adapter_engine.adapters.aws.aws_discovery import AwsDiscoveryUnavailable
+    from unittest.mock import patch, AsyncMock
+    app = _app()
+    with patch.object(mod, "list_regions", new=AsyncMock(side_effect=AwsDiscoveryUnavailable("no creds"))):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.get("/v1/admin/aws/regions")
+    assert r.status_code == 200
+    assert r.json() == {"regions": [], "fallback": True}
+
+
+@pytest.mark.asyncio
+async def test_instance_types_ok():
+    from inferia.services.orchestration.services.adapter_engine.adapters.aws.aws_discovery import InstanceTypeInfo
+    from unittest.mock import patch, AsyncMock
+    info = InstanceTypeInfo("g6.xlarge", 4, 16.0, 1, "L4", True)
+    app = _app()
+    with patch.object(mod, "list_instance_types", new=AsyncMock(return_value=[info])):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.get("/v1/admin/aws/instance-types?region=us-east-1")
+    body = r.json()
+    assert body["fallback"] is False
+    assert body["instance_types"][0]["instance_type"] == "g6.xlarge"
+
+
+@pytest.mark.asyncio
+async def test_instance_types_fallback_on_unavailable():
+    from inferia.services.orchestration.services.adapter_engine.adapters.aws.aws_discovery import AwsDiscoveryUnavailable
+    from unittest.mock import patch, AsyncMock
+    app = _app()
+    with patch.object(mod, "list_instance_types", new=AsyncMock(side_effect=AwsDiscoveryUnavailable("no creds"))):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.get("/v1/admin/aws/instance-types?region=us-east-1")
+    assert r.status_code == 200
+    assert r.json() == {"instance_types": [], "fallback": True}
+
+
+@pytest.mark.asyncio
+async def test_instance_types_requires_region():
+    app = _app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/admin/aws/instance-types")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_instance_types_empty_region_rejected():
+    """region must be min_length=1 — an empty string should 422."""
+    app = _app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/admin/aws/instance-types?region=")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_regions_unconfigured_rbac_returns_503():
+    """If configure() was never called, _deps.require_permission is None → 503."""
+    app = FastAPI()
+    # Reset _deps to simulate unconfigured state
+    mod._deps.require_permission = None
+    app.include_router(mod.router)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/v1/admin/aws/regions")
+    assert r.status_code == 503
+    # Restore for other tests
+    mod.configure(require_permission=lambda perm: (lambda *a, **k: True))
+
+
+@pytest.mark.asyncio
+async def test_instance_types_all_fields_present():
+    """to_dict() returns all expected keys."""
+    from inferia.services.orchestration.services.adapter_engine.adapters.aws.aws_discovery import InstanceTypeInfo
+    from unittest.mock import patch, AsyncMock
+    info = InstanceTypeInfo("p4d.24xlarge", 96, 1152.0, 8, "A100", True)
+    app = _app()
+    with patch.object(mod, "list_instance_types", new=AsyncMock(return_value=[info])):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.get("/v1/admin/aws/instance-types?region=us-east-1")
+    body = r.json()
+    it = body["instance_types"][0]
+    assert it["instance_type"] == "p4d.24xlarge"
+    assert it["vcpus"] == 96
+    assert it["memory_gb"] == 1152.0
+    assert it["gpu_count"] == 8
+    assert it["gpu_model"] == "A100"
+    assert it["is_gpu"] is True
+
+
+def test_server_registers_aws_discovery_router():
+    """Wire-up guard: server.py must import, configure, and include the router."""
+    src = Path(mod.__file__).resolve().parents[1].joinpath("server.py").read_text()
+    assert "admin_aws_discovery" in src, "server.py must import the aws-discovery router"
+    assert "admin_aws_discovery_api.configure(" in src, "server.py must configure() the router"
+    assert "include_router(admin_aws_discovery_api.router)" in src, "server.py must include_router the aws-discovery router"

--- a/package/src/inferia/services/orchestration/api/test_admin_engine_ami.py
+++ b/package/src/inferia/services/orchestration/api/test_admin_engine_ami.py
@@ -129,6 +129,7 @@ async def test_default_start_bake_records_success(monkeypatch):
     await captured["coro"]
     assert mod._BAKES[bake_id]["status"] == "succeeded"
     assert mod._BAKES[bake_id]["ami_id"] == "ami-z"
+    assert "log" in mod._BAKES[bake_id]  # accumulated log must survive completion
 
 
 @pytest.mark.asyncio
@@ -144,6 +145,7 @@ async def test_default_start_bake_records_failure(monkeypatch):
     await captured["coro"]
     assert mod._BAKES[bake_id]["status"] == "failed"
     assert "nope" in mod._BAKES[bake_id]["message"]
+    assert "log" in mod._BAKES[bake_id]  # accumulated log must survive completion
 
 
 @pytest.mark.asyncio
@@ -175,3 +177,44 @@ def test_list_503_when_not_configured(monkeypatch):
     mod._deps.list_engine_amis = None
     app.include_router(mod.router)
     assert TestClient(app).get("/v1/admin/aws/engine-ami").status_code == 503
+
+
+# --- Task 5: _BAKES phase + log; _make_progress factory ---
+
+def test_bake_record_accumulates_phase_and_log():
+    from inferia.services.orchestration.api import admin_engine_ami as m
+    bake_id = "b1"
+    m._BAKES[bake_id] = {"status": "running", "phase": "", "ami_id": None, "region": "us-east-1", "log": []}
+    cb = m._make_progress(bake_id)
+    cb("launching-builder", "launching builder")
+    cb("installing-and-pulling", "Pulling fs layer 50%")
+    rec = m._BAKES[bake_id]
+    assert rec["phase"] == "installing-and-pulling"
+    assert rec["log"][-1] == "Pulling fs layer 50%"
+    assert rec["log"][0] == "launching builder"
+
+
+def test_bake_log_caps_at_2000_lines():
+    from inferia.services.orchestration.api import admin_engine_ami as m
+    bake_id = "b2"
+    m._BAKES[bake_id] = {"status": "running", "phase": "", "ami_id": None, "region": "r", "log": []}
+    cb = m._make_progress(bake_id)
+    for i in range(2100):
+        cb("installing-and-pulling", f"line {i}")
+    assert len(m._BAKES[bake_id]["log"]) == 2000
+    assert m._BAKES[bake_id]["log"][-1] == "line 2099"
+
+
+def test_make_progress_unknown_bake_id_noop():
+    from inferia.services.orchestration.api import admin_engine_ami as m
+    cb = m._make_progress("does-not-exist")
+    cb("phase", "line")  # must not raise
+
+
+def test_make_progress_empty_phase_keeps_prior_phase():
+    from inferia.services.orchestration.api import admin_engine_ami as m
+    m._BAKES["b3"] = {"status": "running", "phase": "creating-ami", "log": [], "region": "r", "ami_id": None}
+    cb = m._make_progress("b3")
+    cb("", "a log line with no phase")
+    assert m._BAKES["b3"]["phase"] == "creating-ami"  # empty phase doesn't overwrite
+    assert m._BAKES["b3"]["log"] == ["a log line with no phase"]

--- a/package/src/inferia/services/orchestration/server.py
+++ b/package/src/inferia/services/orchestration/server.py
@@ -41,6 +41,7 @@ from inferia.services.orchestration.services.model_deployment.deployment_server 
 from inferia.services.orchestration.api import workers as workers_api
 from inferia.services.orchestration.api import admin_workers as admin_workers_api
 from inferia.services.orchestration.api import admin_engine_ami as admin_engine_ami_api
+from inferia.services.orchestration.api import admin_aws_discovery as admin_aws_discovery_api
 from inferia.services.orchestration.api import nodes as nodes_api
 from inferia.services.orchestration.api import providers as providers_api
 from inferia.services.orchestration.services.adapter_engine.registry import (
@@ -366,6 +367,7 @@ async def serve():
         db_pool=db_pool,
     )
     admin_engine_ami_api.configure(require_permission=_permit_all)
+    admin_aws_discovery_api.configure(require_permission=_permit_all)
 
     # /v1/nodes/* — the new node-centric API. Wires only those adapters that
     # implement provision_single_node (Nosana, Akash); the worker adapter is
@@ -453,6 +455,7 @@ async def serve():
     app.include_router(workers_api.router)
     app.include_router(admin_workers_api.router)
     app.include_router(admin_engine_ami_api.router)
+    app.include_router(admin_aws_discovery_api.router)
     app.include_router(nodes_api.router)
     app.include_router(providers_api.router)
 

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/aws_discovery.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/aws_discovery.py
@@ -89,3 +89,55 @@ async def list_regions() -> list[str]:
         raise AwsDiscoveryUnavailable("describe_regions returned no enabled regions")
     _cache_put("regions", regions, _REGIONS_TTL_S)
     return regions
+
+
+async def list_instance_types(region: str) -> list[InstanceTypeInfo]:
+    key = f"itypes:{region}"
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached  # type: ignore[return-value]
+    creds = await _resolve_creds()
+    if not creds:
+        raise AwsDiscoveryUnavailable("no AWS credentials configured")
+    try:
+        ec2 = _ec2(region, creds)
+        names = await asyncio.to_thread(_offered_type_names, ec2, region)
+        infos = await asyncio.to_thread(_describe_types, ec2, names)
+    except AwsDiscoveryUnavailable:
+        raise
+    except Exception as e:  # noqa: BLE001
+        raise AwsDiscoveryUnavailable(f"instance-type discovery failed: {e}") from e
+    infos.sort(key=lambda i: (not i.is_gpu, i.instance_type))
+    _cache_put(key, infos, _ITYPES_TTL_S)
+    return infos
+
+
+def _offered_type_names(ec2, region: str) -> list[str]:
+    names: list[str] = []
+    paginator = ec2.get_paginator("describe_instance_type_offerings")
+    for page in paginator.paginate(
+        LocationType="region",
+        Filters=[{"Name": "location", "Values": [region]}],
+    ):
+        names += [o["InstanceType"] for o in page.get("InstanceTypeOfferings", [])]
+    return names
+
+
+def _describe_types(ec2, names: list[str]) -> list[InstanceTypeInfo]:
+    out: list[InstanceTypeInfo] = []
+    for i in range(0, len(names), 100):  # DescribeInstanceTypes max 100/call
+        batch = names[i:i + 100]
+        resp = ec2.describe_instance_types(InstanceTypes=batch)
+        for it in resp.get("InstanceTypes", []):
+            gpus = (it.get("GpuInfo") or {}).get("Gpus") or []
+            gpu_count = sum(g.get("Count", 0) for g in gpus)
+            gpu_model = gpus[0].get("Name") if gpus else None
+            out.append(InstanceTypeInfo(
+                instance_type=it["InstanceType"],
+                vcpus=(it.get("VCpuInfo") or {}).get("DefaultVCpus", 0),
+                memory_gb=round((it.get("MemoryInfo") or {}).get("SizeInMiB", 0) / 1024, 1),
+                gpu_count=gpu_count,
+                gpu_model=gpu_model,
+                is_gpu=gpu_count > 0,
+            ))
+    return out

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/aws_discovery.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/aws_discovery.py
@@ -1,0 +1,91 @@
+# aws_discovery.py
+"""Live AWS account discovery (regions + instance types) for pool creation.
+
+Creds are resolved from the DB-decrypted providers config via the existing
+sweep resolver. Every public call raises AwsDiscoveryUnavailable when the
+account can't be queried (no creds / AccessDenied / endpoint error) so the
+caller can fall back to static data. Results are TTL-cached (monotonic clock)
+to keep the pool form responsive."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_REGIONS_TTL_S = 3600
+_ITYPES_TTL_S = 24 * 3600
+_CACHE: dict[str, tuple[float, object]] = {}
+
+
+class AwsDiscoveryUnavailable(Exception):
+    """Raised when AWS can't be queried (no creds / denied / error)."""
+
+
+@dataclass
+class InstanceTypeInfo:
+    instance_type: str
+    vcpus: int
+    memory_gb: float
+    gpu_count: int
+    gpu_model: Optional[str]
+    is_gpu: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "instance_type": self.instance_type,
+            "vcpus": self.vcpus,
+            "memory_gb": self.memory_gb,
+            "gpu_count": self.gpu_count,
+            "gpu_model": self.gpu_model,
+            "is_gpu": self.is_gpu,
+        }
+
+
+async def _resolve_creds() -> Optional[dict]:
+    from inferia.services.orchestration.services.adapter_engine.aws_orphan_sweep import (
+        resolve_sweep_aws_env, _creds_from_aws_env,
+    )
+    aws_env = await resolve_sweep_aws_env()
+    if not aws_env:
+        return None
+    return _creds_from_aws_env(aws_env)
+
+
+def _ec2(region: str, creds: dict):
+    import boto3
+    return boto3.client("ec2", region_name=region, **creds)
+
+
+def _cache_get(key: str) -> object | None:
+    hit = _CACHE.get(key)
+    if hit and hit[0] > time.monotonic():
+        return hit[1]
+    return None
+
+
+def _cache_put(key: str, value: object, ttl: float) -> None:
+    _CACHE[key] = (time.monotonic() + ttl, value)
+
+
+async def list_regions() -> list[str]:
+    cached = _cache_get("regions")
+    if cached is not None:
+        return cached  # type: ignore[return-value]
+    creds = await _resolve_creds()
+    if not creds:
+        raise AwsDiscoveryUnavailable("no AWS credentials configured")
+    try:
+        logger.debug("aws_discovery: refreshing regions cache")
+        ec2 = _ec2("us-east-1", creds)
+        resp = await asyncio.to_thread(ec2.describe_regions, AllRegions=False)
+    except Exception as e:  # noqa: BLE001
+        raise AwsDiscoveryUnavailable(f"describe_regions failed: {e}") from e
+    regions = sorted(r["RegionName"] for r in resp.get("Regions", []) if r.get("RegionName"))
+    if not regions:
+        raise AwsDiscoveryUnavailable("describe_regions returned no enabled regions")
+    _cache_put("regions", regions, _REGIONS_TTL_S)
+    return regions

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/engine_ami_bake.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/engine_ami_bake.py
@@ -13,7 +13,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Optional
 
 from inferia.services.orchestration.services.adapter_engine.adapters.pulumi.ami import (
     latest_dlami_ami,
@@ -106,6 +106,21 @@ def _build_bake_script(*, vllm_image: str, worker_image: Optional[str]) -> str:
     return "\n".join(lines)
 
 
+def _emit_new_output(prev: str, cur: str) -> tuple[str, str]:
+    """Return the suffix of `cur` not already covered by `prev`, handling both
+    growth (cur extends prev) and SSM's 24KB tail truncation (cur's head
+    overlaps prev's tail). Returns (new_text, cur)."""
+    if not prev:
+        return cur, cur
+    if cur.startswith(prev):
+        return cur[len(prev):], cur
+    max_k = min(len(prev), len(cur))
+    for k in range(max_k, 0, -1):
+        if prev[-k:] == cur[:k]:
+            return cur[k:], cur
+    return cur, cur
+
+
 def _dlami_root_device(ec2, ami_id: str) -> str:
     """Resolve the base AMI's actual root device name so the size override in
     BlockDeviceMappings isn't silently dropped (boto3 ignores a mapping whose
@@ -129,7 +144,15 @@ def bake_engine_ami(
     instance_type: str = _DEFAULT_INSTANCE_TYPE,
     root_volume_gb: int = _DEFAULT_ROOT_GB,
     ssm_instance_profile: Optional[str] = None,
+    progress: Optional[Callable[[str, str], None]] = None,
 ) -> BakeResult:
+    def _p(phase: str, line: str = "") -> None:
+        if progress:
+            try:
+                progress(phase, line)
+            except Exception:  # noqa: BLE001 — progress must never break the bake
+                pass
+
     if not aws_env:
         raise BakeError("no AWS credentials resolved for the bake")
     if not ssm_instance_profile:
@@ -151,6 +174,7 @@ def bake_engine_ami(
     instance_id: Optional[str] = None
     root_device = _dlami_root_device(ec2, dlami)
     try:
+        _p("launching-builder", f"launching {instance_type} builder in {region}")
         run = ec2.run_instances(
             ImageId=dlami,
             InstanceType=instance_type,
@@ -185,6 +209,8 @@ def bake_engine_ami(
         else:
             raise BakeError(f"builder {instance_id} never became SSM-managed")
 
+        _p("waiting-for-ssm", "builder is SSM-managed")
+        _p("installing-and-pulling", "running install + docker pull on builder")
         cmd = ssm.send_command(
             InstanceIds=[instance_id],
             DocumentName="AWS-RunShellScript",
@@ -192,16 +218,18 @@ def bake_engine_ami(
             TimeoutSeconds=_SSM_CMD_TIMEOUT_S,
         )
         command_id = cmd["Command"]["CommandId"]
-        status = _wait_ssm(ssm, command_id, instance_id)
+        status = _wait_ssm(ssm, command_id, instance_id, emit=_p)
         if status["Status"] != "Success":
             raise BakeError(
                 f"bake command status={status['Status']}: "
                 f"{(status.get('StandardErrorContent') or '')[-500:]}"
             )
 
+        _p("stopping-builder", "")
         ec2.stop_instances(InstanceIds=[instance_id])
         ec2.get_waiter("instance_stopped").wait(InstanceIds=[instance_id])
 
+        _p("creating-ami", "")
         img = ec2.create_image(
             InstanceId=instance_id,
             Name=f"inferia-engine-cache-{vllm_tag}-{instance_id}",
@@ -220,10 +248,12 @@ def bake_engine_ami(
         # Snapshotting a ~80 GB AMI (DLAMI + extracted vLLM) routinely exceeds
         # the waiter's 10 min default (40×15s). Allow up to 40 min so the bake
         # reports success on the AMI rather than a spurious waiter timeout.
+        _p("waiting-for-ami", f"waiting for {ami_id} to become available")
         ec2.get_waiter("image_available").wait(
             ImageIds=[ami_id], WaiterConfig={"Delay": 15, "MaxAttempts": 160},
         )
         logger.info("engine_ami_bake: baked %s in %s", ami_id, region)
+        _p("done", f"baked {ami_id}")
         return BakeResult(ami_id=ami_id, region=region, vllm_tag=vllm_tag, base_dlami=dlami)
     except BakeError:
         raise
@@ -238,16 +268,23 @@ def bake_engine_ami(
                 logger.warning("engine_ami_bake: failed to terminate builder %s: %s", instance_id, e)
 
 
-def _wait_ssm(ssm, command_id: str, instance_id: str) -> dict:
+def _wait_ssm(ssm, command_id: str, instance_id: str, emit=None) -> dict:
     deadline = time.time() + _SSM_CMD_TIMEOUT_S + 60
     terminal = {"Success", "Failed", "Cancelled", "TimedOut"}
     last = {"Status": "Pending"}
+    seen = ""
     while time.time() < deadline:
         try:
             last = ssm.get_command_invocation(CommandId=command_id, InstanceId=instance_id)
         except Exception:  # noqa: BLE001 — invocation not registered yet
             time.sleep(5)
             continue
+        if emit:
+            cur = last.get("StandardOutputContent") or ""
+            new, seen = _emit_new_output(seen, cur)
+            for ln in new.splitlines():
+                if ln.strip():
+                    emit("installing-and-pulling", ln)
         if last.get("Status") in terminal:
             return last
         time.sleep(10)

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_aws_discovery.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_aws_discovery.py
@@ -67,3 +67,54 @@ async def test_list_regions_empty_raises_unavailable():
          patch.object(d, "_resolve_creds", new=AsyncMock(return_value={"aws_access_key_id": "k", "aws_secret_access_key": "s"})):
         with pytest.raises(d.AwsDiscoveryUnavailable, match="no enabled regions"):
             await d.list_regions()
+
+
+@pytest.mark.asyncio
+async def test_list_instance_types_enriches_and_flags_gpu():
+    from unittest.mock import AsyncMock
+    ec2 = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {"InstanceTypeOfferings": [{"InstanceType": "g6.xlarge"}, {"InstanceType": "m5.large"}]},
+    ]
+    ec2.get_paginator.return_value = paginator
+    ec2.describe_instance_types.return_value = {"InstanceTypes": [
+        {"InstanceType": "g6.xlarge", "VCpuInfo": {"DefaultVCpus": 4},
+         "MemoryInfo": {"SizeInMiB": 16384},
+         "GpuInfo": {"Gpus": [{"Name": "L4", "Count": 1}]}},
+        {"InstanceType": "m5.large", "VCpuInfo": {"DefaultVCpus": 2},
+         "MemoryInfo": {"SizeInMiB": 8192}},
+    ]}
+    with patch.object(d, "_ec2", return_value=ec2), \
+         patch.object(d, "_resolve_creds", AsyncMock(return_value={"aws_access_key_id": "k", "aws_secret_access_key": "s"})):
+        out = await d.list_instance_types("us-east-1")
+    by = {i["instance_type"]: i for i in (x.to_dict() for x in out)}
+    assert by["g6.xlarge"]["is_gpu"] is True
+    assert by["g6.xlarge"]["gpu_count"] == 1 and by["g6.xlarge"]["gpu_model"] == "L4"
+    assert by["g6.xlarge"]["memory_gb"] == 16.0
+    assert by["m5.large"]["is_gpu"] is False and by["m5.large"]["gpu_count"] == 0
+    assert out[0].instance_type == "g6.xlarge"  # GPU sorts first
+
+
+@pytest.mark.asyncio
+async def test_list_instance_types_no_creds_raises():
+    from unittest.mock import AsyncMock
+    with patch.object(d, "_resolve_creds", AsyncMock(return_value=None)):
+        with pytest.raises(d.AwsDiscoveryUnavailable):
+            await d.list_instance_types("us-east-1")
+
+
+@pytest.mark.asyncio
+async def test_list_instance_types_batches_over_100():
+    from unittest.mock import AsyncMock
+    ec2 = MagicMock()
+    names = [f"t{i}.x" for i in range(150)]
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"InstanceTypeOfferings": [{"InstanceType": n} for n in names]}]
+    ec2.get_paginator.return_value = paginator
+    ec2.describe_instance_types.return_value = {"InstanceTypes": []}
+    with patch.object(d, "_ec2", return_value=ec2), \
+         patch.object(d, "_resolve_creds", AsyncMock(return_value={"aws_access_key_id": "k", "aws_secret_access_key": "s"})):
+        await d.list_instance_types("us-east-1")
+    # 150 names → 2 describe_instance_types calls (100 + 50)
+    assert ec2.describe_instance_types.call_count == 2

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_aws_discovery.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_aws_discovery.py
@@ -1,0 +1,69 @@
+import time
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from inferia.services.orchestration.services.adapter_engine.adapters.aws import aws_discovery as d
+
+
+def _fake_ec2(**calls):
+    ec2 = MagicMock()
+    for name, ret in calls.items():
+        getattr(ec2, name).return_value = ret
+    return ec2
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    d._CACHE.clear()
+    yield
+    d._CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_list_regions_returns_enabled_sorted():
+    ec2 = _fake_ec2(describe_regions={"Regions": [
+        {"RegionName": "us-west-2"}, {"RegionName": "us-east-1"}]})
+    with patch.object(d, "_ec2", return_value=ec2), \
+         patch.object(d, "_resolve_creds", new=AsyncMock(return_value={"aws_access_key_id": "k", "aws_secret_access_key": "s"})):
+        out = await d.list_regions()
+    assert out == ["us-east-1", "us-west-2"]
+    ec2.describe_regions.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_list_regions_cached_second_call_no_aws():
+    from unittest.mock import AsyncMock
+    ec2 = _fake_ec2(describe_regions={"Regions": [{"RegionName": "us-east-1"}]})
+    creds_mock = AsyncMock(return_value={"aws_access_key_id": "k", "aws_secret_access_key": "s"})
+    with patch.object(d, "_ec2", return_value=ec2) as mk, \
+         patch.object(d, "_resolve_creds", creds_mock):
+        await d.list_regions()
+        await d.list_regions()
+    assert mk.call_count == 1
+    assert creds_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_list_regions_no_creds_raises_unavailable():
+    with patch.object(d, "_resolve_creds", new=AsyncMock(return_value=None)):
+        with pytest.raises(d.AwsDiscoveryUnavailable):
+            await d.list_regions()
+
+
+@pytest.mark.asyncio
+async def test_list_regions_access_denied_raises_unavailable():
+    from botocore.exceptions import ClientError
+    ec2 = MagicMock()
+    ec2.describe_regions.side_effect = ClientError({"Error": {"Code": "UnauthorizedOperation"}}, "DescribeRegions")
+    with patch.object(d, "_ec2", return_value=ec2), \
+         patch.object(d, "_resolve_creds", new=AsyncMock(return_value={"aws_access_key_id": "k", "aws_secret_access_key": "s"})):
+        with pytest.raises(d.AwsDiscoveryUnavailable):
+            await d.list_regions()
+
+
+@pytest.mark.asyncio
+async def test_list_regions_empty_raises_unavailable():
+    ec2 = _fake_ec2(describe_regions={"Regions": []})
+    with patch.object(d, "_ec2", return_value=ec2), \
+         patch.object(d, "_resolve_creds", new=AsyncMock(return_value={"aws_access_key_id": "k", "aws_secret_access_key": "s"})):
+        with pytest.raises(d.AwsDiscoveryUnavailable, match="no enabled regions"):
+            await d.list_regions()

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_engine_ami_bake.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_engine_ami_bake.py
@@ -299,3 +299,33 @@ def test_bake_no_progress_default_still_works(monkeypatch):
     _patch(monkeypatch, ec2, ssm)
     res = bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="p")
     assert res.ami_id == "ami-baked"
+
+
+def test_wait_ssm_accumulates_output_across_polls(monkeypatch):
+    """_wait_ssm must emit each new line exactly once as StandardOutputContent grows
+    across polls (the `seen` variable accumulates diffs — no duplicate lines)."""
+    monkeypatch.setattr(bake.time, "sleep", lambda *a, **k: None)
+    invocations = [
+        {"Status": "InProgress", "StandardOutputContent": "pulling vllm\n"},
+        {"Status": "InProgress", "StandardOutputContent": "pulling vllm\nextracting\n"},
+        {"Status": "Success",    "StandardOutputContent": "pulling vllm\nextracting\ndone\n"},
+    ]
+
+    class _SeqSSM:
+        def __init__(self):
+            self.i = 0
+
+        def get_command_invocation(self, **kw):
+            inv = invocations[min(self.i, len(invocations) - 1)]
+            self.i += 1
+            return inv
+
+    emitted = []
+    out = bake._wait_ssm(
+        _SeqSSM(), "cmd-1", "i-1",
+        emit=lambda phase, line: emitted.append(line),
+    )
+    assert out["Status"] == "Success"
+    # Each line must appear exactly once across the 3 polls — no duplication
+    # from the 24KB-tail diff logic in _emit_new_output.
+    assert emitted == ["pulling vllm", "extracting", "done"]

--- a/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_engine_ami_bake.py
+++ b/package/src/inferia/services/orchestration/services/adapter_engine/adapters/aws/test_engine_ami_bake.py
@@ -209,3 +209,93 @@ def test_dlami_root_device_falls_back(monkeypatch):
         def describe_images(self, **kw):
             raise RuntimeError("denied")
     assert bake._dlami_root_device(_Boom(), "ami-x") == "/dev/sda1"
+
+
+# ---------------------------------------------------------------------------
+# New tests: _emit_new_output + progress callback + SSM stdout streaming
+# ---------------------------------------------------------------------------
+
+def test_emit_new_output_growth_and_truncation():
+    from inferia.services.orchestration.services.adapter_engine.adapters.aws import engine_ami_bake as b
+    new, cur = b._emit_new_output("line1\n", "line1\nline2\n")
+    assert new == "line2\n" and cur == "line1\nline2\n"
+    new, cur = b._emit_new_output("aabbcc", "bbccdd")
+    assert new == "dd"
+    new, cur = b._emit_new_output("xxxx", "yyyy")
+    assert new == "yyyy"
+    new, cur = b._emit_new_output("same", "same")
+    assert new == ""
+
+
+def test_emit_new_output_empty_prev():
+    from inferia.services.orchestration.services.adapter_engine.adapters.aws import engine_ami_bake as b
+    new, cur = b._emit_new_output("", "hello")
+    assert new == "hello"
+
+
+def test_bake_emits_phases(monkeypatch):
+    ec2, ssm = _FakeEC2(), _FakeSSM("Success")
+    _patch(monkeypatch, ec2, ssm)
+    phases = []
+    bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV,
+                         ssm_instance_profile="p", progress=lambda ph, ln="": phases.append(ph))
+    assert "launching-builder" in phases
+    assert "creating-ami" in phases
+    assert phases[-1] == "done"
+
+
+def test_bake_emits_ssm_stdout_lines(monkeypatch):
+    """_wait_ssm should stream non-empty SSM stdout lines via the emit callback."""
+    ec2 = _FakeEC2()
+
+    class _SSMWithOutput:
+        def __init__(self):
+            self.online = True
+
+        def describe_instance_information(self, **kw):
+            return {"InstanceInformationList": [{"InstanceId": "i-build"}]}
+
+        def send_command(self, **kw):
+            self.command = kw
+            return {"Command": {"CommandId": "cmd-1"}}
+
+        def get_command_invocation(self, **kw):
+            return {
+                "Status": "Success",
+                "StandardOutputContent": "pulling vllm\ndocker image ls\n",
+                "StandardErrorContent": "",
+            }
+
+    ssm = _SSMWithOutput()
+    _patch(monkeypatch, ec2, ssm)
+    lines = []
+    bake.bake_engine_ami(
+        region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="p",
+        progress=lambda ph, ln="": lines.append((ph, ln)),
+    )
+    ssm_lines = [ln for ph, ln in lines if ph == "installing-and-pulling"]
+    assert "pulling vllm" in ssm_lines
+    assert "docker image ls" in ssm_lines
+
+
+def test_bake_progress_error_does_not_break_bake(monkeypatch):
+    """A progress callback that raises must not abort the bake."""
+    ec2, ssm = _FakeEC2(), _FakeSSM("Success")
+    _patch(monkeypatch, ec2, ssm)
+
+    def _boom(phase, line=""):
+        raise RuntimeError("progress error")
+
+    res = bake.bake_engine_ami(
+        region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="p",
+        progress=_boom,
+    )
+    assert res.ami_id == "ami-baked"
+
+
+def test_bake_no_progress_default_still_works(monkeypatch):
+    """Calling without progress= (default None) must behave identically to before."""
+    ec2, ssm = _FakeEC2(), _FakeSSM("Success")
+    _patch(monkeypatch, ec2, ssm)
+    res = bake.bake_engine_ami(region="us-east-1", aws_env=AWS_ENV, ssm_instance_profile="p")
+    assert res.ami_id == "ami-baked"


### PR DESCRIPTION
## What
Three AWS-UX improvements, all with graceful fallback (every lookup returns a `fallback` flag; the UI degrades to static data when AWS creds/IAM are unavailable):

1. **Live AMI-build progress** — `engine_ami_bake` gains a `progress(phase, line)` callback; `_wait_ssm` streams the builder's stdout (diffing past SSM's 24 KB tail via `_emit_new_output`); the bake record (`_BAKES`) carries `phase` + a capped live `log`; EngineAmiSection renders a phase badge + scrolling log pane (poll-based).
2. **Dynamic regions** — `aws_discovery.list_regions()` (`ec2:DescribeRegions`, account-enabled, TTL-cached); `GET /v1/admin/aws/regions` + gateway proxy; NewPool region dropdown sourced live with the static list as fallback.
3. **Dynamic instance types** — `aws_discovery.list_instance_types(region)` (`DescribeInstanceTypeOfferings` + `DescribeInstanceTypes` enrichment: vCPU/RAM/GPU, GPU-first); `GET /v1/admin/aws/instance-types`; region-aware `useInstanceCatalog` (curated catalog as fallback, and falls back on thrown errors too).

## New IAM perms needed on the CP creds
`ec2:DescribeRegions`, `ec2:DescribeInstanceTypeOfferings`, `ec2:DescribeInstanceTypes`. The CP AWS creds are currently wiped, so until they're re-entered + perms added, the endpoints return `fallback:true` (200) and the UI shows the static region list / curated catalog / phase-only log.

## Tests
Backend (inferia-test): list_regions/instance_types (cache/fallback/pagination/GPU enrichment), endpoints (fallback flag, RBAC, 422), gateway route-registration, bake progress callback + `_emit_new_output` (incl. multi-poll SSM accumulation) + `_BAKES` phase/log/cap. Frontend (vitest): `useInstanceCatalog` live/curated/throw-fallback + queryKey isolation; `NewPool` 13/13. All green.

## Review
Per-task spec + code-quality review on each of 9 tasks; a final holistic adversarial review across 5 dimensions (caught + fixed the catalog throw-fallback gap and the multi-poll SSM test gap).

Built via subagent-driven development.