### PR TITLE
feat(deploy): bypass the HF model mirror for public-cloud providers

### DIFF
--- a/src/orchestration/models/model_deployment/deployment_linker.py
+++ b/src/orchestration/models/model_deployment/deployment_linker.py
@@ -109,14 +109,15 @@ class DeploymentLinker:
 
     async def on_worker_ready(self, node_id: UUID) -> None:
         async with self._db.acquire() as conn:
-            pool_id_row = await conn.fetchrow(
-                "SELECT pool_id FROM compute_inventory WHERE id=$1",
+            node_row = await conn.fetchrow(
+                "SELECT pool_id, provider FROM compute_inventory WHERE id=$1",
                 node_id,
             )
-            if pool_id_row is None:
+            if node_row is None:
                 logger.warning("on_worker_ready: node %s not found", node_id)
                 return
-            pool_id = pool_id_row["pool_id"]
+            pool_id = node_row["pool_id"]
+            provider = node_row["provider"]
 
             bound: list[dict] = []
             async with conn.transaction():
@@ -157,7 +158,7 @@ class DeploymentLinker:
         # Transaction committed. Drive load_model OUTSIDE the transaction for
         # the deploys we just bound.
         for deploy in bound:
-            await self._drive_deploy(node_id, deploy)
+            await self._drive_deploy(node_id, deploy, provider=provider)
 
         # RE-DRIVE orphaned DEPLOYING deploys. A deploy whose load_model was
         # in flight when the control plane restarted (or whose linker task
@@ -185,7 +186,7 @@ class DeploymentLinker:
                 "(load_model never completed; control-plane restart?)",
                 deploy["id"], node_id,
             )
-            await self._drive_deploy(node_id, deploy)
+            await self._drive_deploy(node_id, deploy, provider=provider)
 
         if bound or orphaned:
             logger.info(
@@ -193,7 +194,8 @@ class DeploymentLinker:
                 len(bound), len(orphaned), node_id, pool_id,
             )
 
-    async def _drive_deploy(self, node_id: UUID, deploy: dict) -> None:
+    async def _drive_deploy(self, node_id: UUID, deploy: dict,
+                            *, provider: str | None = None) -> None:
         """Fire load_model for one already-bound deploy, then promote
         DEPLOYING → RUNNING (and publish the endpoint) on success, or release
         the GPU + mark FAILED on failure. The GPU was allocated at bind time, so
@@ -211,6 +213,7 @@ class DeploymentLinker:
                 spec, recipe=spec["recipe"],
                 artifact_uri=spec["model"]["artifact_uri"],
                 mirror_base=_mirror_base, cache_repo=_mc_deps.get("repo"),
+                provider=provider,
             )
             result = await self._controller.load_model(
                 node_id=str(node_id), spec=spec,

--- a/src/orchestration/models/model_deployment/deployment_server.py
+++ b/src/orchestration/models/model_deployment/deployment_server.py
@@ -1473,6 +1473,7 @@ async def place_and_provision(
                     spec, recipe=spec["recipe"],
                     artifact_uri=spec["model"]["artifact_uri"],
                     mirror_base=_mirror_base, cache_repo=_mc_deps.get("repo"),
+                    provider=pool_row.get("provider"),
                 )
             except Exception:
                 pass  # mirror is best-effort; never block a warm deploy
@@ -1726,7 +1727,15 @@ async def deploy_model(req: DeployModelRequest, request: Request):
             inference_model=req.inference_model,
             model_name=req.model_name,
         )
-        if _dl and _uri and (req.engine or "vllm") in ("vllm", "tei", "infinity", "ollama"):
+        # Skip the CP cache pre-warm for public-cloud providers: their VMs pull
+        # weights from origin directly (the load spec also bypasses the mirror),
+        # so pre-warming would download to the CP for nothing — and over a
+        # home/tunnel uplink that is slow + wasteful.
+        from orchestration.provisioning.engine.registry import (
+            provider_prefers_origin_model_fetch,
+        )
+        _origin_fetch = provider_prefers_origin_model_fetch(pool_row.get("provider"))
+        if _dl and _uri and not _origin_fetch and (req.engine or "vllm") in ("vllm", "tei", "infinity", "ollama"):
             _src, _mid, _rev = derive_cache_key(req.engine or "vllm", str(_uri))
             _dl.start(source=_src, model_id=_mid, revision=_rev, engine_hint=req.engine)
     except Exception:

--- a/src/orchestration/models/model_deployment/mirror_decision.py
+++ b/src/orchestration/models/model_deployment/mirror_decision.py
@@ -57,12 +57,26 @@ def apply_mirror_to_spec(spec: dict, *, recipe: str, mirror_base: str) -> None:
 
 
 async def resolve_and_apply_mirror(
-    spec: dict, *, recipe: str, artifact_uri: str, mirror_base: str, cache_repo
+    spec: dict, *, recipe: str, artifact_uri: str, mirror_base: str, cache_repo,
+    provider: str | None = None,
 ) -> None:
     """Look up the CP cache row and inject mirror coords iff the CP has/IS-getting
-    the model. No-op when mirror_base is blank (dormant) or cache_repo is None."""
+    the model. No-op when mirror_base is blank (dormant), cache_repo is None, or
+    ``provider`` is a public-cloud provider that fetches weights from origin
+    directly (its VMs reach huggingface.co, so routing through the CP mirror is
+    pointless and may be unreachable when the CP sits behind a tunnel)."""
     if not mirror_base or cache_repo is None:
         return
+    # Public-cloud providers (aws/gcp/azure) pull from origin directly — never
+    # inject the CP mirror for them. Lazy import: registry pulls in every
+    # provider adapter, so importing it at module load would be heavy and risk
+    # an import cycle through the deployment modules that import this one.
+    if provider is not None:
+        from orchestration.provisioning.engine.registry import (
+            provider_prefers_origin_model_fetch,
+        )
+        if provider_prefers_origin_model_fetch(provider):
+            return
     source, model_id, revision = derive_cache_key(recipe, artifact_uri)
     try:
         row = await cache_repo.get_by_key(source=source, model_id=model_id, revision=revision)

--- a/src/orchestration/provisioning/engine/base.py
+++ b/src/orchestration/provisioning/engine/base.py
@@ -57,6 +57,15 @@ class ProviderCapabilities:
     supports_cluster_mode: bool = (
         False  # Persistent cluster (SkyPilot) vs job-based (Nosana)
     )
+    # When True, this provider's nodes fetch model weights straight from the
+    # origin (e.g. huggingface.co) rather than through the control plane's HF
+    # mirror. Set for public-cloud providers (AWS/GCP/Azure) whose VMs have
+    # direct internet egress: routing them through the CP mirror is slower and,
+    # when the CP is behind a home/proxy tunnel, often unreachable. Air-gapped
+    # / DePIN / self-hosted providers leave this False so they keep using the
+    # cache-first mirror. Gates both the per-deploy cache pre-warm and the
+    # mirror injection into the load spec.
+    prefers_origin_model_fetch: bool = False
 
     # Pricing
     pricing_model: PricingModel = PricingModel.FIXED
@@ -80,6 +89,7 @@ class ProviderCapabilities:
             "requires_sidecar": self.requires_sidecar,
             "supports_direct_provisioning": self.supports_direct_provisioning,
             "supports_cluster_mode": self.supports_cluster_mode,
+            "prefers_origin_model_fetch": self.prefers_origin_model_fetch,
             "pricing_model": self.pricing_model.value,
             "features": self.features,
         }

--- a/src/orchestration/provisioning/engine/registry.py
+++ b/src/orchestration/provisioning/engine/registry.py
@@ -112,6 +112,30 @@ def is_direct_provision_provider(provider: Optional[str]) -> bool:
     return getattr(cls, "ADAPTER_TYPE", None) != AdapterType.CLOUD
 
 
+def provider_prefers_origin_model_fetch(provider: Optional[str]) -> bool:
+    """Should a deploy on ``provider`` fetch model weights from origin
+    (huggingface.co) directly, bypassing the control-plane HF mirror?
+
+    True iff the provider's adapter CAPABILITIES set
+    ``prefers_origin_model_fetch`` — currently the public-cloud providers
+    (aws/gcp/azure), whose VMs have direct internet egress. Air-gapped /
+    DePIN / self-hosted providers return False and keep the cache-first
+    mirror. Gates both the per-deploy cache pre-warm and the mirror injection
+    into the load spec.
+
+    Reads CLASS attributes only — must NOT instantiate the adapter (mirrors
+    :func:`is_direct_provision_provider`; cloud adapters read pulumi settings
+    and k8s loads kubeconfig at __init__). Unknown / falsy providers → False.
+    """
+    if not provider:
+        return False
+    cls = ADAPTER_REGISTRY.get(provider)
+    if cls is None:
+        return False
+    caps = getattr(cls, "CAPABILITIES", None)
+    return bool(caps is not None and getattr(caps, "prefers_origin_model_fetch", False))
+
+
 async def _deprovision_direct_node(
     node_row: dict,
     *,

--- a/src/providers/pulumi/pulumi_aws_adapter.py
+++ b/src/providers/pulumi/pulumi_aws_adapter.py
@@ -474,6 +474,9 @@ class PulumiAWSAdapter(PulumiProvisioningBase, ProviderAdapter):
     CAPABILITIES = ProviderCapabilities(
         supports_multi_gpu=True,
         supports_cluster_mode=True,
+        # Public-cloud VMs have direct internet egress → pull models straight
+        # from origin (huggingface.co), bypassing the CP HF mirror.
+        prefers_origin_model_fetch=True,
         pricing_model=PricingModel.ON_DEMAND,
         features={"cloud": "aws", "bootstrap": "cloud-init", "iac": "pulumi"},
     )

--- a/src/providers/pulumi/pulumi_azure_adapter.py
+++ b/src/providers/pulumi/pulumi_azure_adapter.py
@@ -50,6 +50,9 @@ class PulumiAzureAdapter(PulumiProvisioningBase, ProviderAdapter):
     CAPABILITIES = ProviderCapabilities(
         supports_multi_gpu=True,
         supports_cluster_mode=True,
+        # Public-cloud VMs have direct internet egress → pull models straight
+        # from origin (huggingface.co), bypassing the CP HF mirror.
+        prefers_origin_model_fetch=True,
         pricing_model=PricingModel.ON_DEMAND,
         features={"cloud": "azure", "bootstrap": "custom-data", "iac": "pulumi"},
     )

--- a/src/providers/pulumi/pulumi_gcp_adapter.py
+++ b/src/providers/pulumi/pulumi_gcp_adapter.py
@@ -58,6 +58,9 @@ class PulumiGCPAdapter(PulumiProvisioningBase, ProviderAdapter):
     CAPABILITIES = ProviderCapabilities(
         supports_multi_gpu=True,
         supports_cluster_mode=True,
+        # Public-cloud VMs have direct internet egress → pull models straight
+        # from origin (huggingface.co), bypassing the CP HF mirror.
+        prefers_origin_model_fetch=True,
         pricing_model=PricingModel.ON_DEMAND,
         features={"cloud": "gcp", "bootstrap": "startup-script", "iac": "pulumi"},
     )

--- a/src/tests/orchestration/adapter_engine/test_registry.py
+++ b/src/tests/orchestration/adapter_engine/test_registry.py
@@ -6,6 +6,7 @@ import pytest
 from orchestration.provisioning.engine.registry import (
     get_adapter, ADAPTER_REGISTRY,
     is_direct_provision_provider,
+    provider_prefers_origin_model_fetch,
     _deprovision_direct_node,
 )
 from providers.nosana.nosana_adapter import NosanaAdapter
@@ -103,6 +104,69 @@ def test_is_direct_provision_covers_every_registry_key():
     for name in ADAPTER_REGISTRY:
         # Must not raise and must return a bool.
         assert isinstance(is_direct_provision_provider(name), bool)
+
+
+# ---------------------------------------------------------------------------
+# provider_prefers_origin_model_fetch — gates the HF-mirror bypass. True for
+# public-cloud providers (direct internet egress → pull from origin), False
+# for DePIN / self-hosted / air-gapped (keep the cache-first mirror).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider,expected",
+    [
+        # Public cloud → fetch from origin, bypass the CP mirror.
+        ("aws", True),
+        ("gcp", True),
+        ("azure", True),
+        # DePIN / self-hosted / k8s → keep the cache-first mirror.
+        ("nosana", False),
+        ("akash", False),
+        ("k8s", False),
+        ("worker", False),
+        ("on_prem", False),
+        # Unknown / unset → never bypass (safe default).
+        ("definitely-not-a-provider", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_provider_prefers_origin_model_fetch(provider, expected):
+    assert provider_prefers_origin_model_fetch(provider) is expected
+
+
+def test_prefers_origin_covers_every_registry_key_without_instantiation():
+    """Classifies every provider via CLASS attributes only (no adapter
+    instantiation — k8s/cloud adapters raise at __init__)."""
+    for name in ADAPTER_REGISTRY:
+        assert isinstance(provider_prefers_origin_model_fetch(name), bool)
+
+
+def test_prefers_origin_matches_cloud_adapter_type():
+    """The bypass set is exactly the CLOUD adapters — keeps the flag and the
+    ADAPTER_TYPE classification from silently diverging."""
+    from orchestration.provisioning.engine.base import AdapterType
+    for name, cls in ADAPTER_REGISTRY.items():
+        is_cloud = getattr(cls, "ADAPTER_TYPE", None) == AdapterType.CLOUD
+        assert provider_prefers_origin_model_fetch(name) is is_cloud, name
+
+
+def test_capabilities_to_dict_includes_prefers_origin():
+    from orchestration.provisioning.engine.base import ProviderCapabilities
+    d = ProviderCapabilities(prefers_origin_model_fetch=True).to_dict()
+    assert d["prefers_origin_model_fetch"] is True
+    assert ProviderCapabilities().to_dict()["prefers_origin_model_fetch"] is False
+
+
+def test_get_provider_info_exposes_prefers_origin():
+    """The capability is surfaced through get_provider_info (the dashboard
+    /inventory/providers payload), True for cloud, False for DePIN/worker."""
+    from orchestration.provisioning.engine.registry import get_provider_info
+    info = get_provider_info()
+    assert info["aws"]["capabilities"]["prefers_origin_model_fetch"] is True
+    assert info["nosana"]["capabilities"]["prefers_origin_model_fetch"] is False
+    assert info["worker"]["capabilities"]["prefers_origin_model_fetch"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/orchestration/model_deployment/test_deployment_linker.py
+++ b/src/tests/orchestration/model_deployment/test_deployment_linker.py
@@ -32,7 +32,7 @@ async def pool():
 
 
 async def _seed_pool_and_node(p, *, gpu_total=4, gpu_allocated=0, state="ready",
-                              advertise_url=None):
+                              advertise_url=None, provider="aws"):
     org_id, pool_id, node_id = uuid4(), uuid4(), uuid4()
     async with p.acquire() as c:
         await c.execute("INSERT INTO organizations(id,name) VALUES($1,$2) "
@@ -42,10 +42,10 @@ async def _seed_pool_and_node(p, *, gpu_total=4, gpu_allocated=0, state="ready",
                  provider, pool_type, allowed_gpu_types, max_cost_per_hour,
                  scheduling_policy, provider_pool_id, is_active, lifecycle_state,
                  gpu_count)
-               VALUES ($1, $2, 'organization', $3::text, 'aws', 'cluster',
+               VALUES ($1, $2, 'organization', $3::text, $6, 'cluster',
                        ARRAY['none'], 0, '{}', $4, true, 'running', $5)""",
             pool_id, f"p-{pool_id}", str(org_id),
-            f"placeholder:{pool_id}", gpu_total,
+            f"placeholder:{pool_id}", gpu_total, provider,
         )
         await c.execute(
             """INSERT INTO compute_inventory(id, pool_id, provider,
@@ -53,11 +53,11 @@ async def _seed_pool_and_node(p, *, gpu_total=4, gpu_allocated=0, state="ready",
                  advertise_url,
                  gpu_total, gpu_allocated, vcpu_total, vcpu_allocated,
                  ram_gb_total, ram_gb_allocated, state)
-               VALUES ($1, $2, 'aws', $3, 'h', $4, 'worker',
+               VALUES ($1, $2, $9, $3, 'h', $4, 'worker',
                        $8,
                        $5, $6, 0, 0, 0, 0, $7)""",
             node_id, pool_id, f"p-{node_id}", f"n-{node_id}",
-            gpu_total, gpu_allocated, state, advertise_url,
+            gpu_total, gpu_allocated, state, advertise_url, provider,
         )
     return pool_id, node_id
 
@@ -276,6 +276,37 @@ async def _seed_deploying_deploy(p, pool_id, node_id, *, gpu_required=1,
             node_id, engine,
         )
     return deploy_id
+
+
+@pytest.mark.parametrize("provider", ["aws", "on_prem", "nosana"])
+async def test_on_worker_ready_threads_node_provider_to_mirror(pool, monkeypatch, provider):
+    """on_worker_ready must read the node's provider and thread it into
+    resolve_and_apply_mirror, so the mirror is bypassed for public-cloud nodes
+    (the gate lives in resolve_and_apply_mirror). Pins the call-site wiring: a
+    regression dropping the provider would route cloud deploys through the CP
+    mirror again."""
+    from orchestration.models.model_deployment import deployment_linker as _dl_mod
+    captured = {}
+
+    async def _spy(spec, *, recipe, artifact_uri, mirror_base, cache_repo,
+                   provider=None):
+        captured["provider"] = provider
+
+    monkeypatch.setattr(_dl_mod, "resolve_and_apply_mirror", _spy)
+
+    pool_id, node_id = await _seed_pool_and_node(pool, provider=provider)
+    await _seed_pending_deploy(pool, pool_id)
+    controller = AsyncMock(spec=WorkerController)
+    linker = DeploymentLinker(
+        db_pool=pool,
+        inventory_repo=InventoryRepository(pool),
+        deployment_repo=ModelDeploymentRepository(pool, event_bus=None),
+        worker_controller=controller,
+    )
+
+    await linker.on_worker_ready(node_id)
+
+    assert captured.get("provider") == provider  # node's provider, verbatim
 
 
 async def test_orphaned_deploying_is_redriven_on_worker_ready(pool):

--- a/src/tests/orchestration/model_deployment/test_mirror_decision.py
+++ b/src/tests/orchestration/model_deployment/test_mirror_decision.py
@@ -125,3 +125,41 @@ async def test_resolve_swallows_lookup_error():
     await resolve_and_apply_mirror(spec, recipe="vllm", artifact_uri="hf://org/m",
                                    mirror_base="https://cp", cache_repo=_ErrorRepo())
     assert "HF_ENDPOINT" not in spec.get("env", {})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["aws", "gcp", "azure"])
+async def test_resolve_noop_for_cloud_provider(provider):
+    """Public-cloud providers fetch from origin directly — the mirror must NOT
+    be injected even when the model is cached and a mirror_base is configured."""
+    spec = {"recipe": "vllm", "model": {"artifact_uri": "hf://org/m"}, "env": {}}
+    await resolve_and_apply_mirror(spec, recipe="vllm", artifact_uri="hf://org/m",
+                                   mirror_base="https://cp",
+                                   cache_repo=_FakeRepo({"status": "cached"}),
+                                   provider=provider)
+    assert "HF_ENDPOINT" not in spec["env"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["nosana", "akash", "worker", "on_prem", "k8s"])
+async def test_resolve_applies_for_non_cloud_provider(provider):
+    """DePIN / self-hosted providers keep the cache-first mirror."""
+    spec = {"recipe": "vllm", "model": {"artifact_uri": "hf://org/m"}, "env": {}}
+    await resolve_and_apply_mirror(spec, recipe="vllm", artifact_uri="hf://org/m",
+                                   mirror_base="https://cp",
+                                   cache_repo=_FakeRepo({"status": "cached"}),
+                                   provider=provider)
+    assert spec["env"]["HF_ENDPOINT"] == "https://cp/hf"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", [None, "", "unknown-provider"])
+async def test_resolve_applies_when_provider_unknown_or_none(provider):
+    """Unknown / unset provider must not bypass the mirror (backward compatible:
+    callers that don't pass a provider keep the prior cache-first behaviour)."""
+    spec = {"recipe": "vllm", "model": {"artifact_uri": "hf://org/m"}, "env": {}}
+    await resolve_and_apply_mirror(spec, recipe="vllm", artifact_uri="hf://org/m",
+                                   mirror_base="https://cp",
+                                   cache_repo=_FakeRepo({"status": "cached"}),
+                                   provider=provider)
+    assert spec["env"]["HF_ENDPOINT"] == "https://cp/hf"

--- a/src/tests/orchestration/model_deployment/test_place_and_provision.py
+++ b/src/tests/orchestration/model_deployment/test_place_and_provision.py
@@ -733,6 +733,60 @@ async def test_bind_to_ready_warm_path_fires_load_model(monkeypatch):
             assert call.args[1] != "FAILED"
 
 
+@pytest.mark.parametrize("provider", ["aws", "on_prem", "nosana", None])
+async def test_bind_to_ready_warm_path_threads_provider_to_mirror(provider, monkeypatch):
+    """The warm path must pass the POOL's provider to resolve_and_apply_mirror
+    so the mirror is bypassed for public-cloud providers (the gate lives in
+    resolve_and_apply_mirror). This pins the call-site wiring: a regression that
+    dropped the provider kwarg would silently re-route cloud deploys through the
+    (often unreachable) CP mirror."""
+    captured = {}
+
+    async def _spy_mirror(spec, *, recipe, artifact_uri, mirror_base, cache_repo,
+                          provider=None):
+        captured["provider"] = provider
+        captured["called"] = True
+
+    # The warm path imports resolve_and_apply_mirror LOCALLY (inside
+    # place_and_provision), so patch the source module — the local import
+    # resolves the name from mirror_decision at call time.
+    from orchestration.models.model_deployment import mirror_decision
+    monkeypatch.setattr(
+        mirror_decision, "resolve_and_apply_mirror", _spy_mirror, raising=True
+    )
+
+    deploy_id, pool_id, node_id = uuid4(), uuid4(), uuid4()
+    placer = AsyncMock(spec=PoolPlacer)
+    placer.place.return_value = BindToReady(node_id=node_id)
+    inventory = AsyncMock(spec=InventoryRepository)
+    inventory.allocate_gpu.return_value = True
+    deploys = AsyncMock(spec=ModelDeploymentRepository)
+    jobs_repo = AsyncMock(spec=ProvisioningJobRepository)
+    controller = AsyncMock(spec=WorkerController)
+    controller.load_model.return_value = CommandResultBody(
+        in_reply_to="x", status="ok", detail="", endpoint_url="http://127.0.0.1:9000",
+    )
+    deps = SimpleNamespace(
+        db_pool=_make_db_pool(advertise_url="http://10.0.0.9:8080"),
+        controller=controller, inventory=inventory, deploys=deploys,
+        placer=placer, jobs_repo=jobs_repo,
+    )
+    source = SimpleNamespace(
+        engine="vllm", configuration=_row_configuration(),
+        inference_model=None, model_name="my-model", gpu_per_replica=1,
+    )
+
+    await place_and_provision(
+        deploy_id=deploy_id, pool_id=pool_id,
+        pool_row={"id": pool_id, "provider": provider},
+        pool_meta={}, gpu_per_replica=1, org_id=str(uuid4()),
+        engine="vllm", load_spec_source=source, deps=deps,
+    )
+
+    assert captured.get("called") is True
+    assert captured["provider"] == provider  # exactly the pool's provider
+
+
 async def test_bind_to_ready_warm_path_failed_status_marks_failed(monkeypatch):
     """BindToReady warm path where the worker replies status='failed' WITHOUT
     raising (e.g. vLLM engine init crash, readiness-probe timeout). The


### PR DESCRIPTION
## Why

AWS (and other public-cloud) deploys were routed through the control-plane HF mirror (`INFERIA_MODEL_MIRROR_BASE`, e.g. `…/api/hf`). When the CP sits behind a home/proxy tunnel, that `/api/hf` path is reachable from the CP itself but **times out from the cloud VM**, so vLLM's weight download hangs and the deploy never becomes ready (readiness-probe timeout). Public-cloud VMs have direct internet egress and should just pull from `huggingface.co`.

## What

Per-provider gate: **cloud (aws/gcp/azure) → fetch from origin (bypass mirror); DePIN/self-hosted/k8s → keep the cache-first mirror.**

- `ProviderCapabilities.prefers_origin_model_fetch` (default `False`), set `True` on the aws/gcp/azure adapters.
- `registry.provider_prefers_origin_model_fetch(provider)` — class-attr read, no adapter instantiation (mirrors `is_direct_provision_provider`).
- `resolve_and_apply_mirror` gains a `provider` kwarg and no-ops for cloud providers.
- Provider threaded through every worker-path mirror site: the deploy **pre-warm** (skips the wasted CP download for cloud), the **BindToReady warm path**, and the linker's `on_worker_ready → _drive_deploy` (reads the node's provider).

## Scope note (from adversarial review)

DePIN (Nosana/Akash) builds its own container spec via the direct-provision path and **never used `resolve_and_apply_mirror`** — it already pulls from origin. This PR leaves DePIN unchanged (correct: the same tunnel issue would make the mirror unreachable from DePIN nodes too, so forcing them through it would break currently-working Nosana deploys). Giving DePIN a working mirror is a separate feature, intentionally out of scope.

## Tests

Provider gate (cloud bypass / non-cloud + unknown/None apply), registry helper + a cloud-`ADAPTER_TYPE` invariant + `get_provider_info` exposure, and call-site wiring spies for both the warm path and the linker. Adversarially reviewed via a multi-agent workflow; coverage findings addressed. (Pre-existing CI/event-loop + DB-harness failures are unrelated — my change adds zero new failures.)