### PR TITLE
feat(dashboard): remove Spot Instances option; rename pool-creation title Node→Pool

### DIFF
--- a/apps/dashboard/src/pages/Compute/NewPool.test.tsx
+++ b/apps/dashboard/src/pages/Compute/NewPool.test.tsx
@@ -22,7 +22,7 @@
  *     so Step 1 → click → Step 2 lands on the cluster-provider branch.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, render, screen, waitFor, within, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -450,27 +450,20 @@ describe("AWS InstanceDropdown (GPU-first flat list, no tier tabs)", () => {
         expect(screen.getByTestId("gpu-count")).toBeInTheDocument();
     });
 
-    it("spot toggle applies a 60% discount on the AWS price summary", async () => {
+    it("shows the on-demand AWS price summary (spot option removed)", async () => {
         const user = await gotoStep2("aws");
         await waitFor(() => screen.getByTestId("instance-dropdown-trigger"));
 
         selectAwsRegion("us-east-1");
         await selectInstanceFromDropdown(user, "g6.xlarge");
 
-        // Pre-spot: 0.805 * 1 → "$0.81/hr"
+        // On-demand cost: 0.805 * 1 → "$0.81/hr"
         await waitFor(() =>
             expect(screen.getByText(/Estimated: \$0\.81\/hr/i)).toBeInTheDocument(),
         );
 
-        // Toggle spot
-        const spotLabel = screen.getByText("Use Spot Instances");
-        const row = spotLabel.closest("div.flex");
-        const spotToggle = row?.querySelector("button.rounded-full");
-        expect(spotToggle).toBeTruthy();
-        await act(async () => { await user.click(spotToggle as HTMLButtonElement); });
-
-        // Post-spot: 0.805 * 0.4 = 0.322 → "$0.32/hr"
-        expect(screen.getByText(/Estimated: \$0\.32\/hr/i)).toBeInTheDocument();
+        // The "Use Spot Instances" option was removed — it must not render.
+        expect(screen.queryByText("Use Spot Instances")).not.toBeInTheDocument();
     });
 
     // -----------------------------------------------------------------------

--- a/apps/dashboard/src/pages/Compute/NewPool.tsx
+++ b/apps/dashboard/src/pages/Compute/NewPool.tsx
@@ -712,7 +712,7 @@ export default function NewPool() {
     return (
         <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in duration-500 font-sans text-foreground">
             <div>
-                <h2 className="text-3xl font-bold tracking-tight">Create New Compute Node</h2>
+                <h2 className="text-3xl font-bold tracking-tight">Create New Compute Pool</h2>
                 <p className="text-muted-foreground mt-2">
                     Add a compute node so deployments can land on it. Each provider registers exactly one node per submission.
                 </p>
@@ -982,33 +982,6 @@ export default function NewPool() {
                                 </p>
                             </div>
                         )}
-
-                        {/* Spot Toggle */}
-                        <div className="p-4 rounded-lg border border-border bg-card">
-                            <div className="flex items-center justify-between">
-                                <div>
-                                    <div className="font-medium">Use Spot Instances</div>
-                                    <div className="text-xs text-muted-foreground">Up to 60% cheaper, but may be interrupted</div>
-                                </div>
-                                <button
-                                    onClick={() => dispatch({ type: "SET_USE_SPOT", payload: !useSpot })}
-                                    className={cn(
-                                        "relative w-12 h-6 rounded-full transition-colors",
-                                        useSpot ? "bg-ember-600" : "bg-muted dark:bg-card"
-                                    )}
-                                >
-                                    <div className={cn(
-                                        "absolute top-1 w-4 h-4 bg-card rounded-full transition-transform",
-                                        useSpot ? "translate-x-7" : "translate-x-1"
-                                    )} />
-                                </button>
-                            </div>
-                            {useSpot && (
-                                <div className="mt-2 text-xs text-ember-600">
-                                    Estimated cost: ~${(computeHourlyCost(selectedResource, useSpot, gpuCount, estimateGcpCost)).toFixed(2)}/hr (60% savings)
-                                </div>
-                            )}
-                        </div>
 
                         {/* Summary. For AWS entries (and any other case
                             where price_per_hour is set on the selected


### PR DESCRIPTION
Removes the **Use Spot Instances** toggle ("Up to 60% cheaper, but may be interrupted") from compute pool creation — `useSpot` now stays `false`, so on-demand pricing applies throughout (payload `use_spot:false`, PoolDetails 'On-demand'). Renames the page title **'Create New Compute Node' → 'Create New Compute Pool'**. NewPool tests updated (the spot-discount test → on-demand + asserts the spot option is gone); 17/17 pass.