### PR TITLE
Deployment overview pool/node links + correct active-GPU counts

### DIFF
--- a/apps/dashboard/src/components/deployment/DeploymentOverview.test.tsx
+++ b/apps/dashboard/src/components/deployment/DeploymentOverview.test.tsx
@@ -7,6 +7,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+// Pool name lookup for the clickable Pool row (avoids a real network call).
+vi.mock("@/services/poolService", () => ({
+  getPool: vi.fn(async () => ({ pool_name: "my-pool" })),
+}));
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -153,5 +159,44 @@ describe("DeploymentOverview — embedding endpoint display with relative INFERE
     const displayedUrl = endpointEl.textContent ?? "";
     expect(displayedUrl).toMatch(/^https?:\/\//);
     expect(displayedUrl).toContain("/inf/v1/embeddings");
+  });
+});
+
+describe("DeploymentOverview — clickable pool & node links", () => {
+  it("renders Pool and Node links pointing at the compute pages", async () => {
+    const { default: DeploymentOverview } = await import("./DeploymentOverview");
+    const dep = {
+      ...baseDeployment,
+      pool_id: "pool-123",
+      node_ids: ["node-abc"],
+    };
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+          <DeploymentOverview deployment={dep} />
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+    // Pool link (label is the id until the name query resolves; href is stable)
+    const poolLink = await screen.findByRole("link", { name: /my-pool|pool-123/ });
+    expect(poolLink).toHaveAttribute("href", "/dashboard/compute/pools/pool-123");
+    // Node link to the canonical node detail route
+    const nodeLink = screen.getByRole("link", { name: "node-abc" });
+    expect(nodeLink).toHaveAttribute(
+      "href",
+      "/dashboard/compute/pools/pool-123/nodes/node-abc"
+    );
+  });
+
+  it("hides Pool and Node rows for external deployments (no pool_id)", async () => {
+    const { default: DeploymentOverview } = await import("./DeploymentOverview");
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+          <DeploymentOverview deployment={baseDeployment} />
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+    expect(screen.queryByText("Pool")).toBeNull();
   });
 });

--- a/apps/dashboard/src/components/deployment/DeploymentOverview.tsx
+++ b/apps/dashboard/src/components/deployment/DeploymentOverview.tsx
@@ -4,6 +4,8 @@ import { cn } from "@/lib/utils"
 import { useState } from "react"
 import { INFERENCE_URL, api } from "@/lib/api"
 import { useQuery } from "@tanstack/react-query"
+import { Link } from "react-router-dom"
+import { getPool } from "@/services/poolService"
 
 interface DeploymentData {
     id?: string
@@ -20,6 +22,9 @@ interface DeploymentData {
     provider?: string
     git_repo?: string
     training_script?: string
+    pool_id?: string
+    node_ids?: string[]
+    target_node_id?: string | null
 }
 
 interface DeploymentOverviewProps {
@@ -59,6 +64,18 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
     const isVideoGen = deployment?.model_type === "video_generation" || deployment?.workload_type === "video"
     const isImageGen = deployment?.model_type === "image_generation" || (deployment?.engine === "inferia-diffusion" && !isVideoGen)
     const state = deployment?.state || deployment?.status || "Unknown"
+
+    // Resolve the pool name for the (clickable) Pool row; pool_id is present for
+    // every non-external deployment. Falls back to the id if the fetch fails.
+    const { data: poolInfo } = useQuery({
+        queryKey: ["pool", deployment?.pool_id],
+        enabled: !!deployment?.pool_id,
+        staleTime: 60_000,
+        queryFn: () => getPool(deployment!.pool_id!),
+    })
+    const nodeIds = (deployment?.node_ids && deployment.node_ids.length > 0)
+        ? deployment.node_ids
+        : (deployment?.target_node_id ? [deployment.target_node_id] : [])
 
     const { data: embeddingMetrics, isLoading: loadingLogMetrics } = useQuery({
         queryKey: ["deployment-overview-metrics", deploymentId],
@@ -216,6 +233,17 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                             <div className="text-xs text-muted-foreground font-mono mb-1">Replicas</div>
                             <div className="font-mono text-sm">1</div>
                         </div>
+                        {deployment?.pool_id && (
+                            <div>
+                                <div className="text-xs text-muted-foreground font-mono mb-1">Pool</div>
+                                <Link
+                                    to={`/dashboard/compute/pools/${deployment.pool_id}`}
+                                    className="font-mono text-sm text-ember-600 hover:underline break-all"
+                                >
+                                    {poolInfo?.pool_name ?? deployment.pool_id}
+                                </Link>
+                            </div>
+                        )}
                     </div>
                     <div className="space-y-6">
                         <div>
@@ -229,6 +257,24 @@ export default function DeploymentOverview({ deployment }: DeploymentOverviewPro
                                 <span className="bg-muted px-2 py-0.5 rounded text-xs font-mono border">provider: {deployment.provider}</span>
                             </div>
                         </div>
+                        {deployment?.pool_id && nodeIds.length > 0 && (
+                            <div>
+                                <div className="text-xs text-muted-foreground font-mono mb-1">
+                                    Node{nodeIds.length > 1 ? "s" : ""}
+                                </div>
+                                <div className="space-y-1">
+                                    {nodeIds.map((nid) => (
+                                        <Link
+                                            key={nid}
+                                            to={`/dashboard/compute/pools/${deployment.pool_id}/nodes/${nid}`}
+                                            className="block font-mono text-sm text-ember-600 hover:underline break-all"
+                                        >
+                                            {nid}
+                                        </Link>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </div>
                 </div>
 

--- a/src/orchestration/repositories/inventory_repo.py
+++ b/src/orchestration/repositories/inventory_repo.py
@@ -469,10 +469,18 @@ class InventoryRepository:
             return data
 
     async def mark_terminated(self, node_id: UUID):
+        # Zero the stored resource counters on terminate so the scheduler's
+        # capacity gate (allocate_gpu reads gpu_allocated) doesn't stay falsely
+        # full if a teardown path flipped the bound deployment terminal without
+        # an explicit release_gpu. (The dashboard now derives gpu_allocated live,
+        # but the scheduler still reads this stored counter.)
         query = """
         UPDATE compute_inventory
         SET
             state = 'terminated',
+            gpu_allocated = 0,
+            vcpu_allocated = 0,
+            ram_gb_allocated = 0,
             updated_at = now()
         WHERE id = $1
         """
@@ -1001,7 +1009,11 @@ async def _mark_terminated_worker_impl(self, *, node_id):
         await conn.execute(
             """
             UPDATE compute_inventory
-            SET state = 'terminated', updated_at = now()
+            SET state = 'terminated',
+                gpu_allocated = 0,
+                vcpu_allocated = 0,
+                ram_gb_allocated = 0,
+                updated_at = now()
             WHERE id = $1
             """,
             node_id,
@@ -1097,9 +1109,23 @@ async def _list_nodes_impl(self, *, org_id, selector=None):
     # Filter on owner_id only so we catch both canonical
     # owner_type='organization' rows and the legacy createpool path which
     # writes owner_type='user' with owner_id set to the org's UUID anyway.
+    # gpu_allocated is DERIVED LIVE from the active deployments bound to the
+    # node, NOT the stored compute_inventory.gpu_allocated counter. That stored
+    # counter drifts upward whenever a teardown path marks a deployment FAILED /
+    # a node terminated without calling release_gpu, which made the dashboard
+    # under-report free GPUs (and falsely report a pool "at capacity"). Deriving
+    # at read time is self-healing regardless of which path forgot to release.
+    # (The stored counter is still the scheduler's atomic capacity gate in
+    # allocate_gpu — untouched here; this only changes what the dashboard reads.)
     sql = (
         "SELECT i.id, i.pool_id, i.node_name, i.agent_kind, i.state,"
-        "       i.advertise_url, i.expose_url, i.gpu_total, i.gpu_allocated,"
+        "       i.advertise_url, i.expose_url, i.gpu_total,"
+        "       COALESCE(("
+        "         SELECT SUM(d.gpu_per_replica * d.replicas)"
+        "           FROM model_deployments d"
+        "          WHERE d.target_node_id = i.id"
+        "            AND d.state IN ('PENDING_NODE','DEPLOYING','RUNNING')"
+        "       ), 0) AS gpu_allocated,"
         "       i.vcpu_total, i.vcpu_allocated, i.ram_gb_total,"
         "       i.ram_gb_allocated, i.last_heartbeat, i.labels,"
         "       i.metadata, i.provider, i.provider_instance_id,"
@@ -1128,7 +1154,13 @@ async def _get_node_impl(self, *, node_id):
         row = await conn.fetchrow(
             """
             SELECT id, pool_id, node_name, agent_kind, state,
-                   advertise_url, expose_url, gpu_total, gpu_allocated,
+                   advertise_url, expose_url, gpu_total,
+                   COALESCE((
+                     SELECT SUM(d.gpu_per_replica * d.replicas)
+                       FROM model_deployments d
+                      WHERE d.target_node_id = compute_inventory.id
+                        AND d.state IN ('PENDING_NODE','DEPLOYING','RUNNING')
+                   ), 0) AS gpu_allocated,
                    vcpu_total, vcpu_allocated, ram_gb_total, ram_gb_allocated,
                    last_heartbeat, labels, metadata,
                    provider, provider_instance_id, created_at, updated_at

--- a/src/tests/orchestration/repositories/test_inventory_repo_gpu_refcount.py
+++ b/src/tests/orchestration/repositories/test_inventory_repo_gpu_refcount.py
@@ -246,3 +246,92 @@ async def test_create_placeholder_uses_external_tx(pool):
             )
             assert row["state"] == "provisioning"
             assert row["gpu_total"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Live-derived gpu_allocated (dashboard reads): list_nodes / get_node must
+# report GPU usage from ACTIVE deployments, not the drifting stored counter.
+# ---------------------------------------------------------------------------
+async def _seed_deployment(p, pool_id, node_id, *, state,
+                           gpu_per_replica=1, replicas=1):
+    dep_id = uuid4()
+    async with p.acquire() as c:
+        await c.execute(
+            """
+            INSERT INTO model_deployments(
+              deployment_id, model_name, replicas, gpu_per_replica,
+              pool_id, target_pool_id, target_node_id, state, org_id
+            ) VALUES ($1, 'm', $2, $3, $4, $4, $5, $6, $7)
+            """,
+            dep_id, replicas, gpu_per_replica, pool_id, node_id, state,
+            str(uuid4()),
+        )
+    return dep_id
+
+
+async def test_list_nodes_derives_gpu_allocated_from_active_deploys(pool):
+    repo = InventoryRepository(pool)
+    org_id, pool_id = await _seed_org_and_pool(pool)
+    # stored counter STALE (4) but only 1 GPU is actually in use
+    node_id = await _seed_node(pool, pool_id, gpu_total=4, gpu_allocated=4)
+    await _seed_deployment(pool, pool_id, node_id, state="RUNNING")
+    nodes = await repo.list_nodes(org_id=str(org_id))
+    n = next(x for x in nodes if x["id"] == node_id)
+    assert n["gpu_allocated"] == 1  # derived, NOT the stale stored 4
+
+
+async def test_get_node_derives_gpu_allocated(pool):
+    repo = InventoryRepository(pool)
+    _, pool_id = await _seed_org_and_pool(pool)
+    node_id = await _seed_node(pool, pool_id, gpu_total=4, gpu_allocated=4)
+    await _seed_deployment(pool, pool_id, node_id, state="DEPLOYING")
+    n = await repo.get_node(node_id=node_id)
+    assert n["gpu_allocated"] == 1
+
+
+async def test_derived_ignores_terminal_deployment(pool):
+    """An orphaned node whose deployment FAILED shows derived 0 (the exact
+    drift bug: stored counter stayed elevated)."""
+    repo = InventoryRepository(pool)
+    org_id, pool_id = await _seed_org_and_pool(pool)
+    node_id = await _seed_node(pool, pool_id, gpu_total=4, gpu_allocated=2)
+    await _seed_deployment(pool, pool_id, node_id, state="FAILED")
+    nodes = await repo.list_nodes(org_id=str(org_id))
+    n = next(x for x in nodes if x["id"] == node_id)
+    assert n["gpu_allocated"] == 0
+
+
+async def test_derived_counts_replicas_times_per_replica(pool):
+    repo = InventoryRepository(pool)
+    _, pool_id = await _seed_org_and_pool(pool)
+    node_id = await _seed_node(pool, pool_id, gpu_total=8, gpu_allocated=0)
+    await _seed_deployment(pool, pool_id, node_id, state="RUNNING",
+                           gpu_per_replica=2, replicas=3)
+    n = await repo.get_node(node_id=node_id)
+    assert n["gpu_allocated"] == 6  # 2 * 3
+
+
+async def test_derived_sums_multiple_active_deploys(pool):
+    repo = InventoryRepository(pool)
+    org_id, pool_id = await _seed_org_and_pool(pool)
+    node_id = await _seed_node(pool, pool_id, gpu_total=8, gpu_allocated=0)
+    await _seed_deployment(pool, pool_id, node_id, state="RUNNING")
+    await _seed_deployment(pool, pool_id, node_id, state="PENDING_NODE")
+    await _seed_deployment(pool, pool_id, node_id, state="TERMINATED")  # excluded
+    nodes = await repo.list_nodes(org_id=str(org_id))
+    n = next(x for x in nodes if x["id"] == node_id)
+    assert n["gpu_allocated"] == 2  # RUNNING + PENDING_NODE, not TERMINATED
+
+
+async def test_mark_terminated_zeroes_stored_counter(pool):
+    repo = InventoryRepository(pool)
+    _, pool_id = await _seed_org_and_pool(pool)
+    node_id = await _seed_node(pool, pool_id, gpu_total=4, gpu_allocated=3)
+    await repo.mark_terminated(node_id)
+    async with pool.acquire() as c:
+        row = await c.fetchrow(
+            "SELECT state, gpu_allocated FROM compute_inventory WHERE id=$1",
+            node_id,
+        )
+    assert row["state"] == "terminated"
+    assert row["gpu_allocated"] == 0


### PR DESCRIPTION
## Summary

- **Deployment Overview → clickable pool & node links.** The "Deployment Information" section now shows the **Pool** (links to the pool page) and **Node(s)** (each links to the node detail page) for every non-external deployment type. Pool name resolved via `getPool(pool_id)`; rows hide for external workloads / pre-assignment.
- **Correct active-GPU counts.** The dashboard summed each node's **stored** `gpu_allocated` counter, which drifts upward whenever a teardown path marks a deployment terminal / a node terminated without `release_gpu` (e.g. orphaned placeholder nodes held phantom GPUs → pools under-reported free GPUs and falsely hit "at capacity"). Fix: derive `gpu_allocated` **live from active deployments** in the dashboard reads (`list_nodes`/`get_node`), aliased so `_to_view` is unchanged — self-healing regardless of which teardown path forgot to release. The scheduler's atomic capacity gate (`allocate_gpu`) is untouched; the stored counter is additionally zeroed on terminate.

## Test Plan
- [x] 24 inventory integration tests vs a real PG (incl. 7 new: live derivation across PENDING_NODE/DEPLOYING/RUNNING, replica×per-replica multiplier, terminal-state excluded, terminate-zeroes-counter).
- [x] 7 DeploymentOverview tests (incl. 2 new asserting the Pool/Node link hrefs + external-workload hides them); dashboard build clean.
- [x] Live-verified: an orphaned placeholder node that reported `gpu_allocated=1` now derives `0`; a serving node correctly shows `1`.
- [ ] Post-merge: rebuild the unified image from main (changes are live via hot-patch).