### PR TITLE
feat(dashboard): GPU-only toggle (default on) + smallest-first instance ordering

### DIFF
--- a/apps/dashboard/src/components/compute/InstanceDropdown.test.tsx
+++ b/apps/dashboard/src/components/compute/InstanceDropdown.test.tsx
@@ -204,6 +204,7 @@ describe("InstanceDropdown — selection callback", () => {
         render(<InstanceDropdown instances={ALL_INSTANCES} value={null} onSelect={onSelect} />);
 
         await user.click(screen.getByTestId("instance-dropdown-trigger"));
+        await user.click(screen.getByTestId("gpu-only-toggle")); // reveal CPU instances (GPU-only is on by default)
         await user.click(screen.getByTestId("inst-option-c6i.xlarge"));
 
         expect(onSelect).toHaveBeenCalledOnce();
@@ -238,21 +239,48 @@ describe("InstanceDropdown — priceLabel (price vs null)", () => {
     });
 });
 
-describe("InstanceDropdown — GPU-first ordering in options list", () => {
-    it("renders instances in the provided order (GPU-first order is caller's responsibility)", async () => {
+describe("InstanceDropdown — GPU-only toggle + smallest-first ordering", () => {
+    it("defaults to GPU only: CPU instances hidden until the toggle is turned off", async () => {
         const user = userEvent.setup();
-        renderDropdown(); // uses ALL_INSTANCES which is heavy → gpu → null_price_gpu → cpu
+        renderDropdown(); // ALL_INSTANCES includes c6i (cpu)
         await user.click(screen.getByTestId("instance-dropdown-trigger"));
+        // GPU instances shown, CPU hidden by default
+        expect(screen.getByTestId("inst-option-g6.xlarge")).toBeInTheDocument();
+        expect(screen.queryByTestId("inst-option-c6i.xlarge")).not.toBeInTheDocument();
+        // Toggle GPU-only OFF (toggle is inside the container, so the list stays open)
+        await user.click(screen.getByTestId("gpu-only-toggle"));
+        expect(screen.getByTestId("inst-option-c6i.xlarge")).toBeInTheDocument();
+    });
 
+    it("GPU-only toggle defaults to checked (on)", () => {
+        renderDropdown();
+        expect(screen.getByTestId("gpu-only-toggle")).toBeChecked();
+    });
+
+    it("orders smallest instance first: ascending vCPU → RAM → GPU (GPU-only view)", async () => {
+        const user = userEvent.setup();
+        renderDropdown(); // p4d(96 vcpu), g6(4), g5(4), c6i(4,cpu→hidden)
+        await user.click(screen.getByTestId("instance-dropdown-trigger"));
         const list = screen.getByTestId("instance-dropdown-list");
-        const buttons = within(list).getAllByRole("button");
-        const names = buttons.map(b => b.getAttribute("data-testid")?.replace("inst-option-", "") ?? "");
+        const names = within(list)
+            .getAllByRole("button")
+            .map((b) => b.getAttribute("data-testid")?.replace("inst-option-", "") ?? "");
+        // GPU-only: g6(4) & g5(4) tie (same vcpu/ram/gpu) → stable input order; p4d(96) last.
+        expect(names).toEqual(["g6.xlarge", "g5.xlarge", "p4d.24xlarge"]);
+    });
 
-        // The order in ALL_INSTANCES is: HEAVY_GPU, GPU, NULL_PRICE_GPU, CPU
-        expect(names[0]).toBe("p4d.24xlarge");
-        expect(names[1]).toBe("g6.xlarge");
-        expect(names[2]).toBe("g5.xlarge");
-        expect(names[3]).toBe("c6i.xlarge");
+    it("with GPU-only off, sorts smallest-first across GPU and CPU together", async () => {
+        const user = userEvent.setup();
+        renderDropdown();
+        await user.click(screen.getByTestId("instance-dropdown-trigger"));
+        await user.click(screen.getByTestId("gpu-only-toggle"));
+        const list = screen.getByTestId("instance-dropdown-list");
+        const names = within(list)
+            .getAllByRole("button")
+            .map((b) => b.getAttribute("data-testid")?.replace("inst-option-", "") ?? "");
+        // vCPU asc: c6i(4 vcpu, 8GB) smallest of the vcpu=4 group; p4d(96) last.
+        expect(names[0]).toBe("c6i.xlarge");
+        expect(names[names.length - 1]).toBe("p4d.24xlarge");
     });
 
     it("GPU instance shows gpu_model, gpu_ram_gb, gpu_count details in option", async () => {
@@ -266,15 +294,14 @@ describe("InstanceDropdown — GPU-first ordering in options list", () => {
         expect(within(option).getByText(/1 GPU/)).toBeInTheDocument();
     });
 
-    it("CPU instance does NOT show GPU details row in option", async () => {
+    it("CPU instance (GPU-only off) does NOT show a GPU details row in option", async () => {
         const user = userEvent.setup();
         renderDropdown({ instances: [CPU_INSTANCE], value: null });
         await user.click(screen.getByTestId("instance-dropdown-trigger"));
+        await user.click(screen.getByTestId("gpu-only-toggle")); // reveal the CPU instance
 
         const option = screen.getByTestId("inst-option-c6i.xlarge");
-        // No GPU model / VRAM row
         expect(within(option).queryByText(/VRAM/)).not.toBeInTheDocument();
-        // vCPU and RAM shown
         expect(within(option).getByText(/4 vCPU/)).toBeInTheDocument();
         expect(within(option).getByText(/8GB RAM/)).toBeInTheDocument();
     });
@@ -286,7 +313,8 @@ describe("InstanceDropdown — empty state", () => {
         renderDropdown({ instances: [] });
         await user.click(screen.getByTestId("instance-dropdown-trigger"));
         expect(screen.getByTestId("instance-dropdown-list")).toBeInTheDocument();
-        expect(screen.getByText(/No instance types available/)).toBeInTheDocument();
+        // GPU-only is on by default → "No GPU instance types available"; either empty message is acceptable.
+        expect(screen.getByText(/No (GPU )?instance types available/)).toBeInTheDocument();
     });
 });
 
@@ -295,6 +323,7 @@ describe("InstanceDropdown — selected item highlight", () => {
         const user = userEvent.setup();
         renderDropdown({ instances: [GPU_INSTANCE, CPU_INSTANCE], value: "g6.xlarge" });
         await user.click(screen.getByTestId("instance-dropdown-trigger"));
+        await user.click(screen.getByTestId("gpu-only-toggle")); // reveal the CPU instance too
 
         const selected = screen.getByTestId("inst-option-g6.xlarge");
         const unselected = screen.getByTestId("inst-option-c6i.xlarge");

--- a/apps/dashboard/src/components/compute/InstanceDropdown.tsx
+++ b/apps/dashboard/src/components/compute/InstanceDropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { InstanceType } from "@/hooks/useInstanceCatalog";
 
 function priceLabel(p: number | null): string {
@@ -9,6 +9,11 @@ function summary(it: InstanceType): string {
   return it.gpu_count > 0
     ? `${it.name} — ${it.gpu_model ?? "GPU"} ${it.gpu_ram_gb}GB · ${it.gpu_count} GPU · ${priceLabel(it.price_per_hour)}`
     : `${it.name} — ${it.vcpu} vCPU · ${it.ram_gb}GB · ${priceLabel(it.price_per_hour)}`;
+}
+
+// Smallest instance first: ascending by vCPU, then RAM, then GPU count.
+function bySize(a: InstanceType, b: InstanceType): number {
+  return a.vcpu - b.vcpu || a.ram_gb - b.ram_gb || a.gpu_count - b.gpu_count;
 }
 
 export function InstanceDropdown({
@@ -23,6 +28,9 @@ export function InstanceDropdown({
   loading?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  // GPU instances are the common case for this platform — default to showing
+  // only them; the toggle reveals CPU instances too.
+  const [gpuOnly, setGpuOnly] = useState(true);
   const ref = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -41,10 +49,28 @@ export function InstanceDropdown({
     };
   }, [open]);
 
+  // Filter by the GPU-only toggle, then order smallest-first. The selected
+  // summary is looked up from the FULL list so a selection the filter hides
+  // still renders in the trigger.
+  const shown = useMemo(
+    () => instances.filter((i) => !gpuOnly || i.gpu_count > 0).slice().sort(bySize),
+    [instances, gpuOnly],
+  );
   const selected = instances.find((i) => i.name === value) ?? null;
 
   return (
     <div ref={ref} className="relative" data-testid="instance-dropdown">
+      <label className="mb-1.5 flex items-center gap-2 text-xs text-muted-foreground select-none">
+        <input
+          type="checkbox"
+          checked={gpuOnly}
+          onChange={(e) => setGpuOnly(e.target.checked)}
+          data-testid="gpu-only-toggle"
+          className="h-3.5 w-3.5 rounded border-input accent-primary"
+        />
+        GPU only
+      </label>
+
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
@@ -67,12 +93,12 @@ export function InstanceDropdown({
           className="absolute z-50 mt-1 w-full max-h-80 overflow-y-auto rounded-md border border-border bg-card shadow-lg"
           data-testid="instance-dropdown-list"
         >
-          {instances.length === 0 ? (
+          {shown.length === 0 ? (
             <div className="px-3 py-4 text-xs text-muted-foreground">
-              No instance types available
+              {gpuOnly ? "No GPU instance types available" : "No instance types available"}
             </div>
           ) : (
-            instances.map((it) => (
+            shown.map((it) => (
               <button
                 key={it.name}
                 type="button"

--- a/apps/dashboard/src/pages/Compute/NewPool.test.tsx
+++ b/apps/dashboard/src/pages/Compute/NewPool.test.tsx
@@ -191,8 +191,13 @@ async function selectInstanceFromDropdown(user: ReturnType<typeof userEvent.setu
     // Open the dropdown
     const trigger = screen.getByTestId("instance-dropdown-trigger");
     await user.click(trigger);
-    // Click the instance option
-    const option = await screen.findByTestId(`inst-option-${instanceName}`);
+    // CPU instances are hidden behind the default-on "GPU only" toggle; if the
+    // target option isn't visible, turn the toggle off to reveal all instances.
+    let option = screen.queryByTestId(`inst-option-${instanceName}`);
+    if (!option) {
+        await user.click(screen.getByTestId("gpu-only-toggle"));
+        option = await screen.findByTestId(`inst-option-${instanceName}`);
+    }
     await user.click(option);
 }
 
@@ -251,37 +256,40 @@ describe("AWS InstanceDropdown (GPU-first flat list, no tier tabs)", () => {
         expect(screen.queryByTestId("aws-inst-c6i.xlarge")).not.toBeInTheDocument();
     });
 
-    it("dropdown lists GPU instances (heavy first, then normal) before CPU instances", async () => {
+    it("defaults to GPU-only (CPU hidden), orders smallest-first, and the toggle reveals CPU", async () => {
         const user = await gotoStep2("aws");
 
-        // Open the dropdown
         await waitFor(() => screen.getByTestId("instance-dropdown-trigger"));
         await user.click(screen.getByTestId("instance-dropdown-trigger"));
 
-        // All instances (GPU + CPU) should be in the dropdown list
+        // GPU instances present by default
         await waitFor(() =>
-            expect(screen.getByTestId("inst-option-p4d.24xlarge")).toBeInTheDocument(),
+            expect(screen.getByTestId("inst-option-p5.48xlarge")).toBeInTheDocument(),
         );
-        // GPU instances present
-        expect(screen.getByTestId("inst-option-p5.48xlarge")).toBeInTheDocument();
-        expect(screen.getByTestId("inst-option-g5.12xlarge")).toBeInTheDocument();
         expect(screen.getByTestId("inst-option-g5.xlarge")).toBeInTheDocument();
-        expect(screen.getByTestId("inst-option-g5.2xlarge")).toBeInTheDocument();
-        expect(screen.getByTestId("inst-option-g6.xlarge")).toBeInTheDocument();
-        // CPU instances present
-        expect(screen.getByTestId("inst-option-c6i.xlarge")).toBeInTheDocument();
-        expect(screen.getByTestId("inst-option-c6i.2xlarge")).toBeInTheDocument();
-        expect(screen.getByTestId("inst-option-m6i.xlarge")).toBeInTheDocument();
+        expect(screen.getByTestId("inst-option-p4d.24xlarge")).toBeInTheDocument();
+        // CPU instances hidden by default (GPU-only on)
+        expect(screen.queryByTestId("inst-option-c6i.xlarge")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("inst-option-m6i.xlarge")).not.toBeInTheDocument();
 
-        // Verify GPU-first ordering: p4d (heavy_gpu first) appears before c6i (cpu)
-        const list = screen.getByTestId("instance-dropdown-list");
-        const buttons = within(list).getAllByRole("button");
-        const names = buttons.map(b => b.getAttribute("data-testid")?.replace("inst-option-", "") ?? "");
-        const p4dIdx = names.indexOf("p4d.24xlarge");
-        const c6iIdx = names.indexOf("c6i.xlarge");
-        expect(p4dIdx).toBeGreaterThanOrEqual(0);
-        expect(c6iIdx).toBeGreaterThanOrEqual(0);
-        expect(p4dIdx).toBeLessThan(c6iIdx);
+        // Smallest-first: a 4-vCPU GPU instance first, the 192-vCPU p5.48xlarge last.
+        const namesGpuOnly = within(screen.getByTestId("instance-dropdown-list"))
+            .getAllByRole("button")
+            .map(b => b.getAttribute("data-testid")?.replace("inst-option-", "") ?? "")
+            .filter(Boolean);
+        expect(["g5.xlarge", "g6.xlarge"]).toContain(namesGpuOnly[0]);
+        expect(namesGpuOnly[namesGpuOnly.length - 1]).toBe("p5.48xlarge");
+
+        // Turn the GPU-only toggle off → CPU instances appear
+        await user.click(screen.getByTestId("gpu-only-toggle"));
+        expect(screen.getByTestId("inst-option-c6i.xlarge")).toBeInTheDocument();
+        expect(screen.getByTestId("inst-option-m6i.xlarge")).toBeInTheDocument();
+        const namesAll = within(screen.getByTestId("instance-dropdown-list"))
+            .getAllByRole("button")
+            .map(b => b.getAttribute("data-testid")?.replace("inst-option-", "") ?? "")
+            .filter(Boolean);
+        // Still smallest-first: p5.48xlarge (192 vCPU) remains last.
+        expect(namesAll[namesAll.length - 1]).toBe("p5.48xlarge");
     });
 
     it("selecting a GPU instance shows it in the trigger and shows the GPU Count selector", async () => {
@@ -406,24 +414,23 @@ describe("AWS InstanceDropdown (GPU-first flat list, no tier tabs)", () => {
         expect(trigger.textContent).toMatch(/g5\.xlarge/);
     });
 
-    it("GPU-first order: heavy instances come before normal_gpu, which come before cpu", async () => {
+    it("orders instances smallest-first (ascending vCPU), independent of heavy/normal class", async () => {
         const user = await gotoStep2("aws");
         await waitFor(() => screen.getByTestId("instance-dropdown-trigger"));
         await user.click(screen.getByTestId("instance-dropdown-trigger"));
 
         const list = await screen.findByTestId("instance-dropdown-list");
-        const buttons = within(list).getAllByRole("button");
-        const names = buttons.map(b => b.getAttribute("data-testid")?.replace("inst-option-", "") ?? "");
+        const names = within(list).getAllByRole("button")
+            .map(b => b.getAttribute("data-testid")?.replace("inst-option-", "") ?? "")
+            .filter(Boolean);
 
-        // heavy_gpu instances from fixture: p4d.24xlarge, p5.48xlarge, g5.12xlarge
-        // normal_gpu: g5.xlarge, g5.2xlarge, g6.xlarge
-        // cpu: c6i.xlarge, c6i.2xlarge, m6i.xlarge
-        const heavyIdx = names.indexOf("p4d.24xlarge");
-        const normalIdx = names.indexOf("g5.xlarge");
-        const cpuIdx = names.indexOf("c6i.xlarge");
-
-        expect(heavyIdx).toBeLessThan(normalIdx);
-        expect(normalIdx).toBeLessThan(cpuIdx);
+        // GPU-only (default). Fixture vCPUs: g5.xlarge/g6.xlarge=4, g5.2xlarge=8,
+        // g5.12xlarge=48 (heavy), p4d.24xlarge=96 (heavy), p5.48xlarge=192 (heavy).
+        // Smallest-first ignores the heavy/normal class:
+        expect(["g5.xlarge", "g6.xlarge"]).toContain(names[0]);          // 4 vCPU first
+        expect(names[names.length - 1]).toBe("p5.48xlarge");             // 192 vCPU last
+        expect(names.indexOf("g5.2xlarge")).toBeLessThan(names.indexOf("g5.12xlarge")); // 8 < 48
+        expect(names.indexOf("g5.12xlarge")).toBeLessThan(names.indexOf("p4d.24xlarge")); // 48 < 96
     });
 
     it("renders the tier selector ONLY for AWS — GCP shows the legacy gcpGpuTypes grid, no dropdown", async () => {


### PR DESCRIPTION
Adds a **GPU only** checkbox above the instance dropdown (on by default) that filters the list, and orders instances **smallest-first** (ascending vCPU → RAM → GPU count) instead of by GPU/CPU tier. The selected-instance summary is looked up from the full list, so a CPU selection still displays in the trigger when the filter hides it. Self-contained in InstanceDropdown (NewPool unchanged). Tests: 39 pass (InstanceDropdown toggle default-on/filter/smallest-first/reveal-CPU; NewPool helper reveals CPU via the toggle, smallest-first ordering).