### PR TITLE
chore(deploy): bump default worker image tag to 0.2.9

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ UPSTREAM_HTTP_CONNECT_TIMEOUT_SECONDS=20
 
 # --- Worker/AWS ---
 INFERIA_WORKER_IMAGE=ghcr.io/inferiaai/inferia-worker
-INFERIA_WORKER_IMAGE_TAG=0.2.7
+INFERIA_WORKER_IMAGE_TAG=0.2.9
 INFERIA_BAKE_SSM_INSTANCE_PROFILE=inferia-engine-ami-builder
 
 # --- Postgres ---

--- a/src/orchestration/config.py
+++ b/src/orchestration/config.py
@@ -148,10 +148,10 @@ class Settings(UnifiedBaseSettings):
     )
     worker_image_tag: str = Field(
         # docker/metadata-action's semver pattern strips the leading "v"
-        # from git tags, so the GHCR tag for git tag v0.2.8 is 0.2.8.
-        # 0.2.8 ships the load_model container-name idempotency fix
+        # from git tags, so the GHCR tag for git tag v0.2.9 is 0.2.9.
+        # 0.2.9 also drops the broken VLLM_USE_FASTOKENS default; 0.2.8 added container-name idempotency fix
         # (remove-before-create) that unsticks DEPLOYING deploys.
-        default="0.2.8",
+        default="0.2.9",
         validation_alias="INFERIA_WORKER_IMAGE_TAG",
     )
     bootstrap_token_ttl_seconds: int = Field(


### PR DESCRIPTION
Points the control plane at `inferia-worker:0.2.9`, which ships the vLLM `fastokens` fix (inferia-worker #10) on top of 0.2.8's container-name idempotency fix (#9). Updates `orchestration/config.py` default + `.env.example`.