### PR TITLE
fix: AWS deploy stuck DEPLOYING — re-drive orphaned load_model + visible failure reason

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,29 +24,36 @@ clean:
 # Docker Commands
 # ==========================================
 
-DOCKER_COMPOSE = docker compose -f docker/docker-compose.profiles.yml
+# The PRIMARY compose is the root ./docker-compose.yml (project: deploy) — the
+# canonical single-file unified stack (app + postgres + redis + ES/Logstash/
+# Kibana) that we actually run and deploy. Split mode is a dev-only topology
+# kept in the docker/ profiles file.
+DOCKER_COMPOSE = docker compose -f docker-compose.yml
+DOCKER_COMPOSE_SPLIT = docker compose -f docker/docker-compose.profiles.yml
 
 # Build images
 docker-build-unified:
-	$(DOCKER_COMPOSE) --profile unified build
+	$(DOCKER_COMPOSE) build
 
 docker-build-split:
-	$(DOCKER_COMPOSE) --profile split build
+	$(DOCKER_COMPOSE_SPLIT) --profile split build
 
 # Run services
 docker-up-unified:
-	$(DOCKER_COMPOSE) --profile unified up -d
+	$(DOCKER_COMPOSE) up -d
 
 docker-up-split:
-	$(DOCKER_COMPOSE) --profile split up -d
+	$(DOCKER_COMPOSE_SPLIT) --profile split up -d
 
-# Stop services
+# Stop services (tear down whichever topology is up; '-' ignores "not running")
 docker-down:
-	$(DOCKER_COMPOSE) --profile unified --profile split down
+	-$(DOCKER_COMPOSE) down
+	-$(DOCKER_COMPOSE_SPLIT) --profile split down
 
 # Clean up docker (volumes, orphans)
 docker-clean:
-	$(DOCKER_COMPOSE) --profile unified --profile split down -v --remove-orphans
+	-$(DOCKER_COMPOSE) down -v --remove-orphans
+	-$(DOCKER_COMPOSE_SPLIT) --profile split down -v --remove-orphans
 
 # ==========================================
 # SSO Topology (InferiaLLM + inferia-auth + Caddy)

--- a/src/orchestration/config.py
+++ b/src/orchestration/config.py
@@ -148,8 +148,10 @@ class Settings(UnifiedBaseSettings):
     )
     worker_image_tag: str = Field(
         # docker/metadata-action's semver pattern strips the leading "v"
-        # from git tags, so the GHCR tag for git tag v0.2.7 is 0.2.7.
-        default="0.2.7",
+        # from git tags, so the GHCR tag for git tag v0.2.8 is 0.2.8.
+        # 0.2.8 ships the load_model container-name idempotency fix
+        # (remove-before-create) that unsticks DEPLOYING deploys.
+        default="0.2.8",
         validation_alias="INFERIA_WORKER_IMAGE_TAG",
     )
     bootstrap_token_ttl_seconds: int = Field(

--- a/src/orchestration/models/model_deployment/deployment_linker.py
+++ b/src/orchestration/models/model_deployment/deployment_linker.py
@@ -154,107 +154,128 @@ class DeploymentLinker:
                     # else: bound to a DIFFERENT in-flight node — leave it for
                     # that node's on_worker_ready.
 
-        # Transaction committed. Fire load_model OUTSIDE the transaction.
+        # Transaction committed. Drive load_model OUTSIDE the transaction for
+        # the deploys we just bound.
         for deploy in bound:
-            gpu_required = int(deploy.get("gpu_per_replica") or 1)
-            try:
-                spec = _spec_from_pending(deploy, gpu_required)
-                try:
-                    from orchestration.config import settings as _s
-                    _mirror_base = getattr(_s, "model_mirror_base", "") or ""
-                except Exception:
-                    _mirror_base = ""
-                await resolve_and_apply_mirror(
-                    spec, recipe=spec["recipe"],
-                    artifact_uri=spec["model"]["artifact_uri"],
-                    mirror_base=_mirror_base, cache_repo=_mc_deps.get("repo"),
-                )
-                result = await self._controller.load_model(
-                    node_id=str(node_id), spec=spec,
-                )
-            except Exception as e:
-                logger.exception(
-                    "linker: load_model failed for deploy=%s: %s",
-                    deploy["id"], e,
-                )
-                # Atomic rollback: release GPU + mark FAILED in one txn so a
-                # partial failure can't leave gpu_allocated out of sync with
-                # deploy state.
-                async with self._db.acquire() as conn:
-                    async with conn.transaction():
-                        await self._inventory.release_gpu(
-                            node_id, gpu_required, tx=conn,
-                        )
-                        await self._deploys.set_state(
-                            deploy["id"], "FAILED", tx=conn,
-                        )
-            else:
-                # The worker can return a CommandResult with status='failed'
-                # (e.g. readiness probe timed out, pull failed) WITHOUT raising
-                # — controller.load_model returns the body verbatim. Treat that
-                # as a load failure: release the GPU + mark FAILED, and DO NOT
-                # publish an endpoint or report RUNNING (the model is not
-                # serving). Previously this fell through to the success branch
-                # and reported RUNNING for a model that never loaded.
-                if getattr(result, "status", None) == "failed":
-                    logger.error(
-                        "linker: load_model returned status=failed for "
-                        "deploy=%s: %s",
-                        deploy["id"], getattr(result, "detail", ""),
-                    )
-                    async with self._db.acquire() as conn:
-                        async with conn.transaction():
-                            await self._inventory.release_gpu(
-                                node_id, gpu_required, tx=conn,
-                            )
-                            await self._deploys.set_state(
-                                deploy["id"], "FAILED", tx=conn,
-                            )
-                    continue
+            await self._drive_deploy(node_id, deploy)
 
-                # Model loaded on the worker. Promote DEPLOYING → RUNNING so
-                # the dashboard reflects the live deployment. The warm-deploy
-                # path does this (controller/worker set RUNNING); the
-                # EC2-bootstrap path previously left the deploy stuck
-                # DEPLOYING forever even though the model was serving.
-                async with self._db.acquire() as conn:
-                    await self._deploys.set_state(
-                        deploy["id"], "RUNNING", tx=conn,
-                    )
-                # Publish the inference endpoint so the data plane can route
-                # to this worker's :8080 inference proxy. We use the node's
-                # CP-reachable advertise_url — NOT the worker's reported
-                # endpoint_url, which is a 127.0.0.1:<port> loopback useless
-                # to the control plane. The proxy auths with the pool
-                # inference_token and routes by X-Inferia-Deployment-Id; the
-                # inference data plane attaches both. Without this the
-                # deployment has endpoint='' and the sandbox "never connects
-                # to the node".
-                try:
-                    async with self._db.acquire() as conn:
-                        advertise = await conn.fetchval(
-                            "SELECT advertise_url FROM compute_inventory "
-                            "WHERE id=$1",
-                            node_id,
-                        )
-                    if advertise:
-                        await self._deploys.update_endpoint(
-                            deploy["id"], advertise,
-                        )
-                    else:
-                        logger.warning(
-                            "linker: node=%s has no advertise_url; deploy=%s "
-                            "endpoint not set (inference unreachable)",
-                            node_id, deploy["id"],
-                        )
-                except Exception:
-                    logger.exception(
-                        "linker: failed to set endpoint for deploy=%s",
-                        deploy["id"],
-                    )
-
-        if bound:
+        # RE-DRIVE orphaned DEPLOYING deploys. A deploy whose load_model was
+        # in flight when the control plane restarted (or whose linker task
+        # otherwise died) stays DEPLOYING forever: it is no longer PENDING_NODE
+        # so the bind loop above skips it, /start reprovisions a NEW node, and
+        # nothing else re-fires load_model — leaving the deployment "deploying"
+        # with no container on the worker. On worker (re)connect the prior
+        # control channel is dead, so re-firing load_model is safe + idempotent.
+        # Skip the ones we just drove above.
+        driven = {d["id"] for d in bound}
+        try:
+            orphaned = [
+                d for d in await self._deploys.list_deploying_for_node(node_id)
+                if d["id"] not in driven
+            ]
+        except Exception:
+            logger.exception(
+                "linker: failed to list orphaned DEPLOYING deploys for node=%s",
+                node_id,
+            )
+            orphaned = []
+        for deploy in orphaned:
             logger.info(
-                "linker: bound %d pending deploys to node=%s pool=%s",
-                len(bound), node_id, pool_id,
+                "linker: re-driving orphaned DEPLOYING deploy=%s on node=%s "
+                "(load_model never completed; control-plane restart?)",
+                deploy["id"], node_id,
+            )
+            await self._drive_deploy(node_id, deploy)
+
+        if bound or orphaned:
+            logger.info(
+                "linker: drove %d new + %d re-driven deploy(s) on node=%s pool=%s",
+                len(bound), len(orphaned), node_id, pool_id,
+            )
+
+    async def _drive_deploy(self, node_id: UUID, deploy: dict) -> None:
+        """Fire load_model for one already-bound deploy, then promote
+        DEPLOYING → RUNNING (and publish the endpoint) on success, or release
+        the GPU + mark FAILED on failure. The GPU was allocated at bind time, so
+        this never re-allocates — on failure it RELEASES the existing
+        allocation. Shared by the freshly-bound path and the orphan re-drive."""
+        gpu_required = int(deploy.get("gpu_per_replica") or 1)
+        try:
+            spec = _spec_from_pending(deploy, gpu_required)
+            try:
+                from orchestration.config import settings as _s
+                _mirror_base = getattr(_s, "model_mirror_base", "") or ""
+            except Exception:
+                _mirror_base = ""
+            await resolve_and_apply_mirror(
+                spec, recipe=spec["recipe"],
+                artifact_uri=spec["model"]["artifact_uri"],
+                mirror_base=_mirror_base, cache_repo=_mc_deps.get("repo"),
+            )
+            result = await self._controller.load_model(
+                node_id=str(node_id), spec=spec,
+            )
+        except Exception as e:
+            logger.exception(
+                "linker: load_model failed for deploy=%s: %s", deploy["id"], e,
+            )
+            # Atomic rollback: release GPU + mark FAILED in one txn so a
+            # partial failure can't leave gpu_allocated out of sync with state.
+            # Record the reason via update_state (NOT set_state) so the failure
+            # is VISIBLE in the deploy row + dashboard — set_state writes state
+            # only, which previously left load_model failures with an empty
+            # error_message and no clue why the container never started.
+            async with self._db.acquire() as conn:
+                async with conn.transaction():
+                    await self._inventory.release_gpu(
+                        node_id, gpu_required, tx=conn,
+                    )
+                    await self._deploys.update_state(
+                        deploy["id"], "FAILED", tx=conn,
+                        error_message=f"load_model error: {e}",
+                    )
+            return
+
+        # The worker can return a CommandResult with status='failed' (readiness
+        # probe timeout, pull failed) WITHOUT raising — treat that as a load
+        # failure: release the GPU + mark FAILED, do NOT report RUNNING.
+        if getattr(result, "status", None) == "failed":
+            detail = getattr(result, "detail", "") or "worker reported load failure"
+            logger.error(
+                "linker: load_model returned status=failed for deploy=%s: %s",
+                deploy["id"], detail,
+            )
+            async with self._db.acquire() as conn:
+                async with conn.transaction():
+                    await self._inventory.release_gpu(
+                        node_id, gpu_required, tx=conn,
+                    )
+                    await self._deploys.update_state(
+                        deploy["id"], "FAILED", tx=conn,
+                        error_message=f"load_model failed on worker: {detail}",
+                    )
+            return
+
+        # Model loaded on the worker. Promote DEPLOYING → RUNNING.
+        async with self._db.acquire() as conn:
+            await self._deploys.set_state(deploy["id"], "RUNNING", tx=conn)
+        # Publish the inference endpoint (the node's CP-reachable advertise_url,
+        # NOT the worker's 127.0.0.1 loopback) so the data plane can route.
+        try:
+            async with self._db.acquire() as conn:
+                advertise = await conn.fetchval(
+                    "SELECT advertise_url FROM compute_inventory WHERE id=$1",
+                    node_id,
+                )
+            if advertise:
+                await self._deploys.update_endpoint(deploy["id"], advertise)
+            else:
+                logger.warning(
+                    "linker: node=%s has no advertise_url; deploy=%s endpoint "
+                    "not set (inference unreachable)",
+                    node_id, deploy["id"],
+                )
+        except Exception:
+            logger.exception(
+                "linker: failed to set endpoint for deploy=%s", deploy["id"],
             )

--- a/src/orchestration/repositories/model_deployment_repo.py
+++ b/src/orchestration/repositories/model_deployment_repo.py
@@ -439,6 +439,29 @@ class ModelDeploymentRepository(BaseRepository):
                 rows = await conn.fetch(q, pool_id)
         return [dict(r) for r in rows]
 
+    async def list_deploying_for_node(self, node_id, *, tx=None):
+        """DEPLOYING deploys bound to a node — used by the linker to RE-DRIVE
+        load_model for deploys orphaned when the control plane restarted with an
+        in-flight load_model (the worker-channel ``on_worker_ready`` hook only
+        binds PENDING_NODE deploys, so an already-DEPLOYING deploy is otherwise
+        never re-driven and stays stuck DEPLOYING with no container). Same
+        column projection as ``list_pending_for_pool`` so ``_spec_from_pending``
+        works unchanged. No row lock — this is a recovery read, not a claim."""
+        q = """
+            SELECT deployment_id AS id, target_node_id, gpu_per_replica,
+                   replicas, model_name, inference_model, engine, configuration
+              FROM model_deployments
+             WHERE target_node_id = $1
+               AND state = 'DEPLOYING'
+          ORDER BY created_at ASC
+            """
+        if tx is not None:
+            rows = await tx.fetch(q, node_id)
+        else:
+            async with self.db.acquire() as conn:
+                rows = await conn.fetch(q, node_id)
+        return [dict(r) for r in rows]
+
     async def bind_to_node(
         self,
         deployment_id: UUID,

--- a/src/tests/orchestration/model_deployment/test_deployment_linker.py
+++ b/src/tests/orchestration/model_deployment/test_deployment_linker.py
@@ -260,6 +260,115 @@ async def test_load_model_failed_status_releases_gpu_and_marks_failed(pool):
     assert node_row["gpu_allocated"] == 0    # GPU released
 
 
+async def _seed_deploying_deploy(p, pool_id, node_id, *, gpu_required=1,
+                                 model_name="test-model", engine="vllm"):
+    """A deploy orphaned in DEPLOYING bound to node_id — e.g. its load_model
+    was in flight when the control plane restarted, so it is no longer
+    PENDING_NODE and the bind loop skips it."""
+    deploy_id = uuid4()
+    async with p.acquire() as c:
+        await c.execute(
+            """INSERT INTO model_deployments(deployment_id, model_name,
+                 replicas, gpu_per_replica, pool_id, target_pool_id,
+                 target_node_id, state, org_id, engine)
+               VALUES ($1, $5, 1, $4, $2, $2, $6, 'DEPLOYING', $3, $7)""",
+            deploy_id, pool_id, str(uuid4()), gpu_required, model_name,
+            node_id, engine,
+        )
+    return deploy_id
+
+
+async def test_orphaned_deploying_is_redriven_on_worker_ready(pool):
+    """A deploy stuck in DEPLOYING (load_model never completed because the
+    control plane restarted mid-flight) is no longer PENDING_NODE, so the bind
+    loop skips it and nothing re-fires load_model — it stays DEPLOYING forever
+    with no container. on_worker_ready must RE-DRIVE such orphans: re-fire
+    load_model on (re)connect and promote to RUNNING."""
+    pool_id, node_id = await _seed_pool_and_node(
+        pool, gpu_total=1, gpu_allocated=1,  # GPU was reserved at bind time
+        advertise_url="http://ec2-x:8080",
+    )
+    deploy_id = await _seed_deploying_deploy(pool, pool_id, node_id)
+    controller = AsyncMock(spec=WorkerController)
+    linker = DeploymentLinker(
+        db_pool=pool,
+        inventory_repo=InventoryRepository(pool),
+        deployment_repo=ModelDeploymentRepository(pool, event_bus=None),
+        worker_controller=controller,
+    )
+
+    await linker.on_worker_ready(node_id)
+
+    async with pool.acquire() as c:
+        row = await c.fetchrow(
+            "SELECT state, endpoint FROM model_deployments WHERE deployment_id=$1",
+            deploy_id,
+        )
+        node = await c.fetchrow(
+            "SELECT gpu_allocated FROM compute_inventory WHERE id=$1", node_id,
+        )
+    assert row["state"] == "RUNNING"           # re-driven, not stuck
+    assert row["endpoint"] == "http://ec2-x:8080"
+    assert node["gpu_allocated"] == 1          # not double-allocated
+    controller.load_model.assert_awaited_once()  # load_model re-fired
+
+
+async def test_orphaned_deploying_not_redriven_twice_when_also_freshly_bound(pool):
+    """A deploy that the bind loop just drove (PENDING_NODE→bound) must NOT be
+    re-driven again by the orphan sweep — load_model fires exactly once."""
+    pool_id, node_id = await _seed_pool_and_node(
+        pool, gpu_total=2, advertise_url="http://ec2-x:8080",
+    )
+    await _seed_pending_deploy(pool, pool_id)
+    controller = AsyncMock(spec=WorkerController)
+    linker = DeploymentLinker(
+        db_pool=pool,
+        inventory_repo=InventoryRepository(pool),
+        deployment_repo=ModelDeploymentRepository(pool, event_bus=None),
+        worker_controller=controller,
+    )
+
+    await linker.on_worker_ready(node_id)
+
+    # The freshly-bound deploy transitions to DEPLOYING then RUNNING within the
+    # same call; the orphan sweep must exclude it (driven set), so load_model
+    # is awaited once, not twice.
+    controller.load_model.assert_awaited_once()
+
+
+async def test_redrive_failure_records_error_message(pool):
+    """When the re-driven load_model fails, the reason must be recorded in
+    error_message (via update_state, not set_state) so the dashboard shows WHY
+    the container never started — the empty-message regression that hid the
+    'container name already in use' worker bug."""
+    pool_id, node_id = await _seed_pool_and_node(pool, gpu_total=1,
+                                                 gpu_allocated=1)
+    deploy_id = await _seed_deploying_deploy(pool, pool_id, node_id)
+    controller = AsyncMock(spec=WorkerController)
+    controller.load_model.side_effect = RuntimeError("container name in use")
+    linker = DeploymentLinker(
+        db_pool=pool,
+        inventory_repo=InventoryRepository(pool),
+        deployment_repo=ModelDeploymentRepository(pool, event_bus=None),
+        worker_controller=controller,
+    )
+
+    await linker.on_worker_ready(node_id)
+
+    async with pool.acquire() as c:
+        row = await c.fetchrow(
+            "SELECT state, error_message FROM model_deployments "
+            "WHERE deployment_id=$1", deploy_id,
+        )
+        node = await c.fetchrow(
+            "SELECT gpu_allocated FROM compute_inventory WHERE id=$1", node_id,
+        )
+    assert row["state"] == "FAILED"
+    assert row["error_message"]                       # non-empty reason recorded
+    assert "container name in use" in row["error_message"]
+    assert node["gpu_allocated"] == 0                 # GPU released
+
+
 async def test_already_bound_deploy_is_promoted_without_reallocate(pool):
     """A ColdStart deploy pre-allocates its GPU on the placeholder and is
     bound to it (target_node_id=node). When the worker registers onto that

--- a/src/tests/orchestration/repositories/test_model_deployment_repo_extensions.py
+++ b/src/tests/orchestration/repositories/test_model_deployment_repo_extensions.py
@@ -132,6 +132,55 @@ async def test_bind_to_node_sets_target_node_id(pool):
     assert row["target_node_id"] == node_id
 
 
+async def _seed_node(pool, pool_id):
+    node_id = uuid4()
+    async with pool.acquire() as c:
+        await c.execute(
+            "INSERT INTO compute_inventory(id, pool_id, provider, "
+            "provider_instance_id, hostname, node_name, agent_kind, "
+            "gpu_total, gpu_allocated, vcpu_total, vcpu_allocated, "
+            "ram_gb_total, ram_gb_allocated, state) "
+            "VALUES ($1, $2, 'aws', $3, 'h', $4, 'worker', 1, 0, 0, 0, 0, 0, 'ready')",
+            str(node_id), str(pool_id), f"p-{node_id}", f"n-{node_id}",
+        )
+    return node_id
+
+
+async def test_list_deploying_for_node_filters_state_and_node(pool):
+    """list_deploying_for_node returns ONLY DEPLOYING deploys bound to the given
+    node, FIFO — the input to the orphan re-drive. Other states (RUNNING,
+    PENDING_NODE, FAILED) and other nodes must be excluded."""
+    repo = ModelDeploymentRepository(pool, event_bus=None)
+    _, pool_id = await _seed_pool_row(pool)
+    node_id = await _seed_node(pool, pool_id)
+    other_node = await _seed_node(pool, pool_id)
+
+    older = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    newer = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    d_old = await _seed_deploy(pool, pool_id=pool_id, state="DEPLOYING",
+                               target_node_id=node_id, created_at=older)
+    d_new = await _seed_deploy(pool, pool_id=pool_id, state="DEPLOYING",
+                               target_node_id=node_id, created_at=newer)
+    # Noise that must be excluded.
+    await _seed_deploy(pool, pool_id=pool_id, state="RUNNING",
+                       target_node_id=node_id)
+    await _seed_deploy(pool, pool_id=pool_id, state="PENDING_NODE",
+                       target_node_id=node_id)
+    await _seed_deploy(pool, pool_id=pool_id, state="DEPLOYING",
+                       target_node_id=other_node)
+
+    rows = await repo.list_deploying_for_node(node_id)
+    ids = [r["id"] for r in rows]
+    assert ids == [d_old, d_new]  # only this node's DEPLOYING, FIFO
+
+
+async def test_list_deploying_for_node_empty_when_none(pool):
+    repo = ModelDeploymentRepository(pool, event_bus=None)
+    _, pool_id = await _seed_pool_row(pool)
+    node_id = await _seed_node(pool, pool_id)
+    assert await repo.list_deploying_for_node(node_id) == []
+
+
 async def test_set_state_changes_state(pool):
     repo = ModelDeploymentRepository(pool, event_bus=None)
     _, pool_id = await _seed_pool_row(pool)


### PR DESCRIPTION
## Problem

An AWS deploy got stuck in `DEPLOYING` for hours with **no vLLM container** on the EC2. Two control-plane gaps:

1. **Orphaned DEPLOYING never re-driven.** `DeploymentLinker.on_worker_ready` only binds/drives `PENDING_NODE` deploys. A deploy whose `load_model` was in flight when the control plane restarted is left in `DEPLOYING` — no longer `PENDING_NODE`, so the bind loop skips it, `/start` reprovisions a *new* node, and nothing re-fires `load_model`. It sits `DEPLOYING` forever.
2. **Failure reason invisible.** `_drive_deploy` marked failures with `set_state(FAILED)` (state only) — `error_message` was empty, so the dashboard gave no clue why the container never started.

## Fix

- `on_worker_ready` re-drives orphaned `DEPLOYING` deploys on worker (re)connect: `list_deploying_for_node(node_id)` (new repo method) for any not already driven this run → extracted `_drive_deploy()`. Idempotent + safe (prior control channel is dead; the worker-side fix in inferia-worker PR #9 makes the container recreate cleanly).
- `_drive_deploy` records the reason via `update_state(FAILED, error_message=...)`.
- `chore(deploy)`: Makefile unified targets now use the root `docker-compose.yml` (project `deploy`); bump `worker_image_tag` default `0.2.7 → 0.2.8` (ships the worker idempotency fix).

## Tests

Against a real `inferia_test` Postgres: re-drive promotes orphaned `DEPLOYING` → `RUNNING`; freshly-bound deploys aren't double-driven; a failed re-drive records a non-empty `error_message`; `list_deploying_for_node` filters by state+node FIFO. 20/20 green; the new tests were confirmed to fail pre-fix.

Pairs with **inferia-worker#9** (load_model container-name idempotency). Worker `0.2.8` must be published before this merges (the tag bump points at it).