### PR TITLE
fix: 405 Method Not Allowed (sandbox chat + logout) — route co-located calls via /api,/inf

### DIFF
--- a/apps/dashboard/src/services/__tests__/authService.test.ts
+++ b/apps/dashboard/src/services/__tests__/authService.test.ts
@@ -172,14 +172,16 @@ describe("logout", () => {
     vi.unstubAllEnvs();
   });
 
-  it("local mode: clears the token store, POSTs /auth/logout, then redirects to /login", async () => {
+  it("local mode: clears the token store, POSTs the gateway-mounted /auth/logout, then redirects to /login", async () => {
     vi.stubEnv("VITE_AUTH_PROVIDER", "local");
     await logout();
     expect(clearSpy).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith("/auth/logout", {
-      method: "POST",
-      credentials: "include",
-    });
+    // Must hit the gateway under its mount prefix (default base http://localhost:8000),
+    // NOT a bare /auth/logout which falls through to the SPA catch-all → 405.
+    const [calledUrl, calledOpts] = fetchMock.mock.calls[0];
+    expect(calledUrl).toMatch(/\/auth\/logout$/);
+    expect(calledUrl).not.toBe("/auth/logout");
+    expect(calledOpts).toMatchObject({ method: "POST", credentials: "include" });
     expect(assignMock).toHaveBeenCalledWith("/login");
   });
 
@@ -188,10 +190,10 @@ describe("logout", () => {
     vi.stubEnv("VITE_EXTERNAL_AUTH_URL", "https://auth.inferia.local");
     await logout();
     expect(clearSpy).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith("/auth/logout", {
-      method: "POST",
-      credentials: "include",
-    });
+    const [logoutUrl, logoutOpts] = fetchMock.mock.calls[0];
+    expect(logoutUrl).toMatch(/\/auth\/logout$/);
+    expect(logoutUrl).not.toBe("/auth/logout");
+    expect(logoutOpts).toMatchObject({ method: "POST", credentials: "include" });
     expect(assignMock).toHaveBeenCalledTimes(1);
     const dest = assignMock.mock.calls[0][0] as string;
     expect(dest).toMatch(/^https:\/\/auth\.inferia\.local\/api\/v1\/auth\/sso-logout\?/);

--- a/apps/dashboard/src/services/authService.ts
+++ b/apps/dashboard/src/services/authService.ts
@@ -91,7 +91,7 @@ export function consumeAccessTokenFragment(): string | null {
 export async function logout(): Promise<void> {
   tokenStore.clearToken();
   try {
-    await fetch("/auth/logout", { method: "POST", credentials: "include" });
+    await fetch(`${API_GATEWAY_URL}/auth/logout`, { method: "POST", credentials: "include" });
   } catch {
     // Network failure on the audit POST must not block the redirect.
   }

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -275,15 +275,37 @@ def run_skypilot_server(queue=None):
             queue.put(ServiceFailed("SkyPilot API Server", error=str(e)))
 
 
+def _set_unified_loopback_env(port: int) -> None:
+    """Point the co-located services at each other through the unified MOUNT
+    prefixes on the loopback. In unified mode the gateway is mounted at /api and
+    inference at /inf on the SAME port, so a co-located service calling the other
+    must use those prefixes. The inference data plane calls the gateway's
+    ``/internal/*`` (policy, context/resolve, completions, logs) via
+    ``API_GATEWAY_URL``, and the gateway reaches inference via ``INFERENCE_URL``.
+    Left at their split-mode defaults (gateway ``localhost:8000`` bare,
+    inference ``localhost:8001``) the bare ``/internal/...`` path falls through
+    to the ``/`` SPA StaticFiles catch-all → 405 Method Not Allowed on POST
+    (the visible "Method Not Allowed" in the sandbox chat and elsewhere), and
+    ``:8001`` no longer exists. setdefault so an explicit env (e.g. split mode)
+    still wins. MUST run before the service configs are imported — they read
+    these env vars at import time.
+    """
+    os.environ.setdefault("API_GATEWAY_URL", f"http://localhost:{port}/api")
+    os.environ.setdefault("INFERENCE_URL", f"http://localhost:{port}/inf")
+
+
 def run_unified_web(queue=None):
     """Serve the entire web surface (/api gateway, /inf inference, root /v2 OCI
     mirror, / dashboard SPA) from ONE uvicorn on APP_PORT. Replaces the separate
     api-gateway(:8000) + inference(:8001) + dashboard(:3001) processes."""
+    port = int(os.environ.get("APP_PORT", "8000"))
+    # Set inter-service loopback URLs BEFORE importing the configs (read at import).
+    _set_unified_loopback_env(port)
+
     from startup_events import ServiceStarting, ServiceStarted, ServiceFailed
     import uvicorn
     from api_gateway.config import settings as gw
 
-    port = int(os.environ.get("APP_PORT", "8000"))
     try:
         if queue:
             queue.put(ServiceStarting("Web (api+inf+dashboard)"))

--- a/src/tests/cli/test_unified_start.py
+++ b/src/tests/cli/test_unified_start.py
@@ -82,3 +82,46 @@ def test_unified_process_specs_returns_list_of_tuples():
         name, target = item
         assert isinstance(name, str), f"Name must be a string, got: {type(name)}"
         assert callable(target), f"Target must be callable, got: {type(target)}"
+
+
+def test_loopback_env_points_services_at_mount_prefixes(monkeypatch):
+    """In unified mode the co-located services must call each other via the
+    mount prefixes (/api, /inf) on the loopback, or bare /internal POSTs fall
+    through to the SPA catch-all and 405."""
+    from cli import _set_unified_loopback_env
+
+    monkeypatch.delenv("API_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("INFERENCE_URL", raising=False)
+
+    _set_unified_loopback_env(8000)
+
+    import os
+    assert os.environ["API_GATEWAY_URL"] == "http://localhost:8000/api"
+    assert os.environ["INFERENCE_URL"] == "http://localhost:8000/inf"
+
+
+def test_loopback_env_honors_app_port(monkeypatch):
+    from cli import _set_unified_loopback_env
+
+    monkeypatch.delenv("API_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("INFERENCE_URL", raising=False)
+
+    _set_unified_loopback_env(9100)
+
+    import os
+    assert os.environ["API_GATEWAY_URL"] == "http://localhost:9100/api"
+    assert os.environ["INFERENCE_URL"] == "http://localhost:9100/inf"
+
+
+def test_loopback_env_does_not_override_explicit(monkeypatch):
+    """setdefault: an explicit env (e.g. split mode) must win."""
+    from cli import _set_unified_loopback_env
+
+    monkeypatch.setenv("API_GATEWAY_URL", "http://gw.internal:8000")
+    monkeypatch.setenv("INFERENCE_URL", "http://inf.internal:8001")
+
+    _set_unified_loopback_env(8000)
+
+    import os
+    assert os.environ["API_GATEWAY_URL"] == "http://gw.internal:8000"
+    assert os.environ["INFERENCE_URL"] == "http://inf.internal:8001"


### PR DESCRIPTION
## Fix: "Method Not Allowed" (405) across the app, incl. sandbox chat

After the single-port cutover, many actions (notably sending a chat in the Sandbox) returned **405 Method Not Allowed**.

### Root cause
The unified app serves the gateway under `/api` and inference under `/inf` on ONE port, but the **co-located services still called each other over the loopback using their split-mode URLs**. The inference data plane delegates to the gateway's `/internal/*` (policy, **context/resolve**, completions, logs) via `API_GATEWAY_URL` (default `http://localhost:8000`). A **bare** `POST /internal/context/resolve` no longer matches `/api`, `/inf`, or `/v2`, so it fell through to the `/` SPA `StaticFiles` catch-all — which allows only GET/HEAD → **405 on POST**. That 405 propagated and broke chat completions (and any flow doing internal POSTs). The gateway's `INFERENCE_URL` (default `:8001`, now gone) had the mirror problem.

### Fixes
- **`cli/__init__.py` (`run_unified_web`)** — before importing the service configs, set the loopback URLs to the mount prefixes: `API_GATEWAY_URL=http://localhost:{APP_PORT}/api`, `INFERENCE_URL=http://localhost:{APP_PORT}/inf` (via `_set_unified_loopback_env`, `setdefault` so split mode still overrides). Co-located services now call each other through `/api` and `/inf`.
- **`dashboard/services/authService.ts`** — logout POSTed to a **bare** `/auth/logout` (→ SPA catch-all → 405); now hits the gateway-mounted `${API_GATEWAY_URL}/auth/logout`.

### Verified live (rebuilt + recreated `inferia-app`)
- Internal `POST /api/internal/context/resolve` → 200 (was 405).
- **Sandbox chat** `POST /inf/v1/chat/completions` (`x-sandbox: true`) → **200** with a real completion (Qwen3-0.6B).
- `POST /api/auth/logout` → 200 (was bare → 405).
- **0 × 405** in steady-state logs.
- 13 unit tests added/updated (loopback-env + logout); CLI + authService suites green.
