### PR TITLE
docs(proxy): single-upstream nginx + hosting guide for the single-port app

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,258 @@
+# Hosting InferiaLLM behind a reverse proxy
+
+As of the single-port consolidation, the `inferia-app` container serves the
+**entire** web surface from **one** port (`APP_PORT`, default `8000`):
+
+| Path        | Served by                  | Notes |
+|-------------|----------------------------|-------|
+| `/`         | dashboard SPA              | client-side routes fall back to `index.html` |
+| `/api/...`  | API gateway                | `/api/auth`, `/api/v1/*` compute, `/api/v1/workers/*` (control **WebSocket** + shell/logs), `/api/hf` model mirror |
+| `/inf/...`  | inference API              | OpenAI-compatible `/inf/v1/*` (chat completions stream as **SSE**) |
+| `/v2/...`   | ollama OCI registry mirror | **must stay at the root** — the OCI spec hardcodes `<host>/v2`; a path-prefixed `/api/v2` will NOT work |
+
+Because it is all one origin, **there is no CORS to configure** and the proxy
+does **no** path rewriting. The app does all internal routing.
+
+## The only rule
+
+> **Forward every path, verbatim, to `inferia-app:${APP_PORT}` (default 8000).**
+> Enable **WebSocket upgrades**, **disable response buffering** (SSE + multi-GB
+> model pulls), allow **large bodies**, and use **long timeouts**.
+
+That's the whole job. Everything below is that rule expressed for each tool.
+
+### Why those four settings
+
+| Setting | Needed by |
+|---|---|
+| WebSocket upgrade (`Upgrade`/`Connection`) | worker control channel `/api/v1/workers/channel`, node shell/logs tunnels |
+| `proxy_buffering off` (+ `X-Accel-Buffering: no`) | SSE token streaming on `/inf/v1/chat/completions`; without it tokens arrive in one lump at the end |
+| `proxy_max_temp_file_size 0` + long timeouts | multi-GB model-weight downloads through `/api/hf` and `/v2` |
+| large `client_max_body_size` (≈200m) | image/video generation + embedding batch requests |
+
+---
+
+## Required environment
+
+The dashboard and workers must agree with the proxy on the host. Defaults are
+already same-origin (`/api`, `/inf`), so for a plain single-domain deploy you
+can leave the `DASHBOARD_*` URLs unset. Set them explicitly only if you serve
+the dashboard on a different origin than the API:
+
+```dotenv
+APP_PORT=8000
+# Same-origin defaults: DASHBOARD_API_GATEWAY_URL=/api, DASHBOARD_INFERENCE_URL=/inf
+# Set the full URL only for a cross-origin / absolute setup:
+DASHBOARD_API_GATEWAY_URL=https://inferia.example.com/api
+DASHBOARD_INFERENCE_URL=https://inferia.example.com/inf
+
+# Worker-facing (must be reachable from the GPU hosts):
+INFERIA_CONTROL_PLANE_EXTERNAL_URL=https://inferia.example.com/api
+INFERIA_MODEL_MIRROR_BASE=https://inferia.example.com/api   # HF mirror -> /api/hf; ollama derives <host>/v2 at root
+```
+
+> **`/v2` caveat (read this if you use ollama / cache-first mirroring):** the
+> ollama client takes the registry from the image-ref host and always requests
+> `https://<host>/v2/...`. Keep `INFERIA_MODEL_MIRROR_BASE` pointed at the host
+> with the `/api` suffix (HF needs `/api/hf`); the app derives the OCI host from
+> the origin so ollama hits `<host>/v2` at the **root**. Never put the OCI
+> registry behind a `/api/v2` (or any) prefix.
+
+---
+
+## Option 1 — No proxy (dev / trusted network)
+
+Just publish the port (compose already maps `${APP_PORT:-8000}`) and hit it directly:
+
+```bash
+docker compose up -d
+# → http://localhost:8000/  (dashboard, /api, /inf, /v2 all here)
+```
+
+No TLS, no host routing. Fine for local dev or a private network.
+
+---
+
+## Option 2 — Caddy (simplest TLS)
+
+Caddy's `reverse_proxy` streams responses and handles WebSocket upgrades
+**automatically** — no buffering/upgrade directives needed. Files provided:
+
+- `Caddyfile.localhost` — plain HTTP on `:8081` (used by `docker-compose.localhost.yml`).
+- `Caddyfile.sso` — internal-CA TLS for `inferia.local` + `auth.inferia.local` (used by `docker-compose.sso.yml`).
+
+For a **public domain with automatic Let's Encrypt**, a whole Caddyfile is two lines:
+
+```caddyfile
+inferia.example.com {
+	reverse_proxy inferia-app:{$APP_PORT:8000}
+}
+```
+
+Run Caddy as a compose service on the `inferia-net` network with ports `80:80`
+and `443:443`; mount the Caddyfile and a `caddy_data` volume (for certs). Drop
+the app's public `ports:` mapping once Caddy fronts it.
+
+---
+
+## Option 3 — nginx (hand-rolled)
+
+Use the provided **`docker/nginx.conf`** (already written for the single
+upstream). Add this service to your compose file:
+
+```yaml
+  proxy:
+    image: nginx:1.27-alpine
+    container_name: inferia-proxy
+    restart: unless-stopped
+    depends_on: [app]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./docker/certs:/etc/nginx/certs:ro       # fullchain.pem + privkey.pem
+      - ./docker/certbot-www:/var/www/certbot    # only for certbot http-01
+    networks:
+      - inferia-net
+```
+
+Edit `server_name` + the cert paths in `nginx.conf`, then drop the app's public
+`ports:`. If `APP_PORT` is not `8000`, change the `upstream inferia_app` line.
+
+If you maintain your own nginx and only want the **server block**, the entire
+location is:
+
+```nginx
+upstream inferia_app { server inferia-app:8000; keepalive 32; }
+
+map $http_upgrade $connection_upgrade { default upgrade; '' close; }
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name inferia.example.com;
+    ssl_certificate     /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+    client_max_body_size 200m;
+
+    location / {
+        proxy_pass http://inferia_app;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+        proxy_buffering          off;
+        proxy_request_buffering  off;
+        proxy_max_temp_file_size 0;
+        add_header X-Accel-Buffering no always;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}
+```
+
+---
+
+## Option 4 — Nginx Proxy Manager (NPM, the web GUI)
+
+Create **one Proxy Host** (NPM proxies the whole hostname to one upstream —
+exactly what the single-port app wants; no per-path setup).
+
+**Networking first:** put the NPM container on the same Docker network as
+`inferia-app` (so the name `inferia-app` resolves), **or** forward to the host's
+published port (`<docker-host-IP>:8000`).
+
+**Proxy Hosts → Add Proxy Host:**
+
+- **Details** tab
+  - **Domain Names:** `inferia.example.com`
+  - **Scheme:** `http`
+  - **Forward Hostname / IP:** `inferia-app` *(same network)* — or your host IP
+  - **Forward Port:** `8000`  *(= APP_PORT)*
+  - **Cache Assets:** OFF
+  - **Block Common Exploits:** ON *(optional)*
+  - **Websockets Support:** **ON**  ← required (worker channel, shell/logs)
+- **SSL** tab
+  - **SSL Certificate:** *Request a new Let's Encrypt certificate* (or upload one)
+  - **Force SSL:** ON · **HTTP/2 Support:** ON · **HSTS:** optional
+- **Advanced** tab — paste this **Custom Nginx Configuration** (NPM's UI does
+  not expose buffering/timeouts, and these are required for SSE streaming +
+  large model pulls):
+
+  ```nginx
+  proxy_buffering off;
+  proxy_request_buffering off;
+  proxy_max_temp_file_size 0;
+  client_max_body_size 200m;
+  proxy_read_timeout 3600s;
+  proxy_send_timeout 3600s;
+  add_header X-Accel-Buffering no always;
+  ```
+
+NPM already injects `Host` / `X-Forwarded-*` and (with **Websockets Support ON**)
+the `Upgrade`/`Connection` headers, so you do **not** add those in Advanced.
+
+> Do **not** create separate Proxy Hosts / custom locations for `/gw`, `/inf`,
+> or `/v2` — that was the old multi-port layout. One Proxy Host for the whole
+> domain → port 8000 is correct now.
+
+---
+
+## Option 5 — Traefik (labels)
+
+On the `app` service in compose:
+
+```yaml
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.inferia.rule=Host(`inferia.example.com`)"
+      - "traefik.http.routers.inferia.entrypoints=websecure"
+      - "traefik.http.routers.inferia.tls.certresolver=le"
+      - "traefik.http.services.inferia.loadbalancer.server.port=8000"
+```
+
+Traefik streams and handles WebSockets by default. For very long model pulls,
+raise the entrypoint/transport timeouts (`--entrypoints.websecure.transport.respondingTimeouts.readTimeout=3600s`).
+
+---
+
+## Option 6 — Cloudflare Tunnel (`cloudflared`, no open ports)
+
+`config.yml`:
+
+```yaml
+tunnel: <tunnel-id>
+credentials-file: /etc/cloudflared/<tunnel-id>.json
+ingress:
+  - hostname: inferia.example.com
+    service: http://inferia-app:8000
+  - service: http_status:404
+```
+
+WebSockets work over Tunnel by default. Note Cloudflare's **100 MB request body
+limit** (free/pro) — large image/video generation uploads may need an
+Enterprise plan or a direct origin; model weight *downloads* (`/v2`, `/api/hf`)
+are responses and are unaffected.
+
+---
+
+## Verify any setup
+
+```bash
+H=https://inferia.example.com
+curl -sf  $H/                       # 200, dashboard HTML
+curl -sf  $H/config.js              # contains window.__RUNTIME_CONFIG__ (/api, /inf)
+curl -sf  $H/api/health             # 200
+curl -s   $H/inf/v1/models          # routes to inference (200, or 401 if it requires a token)
+curl -s -o/dev/null -w '%{http_code}\n' $H/v2/   # NOT 404 (ollama mirror at root)
+# WebSocket (needs a token): wss://inferia.example.com/api/v1/workers/channel
+```
+
+If the dashboard loads but live logs/shell or token streaming hang, your proxy
+is **buffering** or missing the **WebSocket upgrade** — recheck the two settings
+above.

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,33 +1,30 @@
 # =============================================================================
-# InferiaLLM reverse proxy  --  single subdomain, subdirectory routing
+# InferiaLLM reverse proxy  --  single upstream (single-port unified app)
 # =============================================================================
-# Fronts the three externally-facing ports of the unified `inferia-app`
-# container under ONE hostname, split by path prefix:
+# The unified `inferia-app` container now serves the ENTIRE web surface from
+# ONE port (APP_PORT, default 8000):
 #
-#   https://inferia.example.com/         ->  dashboard SPA   (port 3001)
-#   https://inferia.example.com/gw/...   ->  API gateway     (port 8000)
-#   https://inferia.example.com/inf/...  ->  inference API   (port 8001)
+#   /            ->  dashboard SPA
+#   /api/...     ->  API gateway      (auth, /api/v1 compute, /api/v1/workers/*
+#                                      control WS + shell/logs, /api/hf mirror)
+#   /inf/...     ->  inference API    (OpenAI-compatible /inf/v1/*)
+#   /v2/...      ->  ollama OCI registry mirror (MUST stay at root)
 #
-# Why /gw and /inf (stripped) instead of routing the gateway at the root:
-#   The SPA owns root-level client routes (e.g. /auth/login is the login PAGE)
-#   that collide with the gateway's own /auth/* API routes. Namespacing the
-#   APIs under dedicated prefixes that nginx STRIPS keeps the whole root
-#   namespace for the SPA, so there are no collisions -- and because it's all
-#   one origin, there is NO CORS to configure.
+# So this proxy is now DUMB: forward every path, verbatim, to the one upstream.
+# No per-prefix split, no prefix stripping, no SPA file_server, no CORS (one
+# origin). The app does all internal routing.
 #
-# Required: point the dashboard runtime config at the prefixes (deploy/.env),
-# consumed by `inferiallm write-dashboard-config` at container start:
-#     DASHBOARD_API_GATEWAY_URL=https://inferia.example.com/gw
+# Dashboard runtime config (deploy .env, consumed by `inferiallm
+# write-dashboard-config` at container start) should be same-origin:
+#     DASHBOARD_API_GATEWAY_URL=https://inferia.example.com/api
 #     DASHBOARD_INFERENCE_URL=https://inferia.example.com/inf
-# All axios clients derive their baseURL from these, so every configured call
-# (auth, api/v1, management, admin, audit, ws control channel) flows through
-# /gw or /inf automatically.
-#
-# Caveat -- two dashboard calls hardcode absolute ROOT paths and ignore the
-# runtime config (apps/dashboard/src/components/nodes/RetryProvisioningButton.tsx
-# and services/authService.ts). The two `location`s flagged "absolute-fetch
-# fallback" below catch them so this works without a rebuild; the clean fix is
-# to make those calls use the configured api client.
+# (Defaults are already /api and /inf, so these can be omitted for a plain
+# same-origin deploy.) The worker-facing config follows the same host:
+#     INFERIA_CONTROL_PLANE_EXTERNAL_URL=https://inferia.example.com/api
+#     INFERIA_MODEL_MIRROR_BASE=https://inferia.example.com/api
+# (HF mirror resolves to /api/hf; the ollama OCI client derives the registry
+# from the host and hits <host>/v2 at the root — which is why /v2 is NOT under
+# /api and must not be prefixed.)
 #
 # Run as a compose service on the inferia network; snippet at the bottom.
 # Replace inferia.example.com and the cert paths.
@@ -60,7 +57,7 @@ http {
     client_max_body_size 200m;
 
     # WebSocket upgrade plumbing: "upgrade" only when the client sent Upgrade,
-    # else "close" so plain HTTP keepalive is unaffected.
+    # else "close" so plain HTTP / SSE is unaffected.
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;
@@ -74,23 +71,20 @@ http {
     gzip_types        text/plain text/css application/javascript application/json
                       application/wasm image/svg+xml;
 
-    # --- Upstreams (compose service / container name on the inferia network) ---
-    upstream inferia_dashboard { server inferia-app:3001; keepalive 16; }
-    upstream inferia_gateway   { server inferia-app:8000; keepalive 32; }
-    upstream inferia_inference { server inferia-app:8001; keepalive 32; }
+    # --- Single upstream: the unified app's one port on the inferia network ---
+    # Compose interpolates APP_PORT; nginx itself can't read env, so this is
+    # rendered to a literal at template time. Default 8000.
+    upstream inferia_app { server inferia-app:8000; keepalive 32; }
 
-    # Shared proxy headers.
     proxy_http_version 1.1;
     proxy_set_header Host              $host;
     proxy_set_header X-Real-IP         $remote_addr;
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host  $host;
-    # Tell the backend which sub-path it's mounted under (FastAPI root_path etc.)
-    proxy_set_header X-Forwarded-Prefix $http_x_forwarded_prefix;
 
     # -------------------------------------------------------------------------
-    # HTTP -> HTTPS redirect.
+    # HTTP -> HTTPS redirect (+ ACME http-01 challenge passthrough).
     # -------------------------------------------------------------------------
     server {
         listen 80;
@@ -102,7 +96,7 @@ http {
     }
 
     # -------------------------------------------------------------------------
-    # Single TLS endpoint, path-routed.
+    # Single TLS endpoint -> forward EVERYTHING to the unified app.
     # -------------------------------------------------------------------------
     server {
         listen 443 ssl;
@@ -115,78 +109,26 @@ http {
         ssl_protocols       TLSv1.2 TLSv1.3;
         ssl_ciphers         HIGH:!aNULL:!MD5;
 
-        # ---- /gw/ -> API gateway (prefix stripped) --------------------------
-        # Carries auth, api/v1, management, admin, audit AND the worker control
-        # WebSocket + shell/logs tunnels, so it needs upgrade + long timeouts.
-        location ^~ /gw/ {
-            proxy_pass http://inferia_gateway/;   # trailing slash strips /gw/
-            proxy_set_header X-Forwarded-Prefix /gw;
-            proxy_set_header Upgrade    $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            proxy_read_timeout  3600s;
-            proxy_send_timeout  3600s;
-        }
-
-        # ---- /inf/ -> inference API (prefix stripped) -----------------------
-        # OpenAI-style /v1/* endpoints; chat completions stream as SSE so
-        # buffering MUST be off or tokens arrive in one lump at the end.
-        location ^~ /inf/ {
-            proxy_pass http://inferia_inference/;  # trailing slash strips /inf/
-            proxy_set_header X-Forwarded-Prefix /inf;
-            proxy_buffering         off;
-            proxy_request_buffering off;
-            proxy_set_header        Connection "";
-            chunked_transfer_encoding on;
-            proxy_read_timeout  3600s;
-            proxy_send_timeout  3600s;
-            add_header X-Accel-Buffering no always;
-        }
-
-        # ---- model cache mirrors (/hf/* and /v2/* verbatim to gateway) --------
-        # The worker's vLLM (HF_ENDPOINT) and ollama (registry) containers fetch
-        # model weights from the CP cache through these. They MUST sit at the
-        # host root with NO prefix strip:
-        #   * vLLM/huggingface_hub: HF_ENDPOINT=https://<host>/hf
-        #   * ollama: `ollama pull <host>/library/<name>:<tag>` derives the
-        #     registry as https://<host>/v2/ — ollama CANNOT use a path-prefixed
-        #     registry (e.g. /gw/v2 will NOT work), so /v2 must be at the root.
-        # Multi-GB weight files stream straight through: buffering off AND
-        # proxy_max_temp_file_size 0 so nginx never spools a huge body to disk.
-        location ^~ /hf/ {
-            proxy_pass http://inferia_gateway;
-            proxy_buffering off;
-            proxy_request_buffering off;
-            proxy_max_temp_file_size 0;
-            proxy_read_timeout 3600s;
-            proxy_send_timeout 3600s;
-        }
-        location ^~ /v2/ {
-            proxy_pass http://inferia_gateway;
-            proxy_buffering off;
-            proxy_request_buffering off;
-            proxy_max_temp_file_size 0;
-            proxy_read_timeout 3600s;
-            proxy_send_timeout 3600s;
-        }
-
-        # ---- absolute-fetch fallbacks (dashboard calls that ignore config) --
-        # RetryProvisioningButton.tsx -> fetch('/api/v1/nodes/.../retry')
-        location ^~ /api/ {
-            proxy_pass http://inferia_gateway;     # no strip: gateway serves /api/*
-            proxy_set_header Upgrade    $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            proxy_read_timeout  3600s;
-        }
-        # authService.ts -> fetch('/auth/logout'). Exact match so the SPA's
-        # /auth/login PAGE (and any other /auth/* client route) stays on the SPA.
-        location = /auth/logout {
-            proxy_pass http://inferia_gateway/auth/logout;
-        }
-
-        # ---- everything else -> dashboard SPA -------------------------------
         location / {
-            proxy_pass http://inferia_dashboard;
-            proxy_read_timeout 300s;
+            proxy_pass http://inferia_app;          # verbatim path; app routes /api,/inf,/v2,/
+
+            # WebSocket: /api/v1/workers/channel (worker control), shell/logs tunnels.
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+
+            # Streaming, both directions:
+            #   * SSE chat completions (/inf/v1/chat/completions) — tokens must
+            #     flush, not buffer.
+            #   * multi-GB model-weight downloads through /api/hf and /v2 — never
+            #     spool a huge body to a temp file.
+            proxy_buffering          off;
+            proxy_request_buffering  off;
+            proxy_max_temp_file_size 0;
+            add_header X-Accel-Buffering no always;
+
+            # Long-lived: model pulls, deploy waits, WS channels, log tails.
+            proxy_read_timeout  3600s;
+            proxy_send_timeout  3600s;
         }
     }
 }
@@ -204,12 +146,13 @@ http {
 #       - "80:80"
 #       - "443:443"
 #     volumes:
-#       - ./nginx.conf:/etc/nginx/nginx.conf:ro
-#       - ./certs:/etc/nginx/certs:ro          # fullchain.pem + privkey.pem per host
-#       - ./certbot-www:/var/www/certbot       # only if using certbot http-01
+#       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
+#       - ./docker/certs:/etc/nginx/certs:ro    # fullchain.pem + privkey.pem per host
+#       - ./docker/certbot-www:/var/www/certbot # only if using certbot http-01
 #     networks:
 #       - inferia-net
 #
-# With the proxy in front, the app container no longer needs to publish
-# 8000/8001/3001 publicly -- drop those `ports:` and expose only nginx (80/443).
+# With the proxy in front, the app no longer needs to publish its port
+# publicly -- drop the app `ports:` mapping and expose only nginx (80/443).
+# (If APP_PORT is not 8000, change the `upstream inferia_app` server line.)
 # =============================================================================


### PR DESCRIPTION
## Proxy / hosting docs for the single-port app

Follow-up to the single-port consolidation (#270). Updates the reverse-proxy config + adds a hosting guide now that `inferia-app` serves the whole web surface (`/` dashboard, `/api` gateway, `/inf` inference, `/v2` ollama mirror) from one port (`APP_PORT`, default 8000).

- **`docker/nginx.conf`** — rewritten from the old multi-port split (`/gw`→8000, `/inf`→8001, `/`→3001 + prefix-strip + absolute-fetch fallbacks) to a **single upstream**: one `location /` forwarding every path verbatim to `inferia-app:8000`, with WebSocket upgrade, `proxy_buffering off` (SSE + multi-GB model pulls), large body, and long timeouts. Syntax-validated on the deploy network.
- **`docker/README.md`** (new) — hosting guide covering: the one rule (forward all paths → APP_PORT), required env, the `/v2`-must-stay-at-root caveat for ollama, and per-tool setup for **no-proxy / Caddy / nginx / Nginx Proxy Manager / Traefik / Cloudflare Tunnel** — including the exact NPM Proxy Host + Advanced-tab entries and a note that **no subdirectory/custom-location redirection is needed** anymore.

Caddyfiles (`Caddyfile.localhost`, `Caddyfile.sso`) were already single-upstream from #270; no change.
