### PR TITLE
fix(dashboard): audit-logs page survives malformed /audit/logs responses

### DIFF
--- a/apps/dashboard/src/pages/Settings/AuditLogs.tsx
+++ b/apps/dashboard/src/pages/Settings/AuditLogs.tsx
@@ -5,6 +5,7 @@ import { Clock, User, Shield, Search, ChevronDown, ChevronUp, AlertCircle, Tag }
 export default function AuditLogs() {
     const [logs, setLogs] = useState<AuditLog[]>([])
     const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
     const [expandedId, setExpandedId] = useState<string | null>(null)
     const [filters, setFilters] = useState({
         action: "",
@@ -19,10 +20,16 @@ export default function AuditLogs() {
     const fetchLogs = async () => {
         try {
             setLoading(true)
+            setError(null)
             const data = await auditService.getLogs(filters)
             setLogs(data)
-        } catch (error) {
-            console.error("Failed to fetch audit logs:", error)
+        } catch (err) {
+            console.error("Failed to fetch audit logs:", err)
+            setLogs([])
+            const detail =
+                (err as any)?.response?.data?.detail ??
+                (err instanceof Error ? err.message : "Unknown error")
+            setError(`Failed to load audit logs: ${detail}`)
         } finally {
             setLoading(false)
         }
@@ -103,6 +110,15 @@ export default function AuditLogs() {
                 </div>
             </form>
 
+            {/* Error banner — fetch failed or the endpoint answered with an
+                unexpected shape; keep the page alive instead of crashing. */}
+            {error && !loading && (
+                <div className="flex items-center gap-2 p-4 mb-4 rounded-lg border border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400 text-sm">
+                    <AlertCircle className="w-4 h-4 shrink-0" />
+                    <span>{error}</span>
+                </div>
+            )}
+
             {/* Logs List */}
             {loading ? (
                 <div className="space-y-4">
@@ -110,7 +126,7 @@ export default function AuditLogs() {
                         <div key={i} className="h-16 bg-muted animate-pulse rounded-lg" />
                     ))}
                 </div>
-            ) : logs.length === 0 ? (
+            ) : error ? null : logs.length === 0 ? (
                 <div className="text-center py-12 text-muted-foreground border rounded-lg bg-card/50">
                     <Shield className="w-12 h-12 mx-auto mb-4 opacity-50" />
                     <p>No audit logs found</p>

--- a/apps/dashboard/src/services/__tests__/auditService.test.ts
+++ b/apps/dashboard/src/services/__tests__/auditService.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * auditService.getLogs must only ever resolve with an array. When an edge
+ * proxy answers an API path with the SPA's index.html fallback (seen in the
+ * field: a reverse-proxy matcher missing /audit/*), axios resolves with an
+ * HTML string body — without the guard the page crashed inside
+ * `logs.map(...)` ("e.map is not a function").
+ */
+const apiGet = vi.fn();
+vi.mock("@/lib/api", () => ({
+  default: { get: (...args: unknown[]) => apiGet(...args) },
+}));
+
+import { auditService, type AuditLog } from "@/services/auditService";
+
+const sampleLog: AuditLog = {
+  id: "log-1",
+  timestamp: "2026-06-10T12:00:00Z",
+  user_id: "user-1",
+  user_email: "owner@acme.test",
+  action: "login",
+  category: "auth",
+  resource_type: null,
+  resource_id: null,
+  details: null,
+  ip_address: "127.0.0.1",
+  status: "success",
+};
+
+describe("auditService.getLogs", () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+  });
+
+  it("returns the array payload as-is", async () => {
+    apiGet.mockResolvedValue({ data: [sampleLog] });
+    await expect(auditService.getLogs()).resolves.toEqual([sampleLog]);
+  });
+
+  it("returns an empty array payload as-is", async () => {
+    apiGet.mockResolvedValue({ data: [] });
+    await expect(auditService.getLogs()).resolves.toEqual([]);
+  });
+
+  it("throws when the body is an HTML string (SPA fallback)", async () => {
+    apiGet.mockResolvedValue({ data: "<!doctype html><html>...</html>" });
+    await expect(auditService.getLogs()).rejects.toThrow(
+      /Unexpected response from \/audit\/logs/,
+    );
+  });
+
+  it("throws when the body is a JSON object instead of a list", async () => {
+    apiGet.mockResolvedValue({ data: { detail: "Permission denied" } });
+    await expect(auditService.getLogs()).rejects.toThrow(
+      /Unexpected response from \/audit\/logs/,
+    );
+  });
+
+  it("throws when the body is null", async () => {
+    apiGet.mockResolvedValue({ data: null });
+    await expect(auditService.getLogs()).rejects.toThrow(
+      /Unexpected response from \/audit\/logs/,
+    );
+  });
+
+  it("forwards filters and pagination as query params", async () => {
+    apiGet.mockResolvedValue({ data: [] });
+    await auditService.getLogs({ category: "auth" }, { skip: 10, limit: 50 });
+    const [path, opts] = apiGet.mock.calls[0] as [string, { params: URLSearchParams }];
+    expect(path).toBe("/audit/logs");
+    expect(opts.params.get("category")).toBe("auth");
+    expect(opts.params.get("skip")).toBe("10");
+    expect(opts.params.get("limit")).toBe("50");
+  });
+});

--- a/apps/dashboard/src/services/auditService.ts
+++ b/apps/dashboard/src/services/auditService.ts
@@ -68,6 +68,13 @@ export const auditService = {
         }
 
         const { data } = await api.get<AuditLog[]>("/audit/logs", { params });
+        // Defensive: if a proxy/edge layer answers with something other than
+        // the JSON array (e.g. an SPA index.html fallback), axios still
+        // resolves with that body. Surfacing a typed error here keeps the
+        // page on its error path instead of crashing on logs.map(...).
+        if (!Array.isArray(data)) {
+            throw new Error("Unexpected response from /audit/logs (not a list of audit logs)");
+        }
         return data;
     }
 };


### PR DESCRIPTION
## Problem

Opening **Settings → Audit Logs** behind a reverse proxy whose matcher didn't forward `/audit/*` crashed the entire route with `TypeError: e.map is not a function` (router's default error screen). The proxy answered the API call with the SPA's `index.html` fallback; axios resolved with the HTML string; `setLogs(htmlString)` then blew up inside `logs.map(...)`.

The proxy itself is fixed in the deployment stack (InferiaAllSpark `9255f40` — the `:8081` front now proxies the gateway's full route surface and the deploy smoke asserts `/audit/logs` + `/health/services` return JSON). This PR makes the dashboard robust against that class of failure regardless of the edge configuration.

## Changes

- `auditService.getLogs` validates the payload with `Array.isArray` and throws a typed error on anything else (HTML string, error object, null) — the page can never receive a non-array.
- The audit page gains an `error` state rendered as an inline banner (same graceful-degradation pattern as the System Status page), instead of crashing or showing a misleading empty "No audit logs found". Backend `detail` messages (e.g. `Permission denied: audit_log:list required`) are surfaced verbatim.

## Tests

- New `auditService.test.ts` (6 tests): array passthrough, empty array, HTML-string rejection, object rejection, null rejection, filter/pagination param forwarding.
- Full dashboard suite: no new failures (13 pre-existing failures on this branch vs 16 on main — playwright specs under vitest + NewPool/useInstanceCatalog, unrelated); `vite build` green.

## Verification (live, simulated public origin)

With the stack fix deployed: unauthenticated `/audit/logs` → 401 JSON, org-owner token → **200 `[]`**, `/health/services` → 200 JSON with real service statuses.