### PR TITLE
feat: per-node Metrics tab (CPU/mem/GPU/net/disk)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ UPSTREAM_HTTP_CONNECT_TIMEOUT_SECONDS=20
 
 # --- Worker/AWS ---
 INFERIA_WORKER_IMAGE=ghcr.io/inferiaai/inferia-worker
-INFERIA_WORKER_IMAGE_TAG=0.2.5
+INFERIA_WORKER_IMAGE_TAG=0.2.7
 INFERIA_BAKE_SSM_INSTANCE_PROFILE=inferia-engine-ami-builder
 
 # --- Postgres ---

--- a/apps/dashboard/src/components/nodes/NodeMetrics.test.tsx
+++ b/apps/dashboard/src/components/nodes/NodeMetrics.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import NodeMetrics from "./NodeMetrics";
+import * as workerService from "@/services/workerService";
+import type { NodeMetricsSample } from "@/services/workerService";
+
+// recharts ResponsiveContainer needs measured size jsdom lacks; stub it.
+vi.mock("recharts", async (orig) => {
+  const actual = await orig<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 260 }}>{children}</div>
+    ),
+  };
+});
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+const sample = (over: Partial<NodeMetricsSample> = {}): NodeMetricsSample => ({
+  ts: "2026-06-16T00:00:01Z", cpu_pct: 30, mem_used_bytes: 1024 ** 3,
+  mem_total_bytes: 4 * 1024 ** 3, net_rx_bps: 1024, net_tx_bps: 2048,
+  disk_read_bps: 512, disk_write_bps: 256,
+  gpus: [{ index: 0, name: "A100", util_pct: 50, mem_used_mib: 1024, mem_total_mib: 81920 }],
+  ...over,
+});
+
+describe("NodeMetrics", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("shows a placeholder when the node is not ready", () => {
+    wrap(<NodeMetrics nodeId="n1" nodeState="provisioning" currentPhase="bootstrapping" />);
+    expect(screen.getByText(/available once the worker registers/i)).toBeInTheDocument();
+  });
+
+  it("renders charts when ready with samples", async () => {
+    vi.spyOn(workerService, "getNodeMetrics").mockResolvedValue({
+      latest: sample(), samples: [sample(), sample({ ts: "2026-06-16T00:00:06Z" })],
+    });
+    wrap(<NodeMetrics nodeId="n1" nodeState="ready" />);
+    await waitFor(() => expect(screen.getByText(/CPU Utilization/i)).toBeInTheDocument());
+    expect(screen.getByText(/Memory/i)).toBeInTheDocument();
+    expect(screen.getByText(/GPU 0/i)).toBeInTheDocument();
+    expect(screen.getByText(/Network/i)).toBeInTheDocument();
+    expect(screen.getByText(/Disk/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when ready but no samples yet", async () => {
+    vi.spyOn(workerService, "getNodeMetrics").mockResolvedValue({ latest: null, samples: [] });
+    wrap(<NodeMetrics nodeId="n1" nodeState="ready" />);
+    await waitFor(() =>
+      expect(screen.getByText(/waiting for the first metrics sample/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows an error state when the request fails", async () => {
+    vi.spyOn(workerService, "getNodeMetrics").mockRejectedValue(new Error("boom"));
+    wrap(<NodeMetrics nodeId="n1" nodeState="ready" />);
+    await waitFor(() =>
+      expect(screen.getByText(/couldn.t load metrics/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows a loading state while the request is in flight", () => {
+    vi.spyOn(workerService, "getNodeMetrics").mockReturnValue(
+      new Promise(() => {}) as Promise<workerService.NodeMetricsResponse>,
+    );
+    wrap(<NodeMetrics nodeId="n1" nodeState="ready" />);
+    expect(screen.getByText(/loading metrics/i)).toBeInTheDocument();
+  });
+
+  it("omits GPU panels when the node has no GPUs", async () => {
+    const noGpu = (): workerService.NodeMetricsSample => ({
+      ts: "2026-06-16T00:00:01Z", cpu_pct: 10, mem_used_bytes: 1024 ** 3,
+      mem_total_bytes: 2 * 1024 ** 3, net_rx_bps: 1, net_tx_bps: 2,
+      disk_read_bps: 3, disk_write_bps: 4, gpus: [],
+    });
+    vi.spyOn(workerService, "getNodeMetrics").mockResolvedValue({
+      latest: noGpu(), samples: [noGpu()],
+    });
+    wrap(<NodeMetrics nodeId="n1" nodeState="ready" />);
+    await waitFor(() => expect(screen.getByText(/CPU Utilization/i)).toBeInTheDocument());
+    expect(screen.queryByText(/GPU Utilization/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/GPU VRAM/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/dashboard/src/components/nodes/NodeMetrics.tsx
+++ b/apps/dashboard/src/components/nodes/NodeMetrics.tsx
@@ -1,0 +1,143 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  Area, AreaChart, CartesianGrid, Legend, Line, LineChart,
+  ResponsiveContainer, Tooltip, XAxis, YAxis,
+} from "recharts";
+import { getNodeMetrics } from "@/services/workerService";
+import { formatBpsTick, gpuSeries, toChartRows } from "./metricsUtils";
+
+interface NodeMetricsProps {
+  nodeId: string;
+  nodeState?: string;
+  currentPhase?: string | null;
+}
+
+const GPU_COLORS = ["#2563eb", "#db2777", "#16a34a", "#9333ea", "#ea580c", "#0891b2"];
+
+function Panel({ title, children }: { title: string; children: React.ReactElement }) {
+  return (
+    <div className="rounded-xl border bg-card text-card-foreground shadow-sm p-4">
+      <h3 className="font-mono text-sm font-semibold mb-3">{title}</h3>
+      <ResponsiveContainer width="100%" height={220}>
+        {children}
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// Thin wrapper keeps the not-ready early-return free of hooks (Rules of Hooks).
+export default function NodeMetrics({ nodeId, nodeState, currentPhase }: NodeMetricsProps) {
+  if (nodeState && nodeState !== "ready") {
+    return (
+      <div className="rounded-md border bg-card p-6 text-sm text-muted-foreground">
+        Metrics available once the worker registers. Currently {currentPhase ?? "pending"}…
+      </div>
+    );
+  }
+  return <NodeMetricsLive nodeId={nodeId} />;
+}
+
+function NodeMetricsLive({ nodeId }: { nodeId: string }) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["node-metrics", nodeId],
+    queryFn: () => getNodeMetrics(nodeId),
+    refetchInterval: 5000,
+  });
+
+  if (isLoading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading metrics…</div>;
+  }
+  if (isError) {
+    return <div className="p-6 text-sm text-red-500">Couldn’t load metrics for this node.</div>;
+  }
+
+  const samples = data?.samples ?? [];
+  if (samples.length === 0) {
+    return (
+      <div className="rounded-md border bg-card p-6 text-sm text-muted-foreground">
+        Waiting for the first metrics sample from the worker…
+      </div>
+    );
+  }
+
+  const rows = toChartRows(samples);
+  const gpus = gpuSeries(samples);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <Panel title="CPU Utilization (%)">
+        <LineChart data={rows}>
+          <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+          <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={24} />
+          <YAxis tick={{ fontSize: 11 }} domain={[0, 100]} />
+          <Tooltip />
+          <Line type="monotone" dataKey="cpu_pct" stroke="#2563eb" strokeWidth={2} dot={false} name="CPU %" />
+        </LineChart>
+      </Panel>
+
+      <Panel title="Memory (GiB)">
+        <AreaChart data={rows}>
+          <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+          <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={24} />
+          <YAxis tick={{ fontSize: 11 }} />
+          <Tooltip />
+          <Area type="monotone" dataKey="mem_used_gib" stroke="#16a34a" fill="#16a34a" fillOpacity={0.35} name="Used GiB" />
+        </AreaChart>
+      </Panel>
+
+      {gpus.length > 0 && (
+        <Panel title={`GPU Utilization (%) — ${gpus.map((g) => g.label).join(", ")}`}>
+          <LineChart data={rows}>
+            <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+            <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={24} />
+            <YAxis tick={{ fontSize: 11 }} domain={[0, 100]} />
+            <Tooltip />
+            <Legend />
+            {gpus.map((g, i) => (
+              <Line key={g.key} type="monotone" dataKey={g.key} stroke={GPU_COLORS[i % GPU_COLORS.length]} strokeWidth={2} dot={false} name={`${g.label} (${g.name})`} />
+            ))}
+          </LineChart>
+        </Panel>
+      )}
+
+      {gpus.length > 0 && (
+        <Panel title="GPU VRAM (GiB)">
+          <AreaChart data={rows}>
+            <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+            <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={24} />
+            <YAxis tick={{ fontSize: 11 }} />
+            <Tooltip />
+            <Legend />
+            {gpus.map((g, i) => (
+              <Area key={g.vramKey} type="monotone" dataKey={g.vramKey} stroke={GPU_COLORS[i % GPU_COLORS.length]} fill={GPU_COLORS[i % GPU_COLORS.length]} fillOpacity={0.25} name={`${g.label} VRAM`} />
+            ))}
+          </AreaChart>
+        </Panel>
+      )}
+
+      <Panel title="Network (per second)">
+        <LineChart data={rows}>
+          <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+          <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={24} />
+          <YAxis tick={{ fontSize: 11 }} tickFormatter={formatBpsTick} width={80} />
+          <Tooltip formatter={formatBpsTick} />
+          <Legend />
+          <Line type="monotone" dataKey="net_rx_bps" stroke="#0891b2" strokeWidth={2} dot={false} name="RX" />
+          <Line type="monotone" dataKey="net_tx_bps" stroke="#ea580c" strokeWidth={2} dot={false} name="TX" />
+        </LineChart>
+      </Panel>
+
+      <Panel title="Disk I/O (per second)">
+        <LineChart data={rows}>
+          <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+          <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={24} />
+          <YAxis tick={{ fontSize: 11 }} tickFormatter={formatBpsTick} width={80} />
+          <Tooltip formatter={formatBpsTick} />
+          <Legend />
+          <Line type="monotone" dataKey="disk_read_bps" stroke="#9333ea" strokeWidth={2} dot={false} name="Read" />
+          <Line type="monotone" dataKey="disk_write_bps" stroke="#db2777" strokeWidth={2} dot={false} name="Write" />
+        </LineChart>
+      </Panel>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/nodes/metricsUtils.test.ts
+++ b/apps/dashboard/src/components/nodes/metricsUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatBytes, formatBps, toChartRows, gpuSeries } from "./metricsUtils";
+import { formatBytes, formatBps, formatBpsTick, toChartRows, gpuSeries } from "./metricsUtils";
 import type { NodeMetricsSample } from "@/services/workerService";
 
 describe("formatBytes", () => {
@@ -26,6 +26,14 @@ describe("formatBps", () => {
   it("appends /s", () => {
     expect(formatBps(0)).toBe("0 B/s");
     expect(formatBps(1024)).toBe("1.0 KiB/s");
+  });
+});
+
+describe("formatBpsTick", () => {
+  it("coerces number or string to a bps label", () => {
+    expect(formatBpsTick(1024)).toBe("1.0 KiB/s");
+    expect(formatBpsTick("2048")).toBe("2.0 KiB/s");
+    expect(formatBpsTick(0)).toBe("0 B/s");
   });
 });
 

--- a/apps/dashboard/src/components/nodes/metricsUtils.test.ts
+++ b/apps/dashboard/src/components/nodes/metricsUtils.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { formatBytes, formatBps, toChartRows, gpuSeries } from "./metricsUtils";
+import type { NodeMetricsSample } from "@/services/workerService";
+
+describe("formatBytes", () => {
+  it("formats byte magnitudes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(1024)).toBe("1.0 KiB");
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MiB");
+    expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0 GiB");
+  });
+
+  it("formats sub-KiB values as plain bytes", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1)).toBe("1 B");
+  });
+
+  it("returns 0 B for non-positive or non-finite input", () => {
+    expect(formatBytes(-1)).toBe("0 B");
+    expect(formatBytes(NaN)).toBe("0 B");
+    expect(formatBytes(Infinity)).toBe("0 B");
+  });
+});
+
+describe("formatBps", () => {
+  it("appends /s", () => {
+    expect(formatBps(0)).toBe("0 B/s");
+    expect(formatBps(1024)).toBe("1.0 KiB/s");
+  });
+});
+
+const sample = (over: Partial<NodeMetricsSample>): NodeMetricsSample => ({
+  ts: "2026-06-16T00:00:00Z", cpu_pct: 0, mem_used_bytes: 0, mem_total_bytes: 0,
+  net_rx_bps: 0, net_tx_bps: 0, disk_read_bps: 0, disk_write_bps: 0, gpus: [],
+  ...over,
+});
+
+describe("toChartRows", () => {
+  it("maps samples to chart rows with a short time label", () => {
+    const rows = toChartRows([sample({ cpu_pct: 12.3, mem_used_bytes: 1024 })]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cpu_pct).toBe(12.3);
+    expect(typeof rows[0].label).toBe("string");
+    expect(rows[0].mem_used_gib).toBeCloseTo(1024 / 1024 ** 3, 6);
+  });
+
+  it("handles an empty list", () => {
+    expect(toChartRows([])).toEqual([]);
+  });
+
+  it("falls back to raw ts when timestamp has no time component", () => {
+    const rows = toChartRows([sample({ ts: "no-time-here" })]);
+    expect(rows[0].label).toBe("no-time-here");
+  });
+
+  it("includes gpu util and vram keys when gpus are present", () => {
+    const rows = toChartRows([
+      sample({
+        gpus: [
+          { index: 0, name: "A100", util_pct: 55, mem_used_mib: 2048, mem_total_mib: 4096 },
+        ],
+      }),
+    ]);
+    expect(rows[0].gpu0_util).toBe(55);
+    expect(rows[0].gpu0_vram_gib).toBeCloseTo(2048 / 1024, 6);
+  });
+});
+
+describe("gpuSeries", () => {
+  it("returns one series descriptor per GPU index from the latest sample", () => {
+    const series = gpuSeries([
+      sample({ gpus: [
+        { index: 0, name: "A100", util_pct: 10, mem_used_mib: 1, mem_total_mib: 2 },
+        { index: 1, name: "A100", util_pct: 20, mem_used_mib: 3, mem_total_mib: 4 },
+      ] }),
+    ]);
+    expect(series.map((s) => s.key)).toEqual(["gpu0_util", "gpu1_util"]);
+    expect(series[0].label).toContain("GPU 0");
+  });
+
+  it("returns [] when there are no gpus", () => {
+    expect(gpuSeries([sample({})])).toEqual([]);
+    expect(gpuSeries([])).toEqual([]);
+  });
+});

--- a/apps/dashboard/src/components/nodes/metricsUtils.ts
+++ b/apps/dashboard/src/components/nodes/metricsUtils.ts
@@ -1,0 +1,74 @@
+import type { NodeMetricsSample } from "@/services/workerService";
+
+const UNITS = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+export function formatBytes(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "0 B";
+  let i = 0;
+  let v = n;
+  while (v >= 1024 && i < UNITS.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return i === 0 ? `${v} ${UNITS[i]}` : `${v.toFixed(1)} ${UNITS[i]}`;
+}
+
+export function formatBps(n: number): string {
+  return `${formatBytes(n)}/s`;
+}
+
+export interface ChartRow {
+  label: string;
+  cpu_pct: number;
+  mem_used_gib: number;
+  mem_total_gib: number;
+  net_rx_bps: number;
+  net_tx_bps: number;
+  disk_read_bps: number;
+  disk_write_bps: number;
+  [gpuKey: string]: number | string;
+}
+
+function shortTime(ts: string): string {
+  // "2026-06-16T12:34:56Z" -> "12:34:56". Falls back to the raw string.
+  const m = ts.match(/T(\d{2}:\d{2}:\d{2})/);
+  return m ? m[1] : ts;
+}
+
+export function toChartRows(samples: NodeMetricsSample[]): ChartRow[] {
+  return samples.map((s) => {
+    const row: ChartRow = {
+      label: shortTime(s.ts),
+      cpu_pct: s.cpu_pct,
+      mem_used_gib: s.mem_used_bytes / 1024 ** 3,
+      mem_total_gib: s.mem_total_bytes / 1024 ** 3,
+      net_rx_bps: s.net_rx_bps,
+      net_tx_bps: s.net_tx_bps,
+      disk_read_bps: s.disk_read_bps,
+      disk_write_bps: s.disk_write_bps,
+    };
+    for (const g of s.gpus) {
+      row[`gpu${g.index}_util`] = g.util_pct;
+      row[`gpu${g.index}_vram_gib`] = g.mem_used_mib / 1024;
+    }
+    return row;
+  });
+}
+
+export interface GpuSeriesDescriptor {
+  key: string;
+  vramKey: string;
+  label: string;
+  name: string;
+}
+
+export function gpuSeries(samples: NodeMetricsSample[]): GpuSeriesDescriptor[] {
+  const latest = samples.length ? samples[samples.length - 1] : null;
+  if (!latest || latest.gpus.length === 0) return [];
+  return latest.gpus.map((g) => ({
+    key: `gpu${g.index}_util`,
+    vramKey: `gpu${g.index}_vram_gib`,
+    label: `GPU ${g.index}`,
+    name: g.name,
+  }));
+}

--- a/apps/dashboard/src/components/nodes/metricsUtils.ts
+++ b/apps/dashboard/src/components/nodes/metricsUtils.ts
@@ -17,6 +17,13 @@ export function formatBps(n: number): string {
   return `${formatBytes(n)}/s`;
 }
 
+/** Formats a recharts axis tick / tooltip value (number or string) as a
+ * human-readable per-second byte rate. Centralised so the chart component
+ * carries no inline formatter lambdas. */
+export function formatBpsTick(value: number | string): string {
+  return formatBps(Number(value));
+}
+
 export interface ChartRow {
   label: string;
   cpu_pct: number;

--- a/apps/dashboard/src/pages/Compute/NodeDetail.test.tsx
+++ b/apps/dashboard/src/pages/Compute/NodeDetail.test.tsx
@@ -57,6 +57,18 @@ vi.mock("@/components/nodes/NodeLogs", () => ({
   ),
 }));
 
+// Stub NodeMetrics so its polling/recharts don't run in jsdom
+vi.mock("@/components/nodes/NodeMetrics", () => ({
+  default: ({ nodeId }: { nodeId: string }) => (
+    <div data-testid="node-metrics-stub">NodeMetrics:{nodeId}</div>
+  ),
+}));
+
+// Stub getNodeMetrics so the metrics route resolves cleanly
+vi.mock("@/services/workerService", () => ({
+  getNodeMetrics: vi.fn().mockResolvedValue({ latest: null, samples: [] }),
+}));
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -626,5 +638,24 @@ describe("NodeDetail", () => {
     });
     expect(navigateSpy).not.toHaveBeenCalled();
     confirmSpy.mockRestore();
+  });
+
+  // ── Tab order: Metrics appears before Shell and Logs ─────────────────────
+  it("has Metrics tab positioned before Shell and Logs tabs", async () => {
+    renderNodeDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("worker-1").length).toBeGreaterThan(0);
+    });
+
+    const links = await screen.findAllByRole("link");
+    const labels = links.map((l) => l.textContent ?? "");
+    const m = labels.indexOf("Metrics");
+    const s = labels.indexOf("Shell");
+    const lg = labels.indexOf("Logs");
+
+    expect(m).toBeGreaterThanOrEqual(0);
+    expect(m).toBeLessThan(s);
+    expect(m).toBeLessThan(lg);
   });
 });

--- a/apps/dashboard/src/pages/Compute/NodeDetail.tsx
+++ b/apps/dashboard/src/pages/Compute/NodeDetail.tsx
@@ -14,11 +14,12 @@ import { AWSMetadataGrid } from "@/components/nodes/AWSMetadataGrid";
 import ProvisioningStatus from "@/components/nodes/ProvisioningStatus";
 import NodeShell from "@/components/nodes/NodeShell";
 import NodeLogs from "@/components/nodes/NodeLogs";
+import NodeMetrics from "@/components/nodes/NodeMetrics";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-type NodeTab = "provisioning" | "ec2" | "shell" | "logs";
+type NodeTab = "provisioning" | "ec2" | "metrics" | "shell" | "logs";
 
 // ---------------------------------------------------------------------------
 // NodeDetail page
@@ -175,6 +176,7 @@ export default function NodeDetail() {
   const tabs: { label: string; value: NodeTab; hidden?: boolean }[] = [
     { label: "Provisioning Status", value: "provisioning" },
     { label: "EC2 Details", value: "ec2", hidden: !isAws },
+    { label: "Metrics", value: "metrics" },
     { label: "Shell", value: "shell" },
     { label: "Logs", value: "logs" },
   ];
@@ -332,6 +334,19 @@ export default function NodeDetail() {
             ) : (
               <Navigate to="../provisioning" replace />
             )
+          }
+        />
+
+        <Route
+          path="metrics"
+          element={
+            <NodeTabLayout tabs={tabs} activeTab="metrics" poolId={poolId} nid={nid}>
+              <NodeMetrics
+                nodeId={node.id}
+                nodeState={node.state}
+                currentPhase={summary?.current_phase}
+              />
+            </NodeTabLayout>
           }
         />
 

--- a/apps/dashboard/src/services/__tests__/workerService.test.ts
+++ b/apps/dashboard/src/services/__tests__/workerService.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  computeApi: { get: vi.fn() },
+}));
+
+import { computeApi } from "@/lib/api";
+import { getNodeMetrics } from "@/services/workerService";
+
+describe("getNodeMetrics", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("requests the node metrics endpoint and returns the payload", async () => {
+    (computeApi.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { latest: { ts: "b", cpu_pct: 2 }, samples: [{ ts: "a" }, { ts: "b" }] },
+    });
+    const res = await getNodeMetrics("node-1");
+    expect(computeApi.get).toHaveBeenCalledWith("/admin/workers/node-1/metrics");
+    expect(res.samples).toHaveLength(2);
+    expect(res.latest?.cpu_pct).toBe(2);
+  });
+
+  it("defaults to empty when the server returns nothing", async () => {
+    (computeApi.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: undefined });
+    const res = await getNodeMetrics("node-1");
+    expect(res).toEqual({ latest: null, samples: [] });
+  });
+});

--- a/apps/dashboard/src/services/workerService.ts
+++ b/apps/dashboard/src/services/workerService.ts
@@ -58,3 +58,35 @@ export async function listWorkers(poolId: string): Promise<WorkerView[]> {
 export async function revokeWorker(nodeId: string): Promise<void> {
   await computeApi.delete(`/admin/workers/${nodeId}`);
 }
+
+export interface GPUSample {
+  index: number;
+  name: string;
+  util_pct: number;
+  mem_used_mib: number;
+  mem_total_mib: number;
+}
+
+export interface NodeMetricsSample {
+  ts: string;
+  cpu_pct: number;
+  mem_used_bytes: number;
+  mem_total_bytes: number;
+  net_rx_bps: number;
+  net_tx_bps: number;
+  disk_read_bps: number;
+  disk_write_bps: number;
+  gpus: GPUSample[];
+}
+
+export interface NodeMetricsResponse {
+  latest: NodeMetricsSample | null;
+  samples: NodeMetricsSample[];
+}
+
+export async function getNodeMetrics(nodeId: string): Promise<NodeMetricsResponse> {
+  const res = await computeApi.get<NodeMetricsResponse>(
+    `/admin/workers/${nodeId}/metrics`,
+  );
+  return res.data ?? { latest: null, samples: [] };
+}

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
         "src/components/sandbox/markdownUtils.ts",
         "src/components/sandbox/ChatInterface.tsx",
         "src/components/nodes/metricsUtils.ts",
+        "src/components/nodes/NodeMetrics.tsx",
         "src/components/nodes/NodeShell.tsx",
         "src/components/nodes/NodeLogs.tsx",
         "src/components/deployment/TerminalLogs.tsx",

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         "src/components/sandbox/ThinkingBlock.tsx",
         "src/components/sandbox/markdownUtils.ts",
         "src/components/sandbox/ChatInterface.tsx",
+        "src/components/nodes/metricsUtils.ts",
         "src/components/nodes/NodeShell.tsx",
         "src/components/nodes/NodeLogs.tsx",
         "src/components/deployment/TerminalLogs.tsx",

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -830,11 +830,11 @@ def main(argv=None):
     )
     cmp_p.add_argument(
         "--worker-image",
-        default="ghcr.io/inferiaai/inferia-worker:0.1.0",
+        default="ghcr.io/inferiaai/inferia-worker:0.2.7",
         help="Worker container image (full repository:tag). Published via the "
              "InferiaAI/inferia-worker GitHub Action on v* tags. Note that "
              "docker/metadata-action strips the leading 'v' from semver tags, "
-             "so git tag v0.1.0 produces GHCR tag 0.1.0.",
+             "so git tag v0.2.7 produces GHCR tag 0.2.7.",
     )
     cmp_p.add_argument(
         "--inference-port", type=int, default=8080,

--- a/src/orchestration/api/admin_workers.py
+++ b/src/orchestration/api/admin_workers.py
@@ -179,6 +179,11 @@ class ListResponse(BaseModel):
     workers: list[WorkerView]
 
 
+class NodeMetricsResponse(BaseModel):
+    latest: dict | None = None
+    samples: list[dict] = []
+
+
 # ---------------------------------------------------------------------------
 # Endpoints.
 # ---------------------------------------------------------------------------
@@ -318,6 +323,19 @@ async def revoke_worker(
             pass
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/{node_id}/metrics", response_model=NodeMetricsResponse)
+async def get_node_metrics(
+    node_id: str,
+    _granted: bool = Depends(_need_perm("deployment:read")),
+):
+    """Live per-node resource metrics (CPU/mem/GPU/net/disk) from the worker
+    heartbeat ring buffer. Empty buffer (node just connected, never sent
+    metrics, or disconnected) -> {"latest": null, "samples": []} — not a 404."""
+    samples = _registry().get_metrics(node_id)
+    latest = samples[-1] if samples else None
+    return NodeMetricsResponse(latest=latest, samples=samples)
 
 
 # ---------------------------------------------------------------------------

--- a/src/orchestration/api/workers.py
+++ b/src/orchestration/api/workers.py
@@ -318,6 +318,10 @@ async def worker_channel(
                     loaded_models=hb.loaded_models,
                     deploy_metrics=[m.model_dump() for m in hb.deploy_metrics],
                 )
+                # Buffer the structured telemetry sample for the dashboard
+                # Metrics tab. Optional field — older workers omit it.
+                if hb.metrics is not None:
+                    registry.record_metrics(claims.sub, hb.metrics.model_dump())
             elif env_type == "CommandResult":
                 registry.deliver_command_result(
                     CommandResultBody(**body),

--- a/src/orchestration/config.py
+++ b/src/orchestration/config.py
@@ -148,8 +148,8 @@ class Settings(UnifiedBaseSettings):
     )
     worker_image_tag: str = Field(
         # docker/metadata-action's semver pattern strips the leading "v"
-        # from git tags, so the GHCR tag for git tag v0.1.0 is 0.1.0.
-        default="0.1.0",
+        # from git tags, so the GHCR tag for git tag v0.2.7 is 0.2.7.
+        default="0.2.7",
         validation_alias="INFERIA_WORKER_IMAGE_TAG",
     )
     bootstrap_token_ttl_seconds: int = Field(

--- a/src/orchestration/workers/worker_controller/protocol.py
+++ b/src/orchestration/workers/worker_controller/protocol.py
@@ -98,11 +98,32 @@ class DeployMetric(BaseModel):
     engine_metrics: EngineMetrics = Field(default_factory=EngineMetrics)
 
 
+class GPUSample(BaseModel):
+    index: int = 0
+    name: str = ""
+    util_pct: float = 0.0
+    mem_used_mib: int = 0
+    mem_total_mib: int = 0
+
+
+class MetricsSample(BaseModel):
+    ts: str = ""
+    cpu_pct: float = 0.0
+    mem_used_bytes: int = 0
+    mem_total_bytes: int = 0
+    net_rx_bps: float = 0.0
+    net_tx_bps: float = 0.0
+    disk_read_bps: float = 0.0
+    disk_write_bps: float = 0.0
+    gpus: list[GPUSample] = Field(default_factory=list)
+
+
 class HeartbeatBody(BaseModel):
     used: dict[str, str] = Field(default_factory=dict)
     loaded_models: list[str] = Field(default_factory=list)
     events: list[HeartbeatEvent] = Field(default_factory=list)
     deploy_metrics: list[DeployMetric] = Field(default_factory=list)
+    metrics: Optional[MetricsSample] = None
 
 
 class ModelRef(BaseModel):
@@ -259,6 +280,8 @@ __all__ = [
     "HeartbeatEvent",
     "DeployMetric",
     "EngineMetrics",
+    "GPUSample",
+    "MetricsSample",
     "LoadModelBody",
     "UnloadModelBody",
     "CommandResultBody",

--- a/src/orchestration/workers/worker_controller/registry.py
+++ b/src/orchestration/workers/worker_controller/registry.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol, Union
 
@@ -43,6 +44,12 @@ from .protocol import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Per-node in-memory metrics ring buffer size. Worker heartbeats fire ~every
+# 5s, so 360 samples ≈ 30 minutes of live history. Buffers exist only while a
+# node is connected (dropped on detach) and reset on control-plane restart —
+# this is live operational monitoring, not durable history.
+METRICS_RING_SIZE = 360
 
 
 StreamKind = Literal["shell", "logs"]
@@ -113,6 +120,9 @@ class WorkerRegistry:
         # use dict.get without the lock (atomic in CPython).
         self._streams: dict[str, StreamHandle] = {}
         self._lock = asyncio.Lock()
+        # node_id → deque of telemetry samples (ring buffer, maxlen=METRICS_RING_SIZE).
+        # Dropped on detach; never persisted.
+        self._metrics: dict[str, deque] = {}
 
     async def attach(self, node_id: str, conn: WorkerConn) -> None:
         """Register a new connection for node_id. Closes any existing one."""
@@ -143,6 +153,7 @@ class WorkerRegistry:
                 # alone — they belong to the newer conn.
                 return
             self._conns.pop(node_id, None)
+            self._metrics.pop(node_id, None)
             orphaned = [
                 handle
                 for handle in self._streams.values()
@@ -181,6 +192,7 @@ class WorkerRegistry:
         """
         async with self._lock:
             conn = self._conns.pop(node_id, None)
+            self._metrics.pop(node_id, None)
             orphaned = [
                 handle
                 for handle in self._streams.values()
@@ -250,6 +262,28 @@ class WorkerRegistry:
         if fut is None or fut.done():
             return
         fut.set_result(result)
+
+    # ------------------------------------------------------------------
+    # Per-node in-memory metrics ring buffer.
+    # ------------------------------------------------------------------
+
+    def record_metrics(self, node_id: str, sample: dict) -> None:
+        """Append one telemetry sample to the node's ring buffer.
+
+        Lock-free: dict.get/insert + deque.append are atomic in CPython and the
+        buffer is read by get_metrics the same way, so we avoid taking the async
+        lock on the hot heartbeat path.
+        """
+        buf = self._metrics.get(node_id)
+        if buf is None:
+            buf = deque(maxlen=METRICS_RING_SIZE)
+            self._metrics[node_id] = buf
+        buf.append(sample)
+
+    def get_metrics(self, node_id: str) -> list[dict]:
+        """Snapshot the node's buffered samples, oldest->newest. Empty if none."""
+        buf = self._metrics.get(node_id)
+        return list(buf) if buf is not None else []
 
     # ------------------------------------------------------------------
     # Shell + logs stream multiplexing.

--- a/src/tests/orchestration/api/test_admin_workers.py
+++ b/src/tests/orchestration/api/test_admin_workers.py
@@ -533,3 +533,43 @@ class TestRevokeAwsWorker:
         spawn.assert_not_called()
         jobs_repo_cls.assert_not_called()
         assert NODE_ID in inventory.terminated
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/admin/workers/{node_id}/metrics
+# ---------------------------------------------------------------------------
+
+
+class TestNodeMetrics:
+    def test_returns_latest_and_samples(self, app_and_deps):
+        app, _auth, registry, *_ = app_and_deps
+        registry.record_metrics(NODE_ID, {"ts": "a", "cpu_pct": 1.0})
+        registry.record_metrics(NODE_ID, {"ts": "b", "cpu_pct": 2.0})
+        client = TestClient(app)
+        r = client.get(
+            f"/v1/admin/workers/{NODE_ID}/metrics",
+            headers={"Authorization": "Bearer deployment:read"},
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert [s["ts"] for s in data["samples"]] == ["a", "b"]
+        assert data["latest"]["ts"] == "b"
+
+    def test_empty_buffer_returns_null_latest_not_404(self, app_and_deps):
+        app, *_ = app_and_deps
+        client = TestClient(app)
+        r = client.get(
+            f"/v1/admin/workers/{NODE_ID}/metrics",
+            headers={"Authorization": "Bearer deployment:read"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json() == {"latest": None, "samples": []}
+
+    def test_requires_permission(self, app_and_deps):
+        app, *_ = app_and_deps
+        client = TestClient(app)
+        r = client.get(
+            f"/v1/admin/workers/{NODE_ID}/metrics",
+            headers={"Authorization": "Bearer some:other"},
+        )
+        assert r.status_code == 403

--- a/src/tests/orchestration/api/test_workers.py
+++ b/src/tests/orchestration/api/test_workers.py
@@ -97,7 +97,7 @@ class FakeInventory:
     async def update_heartbeat(self, *, node_id, used, loaded_models):
         self.heartbeats.append({"node_id": node_id, "used": used, "loaded_models": loaded_models})
 
-    async def update_heartbeat_with_telemetry(self, *, node_id, used, loaded_models):
+    async def update_heartbeat_with_telemetry(self, *, node_id, used, loaded_models, deploy_metrics=None):
         self.heartbeats.append({"node_id": node_id, "used": used, "loaded_models": loaded_models})
 
 
@@ -674,3 +674,95 @@ def test_channel_unknown_stream_id_is_dropped_not_fatal(app_and_deps):
         _t.sleep(0.1)
     # If the channel had crashed, the context exit would have raised.
     assert True
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat metrics → registry ring buffer
+# ---------------------------------------------------------------------------
+
+
+def test_channel_heartbeat_with_metrics_recorded_into_registry(app_and_deps):
+    """A Heartbeat envelope with a non-null ``metrics`` field must land in the
+    registry's ring buffer for the sending node so the dashboard Metrics tab
+    can read it back.
+
+    NOTE: registry.detach() is called on WS disconnect and clears the node's
+    buffer, so we must assert INSIDE the websocket_connect context (while the
+    node is still attached)."""
+    app, auth, registry, _inv = app_and_deps
+    token = auth.mint_worker_token(node_id="node-metrics", pool_id=POOL_ID)
+    client = TestClient(app)
+    with client.websocket_connect(
+        "/v1/workers/channel",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as ws:
+        _hello = ws.receive_json()
+        ws.send_json({
+            "type": "Heartbeat",
+            "id": "hb-m1",
+            "body": {
+                "used": {},
+                "loaded_models": [],
+                "metrics": {"ts": "2026-01-01T00:00:00Z", "cpu_pct": 42.0, "gpus": []},
+            },
+        })
+        import time as _t
+        _t.sleep(0.1)
+        # Assert inside the WS context: detach() on disconnect clears the buffer.
+        samples = registry.get_metrics("node-metrics")
+        assert len(samples) == 1
+        assert samples[0]["ts"] == "2026-01-01T00:00:00Z"
+        assert samples[0]["cpu_pct"] == 42.0
+
+
+def test_channel_heartbeat_without_metrics_no_op_for_registry(app_and_deps):
+    """A Heartbeat envelope WITHOUT a ``metrics`` field must NOT append anything
+    to the registry ring buffer (backward-compat with older workers)."""
+    app, auth, registry, _inv = app_and_deps
+    token = auth.mint_worker_token(node_id="node-no-metrics", pool_id=POOL_ID)
+    client = TestClient(app)
+    with client.websocket_connect(
+        "/v1/workers/channel",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as ws:
+        _hello = ws.receive_json()
+        ws.send_json({
+            "type": "Heartbeat",
+            "id": "hb-nm1",
+            "body": {"used": {}, "loaded_models": []},
+        })
+        import time as _t
+        _t.sleep(0.1)
+        # Still inside context: buffer must remain empty when metrics is absent.
+        assert registry.get_metrics("node-no-metrics") == []
+
+
+def test_channel_heartbeat_metrics_accumulate_in_order(app_and_deps):
+    """Multiple Heartbeats with metrics must accumulate in the ring buffer in
+    send order so the dashboard can chart them as a time series.
+
+    NOTE: assert inside the WS context — detach() clears the buffer on close."""
+    app, auth, registry, _inv = app_and_deps
+    token = auth.mint_worker_token(node_id="node-multi-metrics", pool_id=POOL_ID)
+    client = TestClient(app)
+    with client.websocket_connect(
+        "/v1/workers/channel",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as ws:
+        _hello = ws.receive_json()
+        for i in range(3):
+            ws.send_json({
+                "type": "Heartbeat",
+                "id": f"hb-seq-{i}",
+                "body": {
+                    "used": {},
+                    "loaded_models": [],
+                    "metrics": {"ts": f"t{i}", "cpu_pct": float(i * 10), "gpus": []},
+                },
+            })
+        import time as _t
+        _t.sleep(0.2)
+        # Assert inside the WS context: detach() on disconnect clears the buffer.
+        samples = registry.get_metrics("node-multi-metrics")
+        assert len(samples) == 3
+        assert [s["ts"] for s in samples] == ["t0", "t1", "t2"]

--- a/src/tests/orchestration/worker_controller/test_protocol.py
+++ b/src/tests/orchestration/worker_controller/test_protocol.py
@@ -251,3 +251,40 @@ def test_envelope_wire_format_round_trip(env_type, body):
     rebuilt = Envelope.model_validate(wire)
     assert rebuilt.type == env_type
     assert rebuilt.body == body
+
+
+# --- HeartbeatBody metrics field ------------------------------------------
+
+
+from orchestration.workers.worker_controller.protocol import HeartbeatBody
+
+
+def test_heartbeat_parses_optional_metrics():
+    body = {
+        "used": {"cpu_pct": "10.0"},
+        "loaded_models": [],
+        "metrics": {
+            "ts": "2026-06-16T00:00:00Z",
+            "cpu_pct": 10.0,
+            "mem_used_bytes": 1024,
+            "mem_total_bytes": 4096,
+            "net_rx_bps": 5.0,
+            "net_tx_bps": 6.0,
+            "disk_read_bps": 7.0,
+            "disk_write_bps": 8.0,
+            "gpus": [
+                {"index": 0, "name": "NVIDIA A100", "util_pct": 42.0,
+                 "mem_used_mib": 100, "mem_total_mib": 81920},
+            ],
+        },
+    }
+    hb = HeartbeatBody.model_validate(body)
+    assert hb.metrics is not None
+    assert hb.metrics.cpu_pct == 10.0
+    assert hb.metrics.gpus[0].util_pct == 42.0
+    assert hb.metrics.gpus[0].mem_total_mib == 81920
+
+
+def test_heartbeat_without_metrics_is_backcompat():
+    hb = HeartbeatBody.model_validate({"used": {}, "loaded_models": []})
+    assert hb.metrics is None

--- a/src/tests/orchestration/worker_controller/test_registry.py
+++ b/src/tests/orchestration/worker_controller/test_registry.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from orchestration.workers.worker_controller.registry import (
+    METRICS_RING_SIZE,
     WorkerConn,
     WorkerRegistry,
 )
@@ -159,3 +160,56 @@ async def test_list_nodes():
     await reg.attach("b", WorkerConn(ws=FakeWS(), pool_id="p"))
     nodes = reg.list_nodes()
     assert set(nodes) == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Metrics ring buffer tests
+# ---------------------------------------------------------------------------
+
+
+class _MetricsFakeWS:
+    async def send_json(self, payload): ...
+    async def close(self, code: int = 1000, reason: str = ""): ...
+
+
+def test_record_and_get_metrics_orders_oldest_to_newest():
+    reg = WorkerRegistry()
+    reg.record_metrics("n1", {"ts": "a"})
+    reg.record_metrics("n1", {"ts": "b"})
+    samples = reg.get_metrics("n1")
+    assert [s["ts"] for s in samples] == ["a", "b"]
+
+
+def test_get_metrics_unknown_node_is_empty():
+    reg = WorkerRegistry()
+    assert reg.get_metrics("nope") == []
+
+
+def test_metrics_ring_trims_to_maxlen():
+    reg = WorkerRegistry()
+    for i in range(METRICS_RING_SIZE + 50):
+        reg.record_metrics("n1", {"ts": str(i)})
+    samples = reg.get_metrics("n1")
+    assert len(samples) == METRICS_RING_SIZE
+    assert samples[0]["ts"] == "50"
+    assert samples[-1]["ts"] == str(METRICS_RING_SIZE + 49)
+
+
+@pytest.mark.asyncio
+async def test_detach_drops_metrics_buffer():
+    reg = WorkerRegistry()
+    ws = _MetricsFakeWS()
+    await reg.attach("n1", WorkerConn(ws=ws, pool_id="p"))
+    reg.record_metrics("n1", {"ts": "a"})
+    await reg.detach("n1", ws)
+    assert reg.get_metrics("n1") == []
+
+
+@pytest.mark.asyncio
+async def test_detach_node_drops_metrics_buffer():
+    reg = WorkerRegistry()
+    ws = _MetricsFakeWS()
+    await reg.attach("n1", WorkerConn(ws=ws, pool_id="p"))
+    reg.record_metrics("n1", {"ts": "a"})
+    await reg.detach_node("n1")
+    assert reg.get_metrics("n1") == []


### PR DESCRIPTION
## Summary
- Adds a new per-node **Metrics** tab in the compute node detail view, placed before Shell and Logs (visible for every provider).
- Control plane: parses the worker heartbeat's optional structured `metrics` sample (new `MetricsSample`/`GPUSample` Pydantic models), buffers the last ~30 min per node in an in-memory ring buffer in `WorkerRegistry`, and serves it via `GET /v1/admin/workers/{node_id}/metrics`.
- Dashboard: `getNodeMetrics` service + pure formatting/series helpers + a `NodeMetrics` component that polls every 5s and charts CPU%, memory, per-GPU util & VRAM, network rx/tx, and disk read/write (recharts).
- Bumps `INFERIA_WORKER_IMAGE_TAG` to `0.2.7` — the worker release that emits this telemetry (ghcr.io/inferiaai/inferia-worker:0.2.7).

History is live-only (in-memory, reset on CP restart / node disconnect); the `metrics` field is optional both directions so old workers/CP interoperate.

## Test Plan
- [x] `pytest` — protocol/registry/workers/admin_workers suites pass (parsing, ring buffer + detach cleanup, heartbeat recording via a real WS TestClient, endpoint incl. empty→200 and perm→403)
- [x] `vitest` — service, helpers (100% cov), NodeMetrics (loading/error/empty/charts/no-GPU), and NodeDetail tab-order; `npm run build` clean
- [x] Cross-language wire contract verified field-by-field (Go ↔ Python ↔ TS)