### PR TITLE
fix: orchestration DSN scheme (failed to load pools/dashboard) + SPA websocket reject

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ INFERIA_BAKE_SSM_INSTANCE_PROFILE=inferia-engine-ami-builder
 # --- Postgres ---
 POSTGRES_USER=inferia
 POSTGRES_PASSWORD=
-DATABASE_URL="postgresql+asyncpg://inferia:CHANGEME@postgres:5432/inferia"
+DATABASE_URL="postgresql://inferia:CHANGEME@postgres:5432/inferia"
 DATABASE_SSL=false
 PG_ADMIN_USER=inferia
 PG_ADMIN_PASSWORD=

--- a/src/orchestration/config.py
+++ b/src/orchestration/config.py
@@ -4,7 +4,7 @@ Orchestration Service Configuration
 
 import os
 from typing import Any, ClassVar, Optional
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 from common.unified_config import UnifiedBaseSettings
 
@@ -85,6 +85,24 @@ class Settings(UnifiedBaseSettings):
     # Pydantic will check DATABASE_URL first.
     # If using POSTGRES_DSN env var, explicit support could be added via alias_priority
     # but Pydantic standardizes on one usually. We'll stick to typical pattern.
+
+    @field_validator("postgres_dsn")
+    @classmethod
+    def _bare_pg_scheme(cls, v: str) -> str:
+        """Normalize a SQLAlchemy-style DSN to the bare driver for asyncpg.
+
+        Orchestration passes ``postgres_dsn`` straight to ``asyncpg.create_pool``,
+        which ONLY accepts ``postgresql://`` / ``postgres://`` and REJECTS a
+        SQLAlchemy scheme like ``postgresql+asyncpg://`` ("invalid DSN: scheme is
+        expected to be either postgresql or postgres"). The api_gateway adds the
+        ``+asyncpg`` suffix itself, so a single shared ``DATABASE_URL`` is written
+        bare; this strips any ``+driver`` so orchestration tolerates either form.
+        """
+        if isinstance(v, str) and "://" in v:
+            scheme, rest = v.split("://", 1)
+            if "+" in scheme:
+                return f"{scheme.split('+', 1)[0]}://{rest}"
+        return v
 
     # Redis
     redis_host: str = Field(default="localhost", validation_alias="REDIS_HOST")

--- a/src/tests/orchestration/test/test_dsn_normalization.py
+++ b/src/tests/orchestration/test/test_dsn_normalization.py
@@ -1,0 +1,35 @@
+"""Orchestration must hand asyncpg a bare postgresql:// DSN.
+
+`asyncpg.create_pool` rejects SQLAlchemy-style schemes (`postgresql+asyncpg://`)
+with "invalid DSN: scheme is expected to be either postgresql or postgres". The
+orchestration Settings strips any `+driver` from DATABASE_URL so a single shared
+DATABASE_URL (which the api_gateway uses by adding +asyncpg itself) works here.
+"""
+
+from orchestration.config import Settings
+
+
+def _dsn(value: str) -> str:
+    # init kwargs are highest precedence and run through the field validator.
+    return Settings(DATABASE_URL=value).postgres_dsn
+
+
+def test_strips_asyncpg_driver():
+    assert _dsn("postgresql+asyncpg://u:p@h:5432/db") == "postgresql://u:p@h:5432/db"
+
+
+def test_strips_other_drivers():
+    assert _dsn("postgresql+psycopg2://u:p@h/db") == "postgresql://u:p@h/db"
+
+
+def test_bare_postgresql_unchanged():
+    assert _dsn("postgresql://u:p@h:5432/db") == "postgresql://u:p@h:5432/db"
+
+
+def test_short_postgres_scheme_unchanged():
+    assert _dsn("postgres://u:p@h/db") == "postgres://u:p@h/db"
+
+
+def test_password_with_special_chars_preserved():
+    # the split is on the first "://" only, so credentials/paths are untouched.
+    assert _dsn("postgresql+asyncpg://u:p@ss@h/db") == "postgresql://u:p@ss@h/db"

--- a/src/tests/unified_web/test_spa_websocket.py
+++ b/src/tests/unified_web/test_spa_websocket.py
@@ -1,0 +1,72 @@
+"""The "/" SPA catch-all must not crash on a stray WebSocket.
+
+A WebSocket whose path matches none of /api, /inf, /v2 falls through to the
+SPAStaticFiles mount at "/". Plain StaticFiles asserts scope["type"]=="http"
+and would raise AssertionError (unhandled ASGI exception) per stray WS — e.g.
+an old-config worker hitting bare /v1/workers/channel, or a probe. SPAStaticFiles
+must reject the websocket cleanly instead.
+"""
+
+import pytest
+
+from unified_web.spa import SPAStaticFiles
+
+
+@pytest.mark.asyncio
+async def test_websocket_is_closed_not_asserted(tmp_path):
+    (tmp_path / "index.html").write_text("<!doctype html><html></html>")
+    app = SPAStaticFiles(directory=str(tmp_path), html=True)
+
+    scope = {"type": "websocket", "path": "/v1/workers/channel", "headers": []}
+    sent = []
+
+    async def receive():
+        return {"type": "websocket.connect"}
+
+    async def send(message):
+        sent.append(message)
+
+    # Must NOT raise AssertionError.
+    await app(scope, receive, send)
+
+    assert sent and sent[-1]["type"] == "websocket.close"
+
+
+@pytest.mark.asyncio
+async def test_http_still_serves_index(tmp_path):
+    (tmp_path / "index.html").write_text("<!doctype html><html>app</html>")
+    app = SPAStaticFiles(directory=str(tmp_path), html=True)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/deep/spa/route",
+        "headers": [],
+    }
+    messages = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        messages.append(message)
+
+    await app(scope, receive, send)
+
+    start = next(m for m in messages if m["type"] == "http.response.start")
+    assert start["status"] == 200  # SPA fallback served index.html
+
+
+@pytest.mark.asyncio
+async def test_lifespan_scope_ignored(tmp_path):
+    (tmp_path / "index.html").write_text("<!doctype html>")
+    app = SPAStaticFiles(directory=str(tmp_path), html=True)
+
+    async def receive():
+        return {"type": "lifespan.startup"}
+
+    async def send(message):  # pragma: no cover - should not be called
+        raise AssertionError("lifespan scope must be ignored, not handled")
+
+    # Must return without raising.
+    await app({"type": "lifespan"}, receive, send)

--- a/src/unified_web/spa.py
+++ b/src/unified_web/spa.py
@@ -27,6 +27,23 @@ class SPAStaticFiles(StaticFiles):
     handle both the raised-exception path and a returned 404.
     """
 
+    async def __call__(self, scope, receive, send) -> None:
+        # The "/" SPA mount is the catch-all, so a WebSocket whose path matches
+        # none of /api, /inf, /v2 falls through to here. StaticFiles only serves
+        # HTTP and ``assert scope["type"] == "http"`` would raise AssertionError
+        # (an ugly unhandled ASGI exception logged per stray WS). Reject the
+        # websocket cleanly and ignore other non-http scopes instead.
+        if scope["type"] == "websocket":
+            try:
+                await receive()  # consume the websocket.connect event
+            except Exception:
+                pass
+            await send({"type": "websocket.close", "code": 1000})
+            return
+        if scope["type"] != "http":
+            return
+        await super().__call__(scope, receive, send)
+
     def _is_spa_route(self, path: str) -> bool:
         return "." not in path.rsplit("/", 1)[-1]
 


### PR DESCRIPTION
## Fix: dashboard "failed to load pools" / "Failed to load dashboard data"

Root cause: after the single-port cutover the **orchestration service crashed on boot**:

```
[FATAL] Orchestration Service failed to start: invalid DSN: scheme is expected
to be either "postgresql" or "postgres", got 'postgresql+asyncpg'
```

The dashboard's pools / deployments / insights load through the gateway, which **proxies them to orchestration** (`localhost:8080`). With orchestration down every such call failed → the two error toasts. The regression came from the `.env` minimisation that switched `DATABASE_URL` to `postgresql+asyncpg://`; the api_gateway normalizes that, but orchestration passes the DSN **straight to `asyncpg.create_pool`**, which rejects the SQLAlchemy `+asyncpg` scheme.

### Fixes
- **`orchestration/config.py`** — a `postgres_dsn` validator strips any `+driver` so orchestration tolerates either `postgresql://` or `postgresql+asyncpg://` (robust against recurrence).
- **`.env` / `.env.example`** — `DATABASE_URL` back to the canonical bare `postgresql://` (accepted by both the gateway, which adds `+asyncpg` itself, and asyncpg).
- **`unified_web/spa.py`** — the `/` SPA catch-all now rejects stray WebSockets cleanly instead of raising `AssertionError` (a second issue the logs revealed: a WS to a non-`/api` path was crashing StaticFiles with an unhandled ASGI exception).

### Verification (live, on the running container after rebuild + recreate)
- Orchestration boots; `localhost:8080/health` → 200; no DSN crash, no AssertionError.
- The actual dashboard endpoints with a real token: `listPools` 200 (returns pools), `deployment/deployments` 200, `management/.../recent-logs` 200, `organizations/me` 200.
- 31 new/related unit tests pass (DSN normalization + SPA websocket reject).
