### PR TITLE
fix: SSO sandbox JWT + Nosana vLLM deploy (max_model_len/v0.22.1) + OAuth login resilience

### DIFF
--- a/src/api_gateway/rbac/jwks_verifier.py
+++ b/src/api_gateway/rbac/jwks_verifier.py
@@ -1,180 +1,20 @@
-"""Ed25519 JWT verifier backed by a cached JWKS endpoint.
+"""Backwards-compatible re-export of the shared JWKS verifier.
 
-Implements the inferia-auth side of the OAuth2 SSO integration: pulls
-`/.well-known/jwks.json` once per ``cache_ttl`` seconds, then verifies
-every incoming bearer token locally with PyJWT.
+The implementation now lives in :mod:`common.jwks_verifier` so that both the
+api_gateway (SSO token verification) and the inference data plane (sandbox JWT
+verification) can use it without inference importing ``api_gateway.rbac`` —
+whose package ``__init__`` pulls in DB models and ``auth_service``.
 
-python-jose 3.5 does NOT support EdDSA, so we use PyJWT[crypto] +
-cryptography's Ed25519PublicKey to parse the OKP/Ed25519 JWK manually.
+Importing from ``api_gateway.rbac.jwks_verifier`` keeps working unchanged.
 """
 
 from __future__ import annotations
 
-import base64
-import logging
-import time
-from typing import Optional
-
-import httpx
-import jwt as pyjwt
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-from jwt import (
-    ExpiredSignatureError,
-    InvalidAudienceError,
-    InvalidIssuerError,
-    InvalidSignatureError,
-    InvalidTokenError,
-    MissingRequiredClaimError,
-    PyJWTError,
+from common.jwks_verifier import (  # noqa: F401
+    JWKSVerifier,
+    JWKSVerifyError,
+    _b64url_to_bytes,
+    _jwk_to_ed25519_public,
 )
 
-logger = logging.getLogger(__name__)
-
-
-class JWKSVerifyError(Exception):
-    """Raised whenever a token cannot be verified for any reason.
-
-    The internal cause (network, signature, expired, etc.) is folded into
-    the message so callers can log/forward; HTTP handlers should map this
-    to 401.
-    """
-
-
-_MAX_TOKEN_LEN = 8192
-_CLOCK_SKEW_SECONDS = 60
-
-
-def _b64url_to_bytes(s: str) -> bytes:
-    pad = "=" * (-len(s) % 4)
-    return base64.urlsafe_b64decode(s + pad)
-
-
-def _jwk_to_ed25519_public(jwk: dict) -> Ed25519PublicKey:
-    """Convert an OKP/Ed25519 JWK dict to a usable PublicKey object."""
-    if jwk.get("kty") != "OKP" or jwk.get("crv") != "Ed25519":
-        raise JWKSVerifyError("JWK is not an Ed25519 key")
-    x = jwk.get("x")
-    if not x:
-        raise JWKSVerifyError("JWK missing 'x' parameter")
-    try:
-        raw = _b64url_to_bytes(x)
-        return Ed25519PublicKey.from_public_bytes(raw)
-    except Exception as e:  # pragma: no cover - defensive
-        raise JWKSVerifyError(f"invalid Ed25519 JWK: {type(e).__name__}") from e
-
-
-class JWKSVerifier:
-    """Synchronous verifier with an in-memory JWKS cache.
-
-    Verification is CPU-bound and the JWKS fetch is amortised across many
-    tokens, so the public surface is intentionally sync. ``verify`` is an
-    async wrapper for callers that prefer await syntax.
-    """
-
-    def __init__(
-        self,
-        *,
-        jwks_url: str,
-        issuer: str,
-        audience: str,
-        cache_ttl: int = 3600,
-        http_client: Optional[httpx.Client] = None,
-        verify: object = True,
-    ) -> None:
-        self._url = jwks_url
-        self._issuer = issuer
-        self._audience = audience
-        self._cache_ttl = cache_ttl
-        self._verify = verify
-        self._jwks: Optional[dict] = None
-        self._cached_at: float = 0.0
-        self._client = http_client or httpx.Client(timeout=5.0, verify=self._verify)
-
-    # --- cache plumbing -----------------------------------------------------
-
-    def _fetch_jwks(self) -> dict:
-        try:
-            resp = self._client.get(self._url)
-            resp.raise_for_status()
-            data = resp.json()
-        except (httpx.HTTPError, ValueError) as e:
-            raise JWKSVerifyError(
-                f"JWKS fetch failed: {type(e).__name__}"
-            ) from e
-        if not isinstance(data, dict) or "keys" not in data:
-            raise JWKSVerifyError("JWKS response missing 'keys'")
-        return data
-
-    def _get_jwks(self) -> dict:
-        if (
-            self._jwks is not None
-            and (time.time() - self._cached_at) < self._cache_ttl
-        ):
-            return self._jwks
-        self._jwks = self._fetch_jwks()
-        self._cached_at = time.time()
-        return self._jwks
-
-    def _resolve_key(self, kid: Optional[str]) -> Ed25519PublicKey:
-        jwks = self._get_jwks()
-        keys = jwks.get("keys") or []
-        if kid:
-            for jwk in keys:
-                if jwk.get("kid") == kid:
-                    return _jwk_to_ed25519_public(jwk)
-            raise JWKSVerifyError(f"unknown kid: {kid}")
-        # No kid in header — fall back to the single key (or first OKP key).
-        for jwk in keys:
-            if jwk.get("kty") == "OKP" and jwk.get("crv") == "Ed25519":
-                return _jwk_to_ed25519_public(jwk)
-        raise JWKSVerifyError("no Ed25519 keys in JWKS")
-
-    # --- verification -------------------------------------------------------
-
-    def verify_sync(self, token: str) -> dict:
-        if not token or len(token) > _MAX_TOKEN_LEN:
-            raise JWKSVerifyError("token length out of range")
-        # Pull kid from the unverified header so we know which key to use.
-        try:
-            header = pyjwt.get_unverified_header(token)
-        except PyJWTError as e:
-            raise JWKSVerifyError(f"invalid token header: {type(e).__name__}") from e
-        if header.get("alg") != "EdDSA":
-            raise JWKSVerifyError(
-                f"unsupported alg: {header.get('alg')!r}; only EdDSA accepted"
-            )
-        key = self._resolve_key(header.get("kid"))
-        try:
-            claims = pyjwt.decode(
-                token,
-                key=key,
-                algorithms=["EdDSA"],
-                audience=self._audience,
-                issuer=self._issuer,
-                leeway=_CLOCK_SKEW_SECONDS,
-                options={"require": ["exp", "iat", "iss", "aud", "sub"]},
-            )
-        except ExpiredSignatureError as e:
-            raise JWKSVerifyError("token expired") from e
-        except InvalidAudienceError as e:
-            raise JWKSVerifyError("invalid audience") from e
-        except InvalidIssuerError as e:
-            raise JWKSVerifyError("invalid issuer") from e
-        except InvalidSignatureError as e:
-            raise JWKSVerifyError("invalid signature") from e
-        except MissingRequiredClaimError as e:
-            raise JWKSVerifyError(f"missing claim: {e}") from e
-        except InvalidTokenError as e:
-            raise JWKSVerifyError(f"invalid token: {type(e).__name__}") from e
-        if claims.get("type") != "access":
-            raise JWKSVerifyError("token type must be access")
-        return claims
-
-    async def verify(self, token: str) -> dict:
-        """Async wrapper around :meth:`verify_sync`.
-
-        Kept thin because the actual work (PyJWT.decode + cached HTTP) is
-        synchronous; the wrapper exists so callers in async contexts can
-        use ``await`` without juggling executor threads.
-        """
-        return self.verify_sync(token)
+__all__ = ["JWKSVerifier", "JWKSVerifyError"]

--- a/src/api_gateway/rbac/oauth_client.py
+++ b/src/api_gateway/rbac/oauth_client.py
@@ -56,13 +56,53 @@ class OAuthClient:
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=self._timeout, verify=self._verify)
+            # No idle keep-alive: OAuth token exchange is infrequent (once per
+            # login) and the IdP sits behind an external proxy/tunnel that
+            # silently drops idle connections. A pooled keep-alive connection
+            # would go stale between logins and the next reuse fails. Dialing
+            # fresh each time costs nothing here and removes that whole class of
+            # "works after restart, then breaks again" failures.
+            self._client = httpx.AsyncClient(
+                timeout=self._timeout,
+                verify=self._verify,
+                limits=httpx.Limits(max_keepalive_connections=0),
+            )
         return self._client
 
     async def close(self) -> None:
         if self._client is not None and not self._client.is_closed:
             await self._client.aclose()
         self._client = None
+
+    async def _post(self, url: str, data: dict) -> httpx.Response:
+        """POST form data, retrying ONCE on a transport error with a fresh client.
+
+        A long-lived singleton client can hold a connection the IdP's
+        proxy/tunnel has already dropped; reusing it raises a transport error.
+        We discard the client (so the next dial is fresh) and retry once, which
+        lets the gateway self-heal on the very next request instead of needing a
+        process restart. Re-sending the request is safe: a transport error means
+        no response was received, and an authorization code that the IdP did
+        manage to consume simply comes back as a 4xx on retry (handled as
+        'auth failed') — never a double-spend.
+        """
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        last_exc: Optional[httpx.HTTPError] = None
+        for attempt in (1, 2):
+            try:
+                return await self._get_client().post(url, data=data, headers=headers)
+            except httpx.HTTPError as e:
+                last_exc = e
+                # Drop the (possibly stale) client so the retry — and every
+                # later request — dials a brand-new connection.
+                await self.close()
+                logger.info(
+                    "OAuth POST to %s failed (%s); attempt %d/2",
+                    url, type(e).__name__, attempt,
+                )
+        raise OAuthClientError(
+            f"OAuth request failed after retry: {type(last_exc).__name__}"
+        ) from last_exc
 
     # --- token endpoint -----------------------------------------------------
 
@@ -108,16 +148,7 @@ class OAuthClient:
 
     async def _post_token(self, data: dict) -> Optional[dict]:
         url = f"{self._base_url}/oauth/token"
-        try:
-            resp = await self._get_client().post(
-                url,
-                data=data,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-        except httpx.HTTPError as e:
-            raise OAuthClientError(
-                f"OAuth token request failed: {type(e).__name__}"
-            ) from e
+        resp = await self._post(url, data)
 
         if resp.status_code >= 500:
             raise OAuthClientError(
@@ -157,12 +188,10 @@ class OAuthClient:
 
         url = f"{self._base_url}/oauth/revoke"
         try:
-            resp = await self._get_client().post(
-                url,
-                data={"token": token, "token_type_hint": token_type_hint},
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            resp = await self._post(
+                url, {"token": token, "token_type_hint": token_type_hint}
             )
-        except httpx.HTTPError:
+        except OAuthClientError:
             logger.warning("OAuth revoke network error; treating as not revoked")
             return False
 

--- a/src/common/jwks_verifier.py
+++ b/src/common/jwks_verifier.py
@@ -1,0 +1,180 @@
+"""Ed25519 JWT verifier backed by a cached JWKS endpoint.
+
+Implements the inferia-auth side of the OAuth2 SSO integration: pulls
+`/.well-known/jwks.json` once per ``cache_ttl`` seconds, then verifies
+every incoming bearer token locally with PyJWT.
+
+python-jose 3.5 does NOT support EdDSA, so we use PyJWT[crypto] +
+cryptography's Ed25519PublicKey to parse the OKP/Ed25519 JWK manually.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import time
+from typing import Optional
+
+import httpx
+import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jwt import (
+    ExpiredSignatureError,
+    InvalidAudienceError,
+    InvalidIssuerError,
+    InvalidSignatureError,
+    InvalidTokenError,
+    MissingRequiredClaimError,
+    PyJWTError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class JWKSVerifyError(Exception):
+    """Raised whenever a token cannot be verified for any reason.
+
+    The internal cause (network, signature, expired, etc.) is folded into
+    the message so callers can log/forward; HTTP handlers should map this
+    to 401.
+    """
+
+
+_MAX_TOKEN_LEN = 8192
+_CLOCK_SKEW_SECONDS = 60
+
+
+def _b64url_to_bytes(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def _jwk_to_ed25519_public(jwk: dict) -> Ed25519PublicKey:
+    """Convert an OKP/Ed25519 JWK dict to a usable PublicKey object."""
+    if jwk.get("kty") != "OKP" or jwk.get("crv") != "Ed25519":
+        raise JWKSVerifyError("JWK is not an Ed25519 key")
+    x = jwk.get("x")
+    if not x:
+        raise JWKSVerifyError("JWK missing 'x' parameter")
+    try:
+        raw = _b64url_to_bytes(x)
+        return Ed25519PublicKey.from_public_bytes(raw)
+    except Exception as e:  # pragma: no cover - defensive
+        raise JWKSVerifyError(f"invalid Ed25519 JWK: {type(e).__name__}") from e
+
+
+class JWKSVerifier:
+    """Synchronous verifier with an in-memory JWKS cache.
+
+    Verification is CPU-bound and the JWKS fetch is amortised across many
+    tokens, so the public surface is intentionally sync. ``verify`` is an
+    async wrapper for callers that prefer await syntax.
+    """
+
+    def __init__(
+        self,
+        *,
+        jwks_url: str,
+        issuer: str,
+        audience: str,
+        cache_ttl: int = 3600,
+        http_client: Optional[httpx.Client] = None,
+        verify: object = True,
+    ) -> None:
+        self._url = jwks_url
+        self._issuer = issuer
+        self._audience = audience
+        self._cache_ttl = cache_ttl
+        self._verify = verify
+        self._jwks: Optional[dict] = None
+        self._cached_at: float = 0.0
+        self._client = http_client or httpx.Client(timeout=5.0, verify=self._verify)
+
+    # --- cache plumbing -----------------------------------------------------
+
+    def _fetch_jwks(self) -> dict:
+        try:
+            resp = self._client.get(self._url)
+            resp.raise_for_status()
+            data = resp.json()
+        except (httpx.HTTPError, ValueError) as e:
+            raise JWKSVerifyError(
+                f"JWKS fetch failed: {type(e).__name__}"
+            ) from e
+        if not isinstance(data, dict) or "keys" not in data:
+            raise JWKSVerifyError("JWKS response missing 'keys'")
+        return data
+
+    def _get_jwks(self) -> dict:
+        if (
+            self._jwks is not None
+            and (time.time() - self._cached_at) < self._cache_ttl
+        ):
+            return self._jwks
+        self._jwks = self._fetch_jwks()
+        self._cached_at = time.time()
+        return self._jwks
+
+    def _resolve_key(self, kid: Optional[str]) -> Ed25519PublicKey:
+        jwks = self._get_jwks()
+        keys = jwks.get("keys") or []
+        if kid:
+            for jwk in keys:
+                if jwk.get("kid") == kid:
+                    return _jwk_to_ed25519_public(jwk)
+            raise JWKSVerifyError(f"unknown kid: {kid}")
+        # No kid in header — fall back to the single key (or first OKP key).
+        for jwk in keys:
+            if jwk.get("kty") == "OKP" and jwk.get("crv") == "Ed25519":
+                return _jwk_to_ed25519_public(jwk)
+        raise JWKSVerifyError("no Ed25519 keys in JWKS")
+
+    # --- verification -------------------------------------------------------
+
+    def verify_sync(self, token: str) -> dict:
+        if not token or len(token) > _MAX_TOKEN_LEN:
+            raise JWKSVerifyError("token length out of range")
+        # Pull kid from the unverified header so we know which key to use.
+        try:
+            header = pyjwt.get_unverified_header(token)
+        except PyJWTError as e:
+            raise JWKSVerifyError(f"invalid token header: {type(e).__name__}") from e
+        if header.get("alg") != "EdDSA":
+            raise JWKSVerifyError(
+                f"unsupported alg: {header.get('alg')!r}; only EdDSA accepted"
+            )
+        key = self._resolve_key(header.get("kid"))
+        try:
+            claims = pyjwt.decode(
+                token,
+                key=key,
+                algorithms=["EdDSA"],
+                audience=self._audience,
+                issuer=self._issuer,
+                leeway=_CLOCK_SKEW_SECONDS,
+                options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+            )
+        except ExpiredSignatureError as e:
+            raise JWKSVerifyError("token expired") from e
+        except InvalidAudienceError as e:
+            raise JWKSVerifyError("invalid audience") from e
+        except InvalidIssuerError as e:
+            raise JWKSVerifyError("invalid issuer") from e
+        except InvalidSignatureError as e:
+            raise JWKSVerifyError("invalid signature") from e
+        except MissingRequiredClaimError as e:
+            raise JWKSVerifyError(f"missing claim: {e}") from e
+        except InvalidTokenError as e:
+            raise JWKSVerifyError(f"invalid token: {type(e).__name__}") from e
+        if claims.get("type") != "access":
+            raise JWKSVerifyError("token type must be access")
+        return claims
+
+    async def verify(self, token: str) -> dict:
+        """Async wrapper around :meth:`verify_sync`.
+
+        Kept thin because the actual work (PyJWT.decode + cached HTTP) is
+        synchronous; the wrapper exists so callers in async contexts can
+        use ``await`` without juggling executor threads.
+        """
+        return self.verify_sync(token)

--- a/src/inference/app.py
+++ b/src/inference/app.py
@@ -9,6 +9,7 @@ import json
 from typing import Optional
 from jose import JWTError, jwt
 
+from common.jwks_verifier import JWKSVerifier, JWKSVerifyError
 from common.schemas.common import HealthCheckResponse
 from inference.client import api_gateway_client
 from inference.config import settings
@@ -58,12 +59,68 @@ async def shutdown_event():
     await api_gateway_client.close_client()
 
 
+_sandbox_verifier: Optional[JWKSVerifier] = None
+
+
+def _get_sandbox_verifier() -> JWKSVerifier:
+    """Lazily build the JWKS verifier for external-mode sandbox tokens.
+
+    Mirrors api_gateway.rbac.middleware._get_verifier: generic OIDC IdPs issue
+    tokens with aud=client_id, while InferiaAuth issues aud=app_namespace.
+    """
+    global _sandbox_verifier
+    if _sandbox_verifier is None:
+        audience = (
+            settings.oauth_client_id
+            if settings.auth_provider == "oidc"
+            else settings.app_namespace
+        )
+        _sandbox_verifier = JWKSVerifier(
+            jwks_url=settings.external_auth_url.rstrip("/") + "/.well-known/jwks.json",
+            issuer=settings.external_auth_issuer,
+            audience=audience,
+            cache_ttl=settings.oauth_jwks_cache_ttl_seconds,
+            verify=settings.httpx_verify,
+        )
+    return _sandbox_verifier
+
+
+def _sandbox_key_from_claims(claims: dict) -> str:
+    """Build the `sandbox:{org_id}:{user_id}` key from verified JWT claims.
+
+    The `sub` of an InferiaAuth token is prefixed (`user:<uuid>`); the prefix
+    MUST be stripped because the policy engine splits this key on ':' and
+    requires exactly 3 parts. org_id comes from the explicit `org_id` claim,
+    else the first entry of `org_ids[]` (matches api_gateway extraction).
+    """
+    sub = claims.get("sub", "") or ""
+    user_id = sub.split(":", 1)[1] if ":" in sub else sub
+    org_id = claims.get("org_id")
+    if not org_id:
+        org_ids = claims.get("org_ids") or []
+        org_id = org_ids[0] if org_ids else None
+    return f"sandbox:{org_id}:{user_id}"
+
+
 def extract_api_key(authorization: str, sandbox: bool = False) -> str:
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid API Key format")
     token = authorization.split(" ")[1]
 
     if sandbox:
+        # External SSO (oidc/inferiaauth): the bearer is an EdDSA JWT issued by
+        # the IdP, verified via JWKS — NOT the local HS256 secret. The verifier
+        # already enforces type==access + iss/aud/sub/exp/iat.
+        if settings.is_external_mode:
+            try:
+                claims = _get_sandbox_verifier().verify_sync(token)
+            except JWKSVerifyError:
+                raise HTTPException(
+                    status_code=401, detail="Invalid JWT token for sandbox mode"
+                )
+            return _sandbox_key_from_claims(claims)
+
+        # Local mode: built-in HS256 access token.
         try:
             payload = jwt.decode(
                 token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm]

--- a/src/inference/config.py
+++ b/src/inference/config.py
@@ -213,6 +213,42 @@ class Settings(BaseSettings):
     )
     jwt_algorithm: str = "HS256"
 
+    # External SSO auth (sandbox JWT verification in oidc/inferiaauth mode).
+    # In these modes the dashboard's bearer is an EdDSA JWT issued by the IdP
+    # (verified via JWKS), NOT a local HS256 token — so the sandbox path must
+    # verify it the same way the api_gateway does. Mirrors api_gateway.config.
+    auth_provider: str = Field(default="local", validation_alias="AUTH_PROVIDER")
+    external_auth_url: Optional[str] = Field(
+        default=None, validation_alias="EXTERNAL_AUTH_URL"
+    )
+    external_auth_issuer: Optional[str] = Field(
+        default=None, validation_alias="EXTERNAL_AUTH_ISSUER"
+    )
+    app_namespace: str = Field(
+        default="inferiallm", validation_alias="APP_NAMESPACE"
+    )
+    oauth_client_id: Optional[str] = Field(
+        default=None, validation_alias="OAUTH_CLIENT_ID"
+    )
+    oauth_jwks_cache_ttl_seconds: int = Field(
+        default=3600, ge=60, le=86400,
+        validation_alias="OAUTH_JWKS_CACHE_TTL_SECONDS",
+    )
+    verify_ssl: bool = Field(default=True, validation_alias="VERIFY_SSL")
+    ssl_ca_bundle: Optional[str] = Field(
+        default=None, validation_alias="SSL_CA_BUNDLE"
+    )
+
+    @property
+    def is_external_mode(self) -> bool:
+        """True when auth is delegated to an external IdP (oidc/inferiaauth)."""
+        return self.auth_provider in ("oidc", "inferiaauth", "external")
+
+    @property
+    def httpx_verify(self) -> object:
+        """httpx ``verify=`` value: CA-bundle path if set, else the bool."""
+        return self.ssl_ca_bundle or self.verify_ssl
+
     @property
     def is_production(self) -> bool:
         """Check if running in production environment."""

--- a/src/orchestration/models/model_deployment/preflight.py
+++ b/src/orchestration/models/model_deployment/preflight.py
@@ -9,6 +9,61 @@ import httpx
 logger = logging.getLogger(__name__)
 
 HF_API_BASE = "https://huggingface.co/api/models"
+HF_RESOLVE_BASE = "https://huggingface.co"
+
+# Field names HF model configs use for the native context window. Multimodal
+# configs (e.g. Gemma 3) nest the language model under "text_config".
+_CTX_FIELDS = (
+    "max_position_embeddings",
+    "max_sequence_length",
+    "seq_length",
+    "n_positions",
+    "max_seq_len",
+)
+
+
+def _native_context_from_config(config: Optional[Dict[str, Any]]) -> Optional[int]:
+    """Extract a model's native context window from an HF config dict.
+
+    Checks the top level and a nested ``text_config`` (multimodal models).
+    Returns the int, or None when no recognized field is present.
+    """
+    if not isinstance(config, dict):
+        return None
+    sources = [config]
+    text_cfg = config.get("text_config")
+    if isinstance(text_cfg, dict):
+        sources.append(text_cfg)
+    for src in sources:
+        for field_name in _CTX_FIELDS:
+            val = src.get(field_name)
+            if isinstance(val, int) and val > 0:
+                return val
+    return None
+
+
+async def fetch_native_max_len(
+    model_id: str, hf_token: Optional[str] = None
+) -> Optional[int]:
+    """Best-effort fetch of a model's native context window from its config.json.
+
+    Used to clamp a deploy's ``max_model_len`` so it never exceeds the model's
+    native context — vLLM HARD-ERRORS at startup otherwise (and the container
+    crashes during model load). Returns None on any failure (gated / missing /
+    parse error); callers then let the engine derive the context itself.
+    """
+    url = f"{HF_RESOLVE_BASE}/{model_id}/resolve/main/config.json"
+    headers = {}
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+    try:
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            resp = await client.get(url, headers=headers)
+            if resp.status_code == 200:
+                return _native_context_from_config(resp.json())
+    except Exception as e:
+        logger.warning("Failed to fetch native context for %s: %s", model_id, e)
+    return None
 
 # Engines that require config.json (transformers-based)
 ENGINES_REQUIRING_CONFIG_JSON = {"vllm", "tei", "infinity"}
@@ -516,15 +571,10 @@ def check_context_length(
     if not hf_info or not max_model_len:
         return ContextLengthCheckResult(ok=True, skipped=True)
 
-    # HF config sometimes has max_position_embeddings
     config = hf_info.get("config", {}) or {}
-    native_ctx = (
-        config.get("max_position_embeddings")
-        or config.get("max_sequence_length")
-        or config.get("seq_length")
-    )
+    native_ctx = _native_context_from_config(config)
 
-    if not native_ctx or not isinstance(native_ctx, int):
+    if not native_ctx:
         return ContextLengthCheckResult(ok=True, skipped=True)
 
     if max_model_len > native_ctx:

--- a/src/providers/akash/akash_adapter.py
+++ b/src/providers/akash/akash_adapter.py
@@ -182,7 +182,7 @@ class AkashAdapter(ProviderAdapter):
             # Inference & General Purpose
             service_name = metadata.get("service_name", "app")
             sdl_content = build_inference_sdl(
-                image=image or "docker.io/vllm/vllm-openai:v0.16.0",
+                image=image or "docker.io/vllm/vllm-openai:v0.22.1",
                 service_name=service_name,
                 env=env,
                 command=command,

--- a/src/providers/nosana/job_builder.py
+++ b/src/providers/nosana/job_builder.py
@@ -50,7 +50,7 @@ CUDA_DRIVER_LD_LIBRARY_PATH = (
 
 def create_vllm_job(
     model_id: str,
-    image: str = "docker.io/vllm/vllm-openai:v0.16.0",
+    image: str = "docker.io/vllm/vllm-openai:v0.22.1",
     hf_token: Optional[str] = None,
     api_key: Optional[str] = None,
     # Stability & Hardware
@@ -65,7 +65,7 @@ def create_vllm_job(
     enforce_eager: bool = False,
     min_vram: int = 8,
     # Advanced Tuning
-    max_model_len: int = 8192,
+    max_model_len: Optional[int] = None,
     max_num_seqs: int = 256,
     quantization: Optional[str] = None,
     # Additional config
@@ -144,8 +144,6 @@ def create_vllm_job(
         "0.0.0.0",
         "--port",
         "9000",
-        "--max-model-len",
-        str(max_model_len),
         "--gpu-memory-utilization",
         str(gpu_util),
         "--max-num-seqs",
@@ -153,6 +151,15 @@ def create_vllm_job(
         "--dtype",
         dtype,
     ]
+
+    # Only pin --max-model-len when it is explicitly known. Forcing a value
+    # ABOVE the model's native context (max_position_embeddings) makes vLLM
+    # HARD-ERROR at config creation and the container crashes during model load
+    # ("User-specified max_model_len (8192) is greater than the derived
+    # max_model_len" — e.g. facebook/opt-125m's native 2048). When None, vLLM
+    # derives the model's native context, which is always valid.
+    if max_model_len is not None:
+        cmd_args.extend(["--max-model-len", str(max_model_len)])
 
     if trust_remote_code:
         cmd_args.append("--trust-remote-code")
@@ -318,7 +325,7 @@ def create_vllm_omni_job(
     enforce_eager: bool = False,
     min_vram: int = 16,
     # Advanced Tuning
-    max_model_len: int = 8192,
+    max_model_len: Optional[int] = None,
     max_num_seqs: int = 64,
     limit_mm_per_prompt: str = "image=1,video=1",
     required_cuda: Optional[List[str]] = None,
@@ -376,8 +383,6 @@ def create_vllm_omni_job(
         "--port",
         "9000",
         "--omni",
-        "--max-model-len",
-        str(max_model_len),
         "--gpu-memory-utilization",
         str(gpu_util),
         "--max-num-seqs",
@@ -386,6 +391,11 @@ def create_vllm_omni_job(
         dtype,
         "--trust-remote-code",
     ]
+
+    # See create_vllm_job: pin --max-model-len only when known, else let vLLM
+    # derive the native context (forcing > native crashes the container).
+    if max_model_len is not None:
+        cmd_args.extend(["--max-model-len", str(max_model_len)])
 
     if enforce_eager:
         cmd_args.append("--enforce-eager")
@@ -912,7 +922,7 @@ def build_job_definition(
     if engine == "vllm":
         job = create_vllm_job(
             model_id=model_id,
-            image=image or "docker.io/vllm/vllm-openai:v0.16.0",
+            image=image or "docker.io/vllm/vllm-openai:v0.22.1",
             hf_token=hf_token,
             api_key=api_key,
             **{

--- a/src/providers/nosana/nosana_adapter.py
+++ b/src/providers/nosana/nosana_adapter.py
@@ -18,8 +18,34 @@ from providers.nosana.job_builder import (
     INTERNAL_API_KEY,
 )
 from orchestration.config import settings
+from orchestration.models.model_deployment.preflight import fetch_native_max_len
 
 logger = logging.getLogger(__name__)
+
+# Default context-length cap for vLLM deploys when the user doesn't specify one.
+# Keeps KV-cache memory bounded for large-context models; always clamped down to
+# the model's native context so small models (e.g. opt-125m, native 2048) never
+# get a value above their max_position_embeddings (which vLLM rejects at startup).
+DEFAULT_VLLM_MAX_MODEL_LEN = 8192
+
+
+def _clamp_max_model_len(
+    requested: Optional[int], native: Optional[int]
+) -> Optional[int]:
+    """Resolve the effective vLLM --max-model-len.
+
+    - requested set  -> min(requested, native) if native known, else requested.
+    - requested unset -> min(DEFAULT, native) if native known, else None.
+
+    Returns None to mean "omit the flag" so vLLM derives the model's native
+    context (always valid). Never returns a value above ``native``.
+    """
+    if requested:
+        return min(requested, native) if native else requested
+    if native:
+        return min(DEFAULT_VLLM_MAX_MODEL_LEN, native)
+    return None
+
 
 TERMINAL_JOB_STATES = {2, 3, 4, "COMPLETED", "STOPPED", "FAILED", "QUIT"}
 
@@ -243,6 +269,26 @@ class NosanaAdapter(ProviderAdapter):
         elif model_id:
             logger.info(f"Using job_builder for engine={engine}, model={model_id}")
 
+            # Clamp the vLLM context length to the model's native window. Forcing
+            # a value above max_position_embeddings makes vLLM hard-error at
+            # startup → the container crashes during model load ("endpoint never
+            # served"). This was crashing every small-context model (opt-125m,
+            # etc.) while large-context models (Qwen3) ran fine. Best-effort
+            # fetch; on failure the flag is omitted and vLLM derives the context.
+            requested_mml = metadata.get("max_model_len")
+            if engine in ("vllm", "vllm-omni"):
+                native_ctx = await fetch_native_max_len(model_id, hf_token)
+                effective_mml = _clamp_max_model_len(requested_mml, native_ctx)
+                logger.info(
+                    "vLLM max_model_len for %s: requested=%s native=%s -> %s",
+                    model_id, requested_mml, native_ctx, effective_mml,
+                )
+            else:
+                effective_mml = (
+                    requested_mml if requested_mml is not None
+                    else DEFAULT_VLLM_MAX_MODEL_LEN
+                )
+
             # Extract additional config from metadata.
             # Default 0.80 (not 0.95): community/DePIN GPUs reserve VRAM for the CUDA
             # context + co-tenants, and vLLM ABORTS at startup if free < gpu_util*total.
@@ -251,7 +297,7 @@ class NosanaAdapter(ProviderAdapter):
                 "gpu_util": metadata.get("gpu_util", 0.80),
                 "dtype": metadata.get("dtype", "auto"),
                 "enforce_eager": metadata.get("enforce_eager", False),
-                "max_model_len": metadata.get("max_model_len", 8192),
+                "max_model_len": effective_mml,
                 "max_num_seqs": metadata.get("max_num_seqs", 256),
                 "quantization": metadata.get("quantization"),
                 "min_vram": metadata.get("min_vram", 12),

--- a/src/tests/api_gateway/test_oauth_client.py
+++ b/src/tests/api_gateway/test_oauth_client.py
@@ -314,3 +314,97 @@ def test_oauth_client_get_client_uses_verify():
     # httpx.AsyncClient stores verify internally; just confirm it was created.
     assert inner is not None
     assert not inner.is_closed
+
+
+# ---------------------------------------------------------------------------
+# Resilience: retry once on a transport error with a fresh connection so the
+# gateway self-heals (no process restart needed) when the IdP's proxy/tunnel
+# drops a pooled connection.
+# ---------------------------------------------------------------------------
+
+import httpx as _httpx
+
+
+class _FlakyClient:
+    """Fake httpx client: raises ConnectError for the first `fail_times` posts,
+    then returns `response`."""
+
+    def __init__(self, fail_times, response):
+        self.calls = 0
+        self._fail_times = fail_times
+        self._response = response
+        self.is_closed = False
+
+    async def post(self, url, data=None, headers=None):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise _httpx.ConnectError("stale pooled connection")
+        return self._response
+
+    async def aclose(self):
+        self.is_closed = True
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_retries_once_then_succeeds():
+    resp = _httpx.Response(200, json={"access_token": "atk", "refresh_token": "rtk"})
+    flaky = _FlakyClient(fail_times=1, response=resp)
+    c = OAuthClient(base_url="http://idp.test", client_id="x")
+    c._get_client = lambda: flaky  # bypass real httpx; exercise the retry loop
+
+    tokens = await c.exchange_code(
+        code="abc", code_verifier="verifier-12345-with-enough-bytes",
+        redirect_uri="https://app.example.test/auth/callback",
+    )
+    assert tokens["access_token"] == "atk"
+    assert flaky.calls == 2  # failed once, retried once, succeeded
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_retry_exhausted_raises():
+    flaky = _FlakyClient(fail_times=2, response=_httpx.Response(200, json={}))
+    c = OAuthClient(base_url="http://idp.test", client_id="x")
+    c._get_client = lambda: flaky
+
+    with pytest.raises(OAuthClientError):
+        await c.exchange_code(
+            code="abc", code_verifier="verifier-12345-with-enough-bytes",
+            redirect_uri="https://app.example.test/auth/callback",
+        )
+    assert flaky.calls == 2  # exactly one retry, then give up
+
+
+@pytest.mark.asyncio
+async def test_transport_error_discards_client_so_next_request_redials():
+    # After a transport failure the cached client must be dropped so a later
+    # request builds a fresh one — this is what removes the "stuck until
+    # restart" behavior.
+    bad = OAuthClient(base_url="http://127.0.0.1:1", client_id="x", timeout=0.3)
+    with pytest.raises(OAuthClientError):
+        await bad.exchange_code(
+            code="abc", code_verifier="verifier-12345-with-enough-bytes",
+            redirect_uri="https://app.example.test/auth/callback",
+        )
+    assert bad._client is None  # discarded -> next call dials fresh
+
+
+@pytest.mark.asyncio
+async def test_client_rebuilt_after_close():
+    # close() must drop the client so the next request dials fresh (the
+    # self-heal path). _get_client caches within a session but rebuilds after.
+    c = OAuthClient(base_url="http://idp.test", client_id="x")
+    first = c._get_client()
+    assert c._get_client() is first  # cached within a session
+    await c.close()
+    assert c._client is None
+    assert c._get_client() is not first  # fresh client after close
+    await c.close()
+
+
+@pytest.mark.asyncio
+async def test_revoke_retries_then_succeeds():
+    flaky = _FlakyClient(fail_times=1, response=_httpx.Response(200))
+    c = OAuthClient(base_url="http://idp.test", client_id="x")
+    c._get_client = lambda: flaky
+    assert await c.revoke(token="rtk") is True
+    assert flaky.calls == 2

--- a/src/tests/inference/test_sandbox_auth.py
+++ b/src/tests/inference/test_sandbox_auth.py
@@ -1,0 +1,210 @@
+"""Tests for inference sandbox token extraction (extract_api_key).
+
+Covers the external-SSO (oidc/inferiaauth) path — where the bearer is an
+EdDSA JWT verified via JWKS — alongside the legacy local HS256 path and the
+edge cases (bad alg, bad signature, wrong issuer/audience, length overflow,
+prefix-stripping, org_ids fallback, missing Bearer).
+"""
+
+import base64
+import time
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from fastapi import HTTPException
+
+from inference.app import extract_api_key
+from inference.config import settings
+
+# NB: `from inference import app` would bind the FastAPI instance (the package
+# re-exports it), not the module — so the singleton is reset by string path.
+_VERIFIER_SINGLETON = "inference.app._sandbox_verifier"
+
+ISS = "https://idp.test"
+AUD = "inferiallm"
+
+# One Ed25519 keypair + its JWKS for the whole module.
+_PRIV = Ed25519PrivateKey.generate()
+_RAW_PUB = _PRIV.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+_X = base64.urlsafe_b64encode(_RAW_PUB).rstrip(b"=").decode()
+JWKS = {
+    "keys": [
+        {"kty": "OKP", "crv": "Ed25519", "kid": "test-key", "x": _X,
+         "alg": "EdDSA", "use": "sig"}
+    ]
+}
+
+
+def _eddsa(claims: dict, kid: str = "test-key") -> str:
+    return pyjwt.encode(claims, _PRIV, algorithm="EdDSA", headers={"kid": kid})
+
+
+def _access_claims(**over) -> dict:
+    now = int(time.time())
+    base = {
+        "type": "access",
+        "iss": ISS,
+        "aud": AUD,
+        "sub": "user:abc-123",
+        "iat": now,
+        "exp": now + 3600,
+    }
+    base.update(over)
+    return base
+
+
+@pytest.fixture
+def external_mode(monkeypatch):
+    """inferiaauth mode + JWKS injected (no network)."""
+    monkeypatch.setattr(settings, "auth_provider", "inferiaauth")
+    monkeypatch.setattr(settings, "external_auth_url", ISS)
+    monkeypatch.setattr(settings, "external_auth_issuer", ISS)
+    monkeypatch.setattr(settings, "app_namespace", AUD)
+    monkeypatch.setattr(settings, "oauth_client_id", None)
+    monkeypatch.setattr(settings, "ssl_ca_bundle", None)
+    monkeypatch.setattr(settings, "verify_ssl", True)
+    monkeypatch.setattr(_VERIFIER_SINGLETON, None, raising=False)
+    monkeypatch.setattr(
+        "common.jwks_verifier.JWKSVerifier._fetch_jwks", lambda self: JWKS
+    )
+    yield
+    monkeypatch.setattr(_VERIFIER_SINGLETON, None, raising=False)
+
+
+@pytest.fixture
+def local_mode(monkeypatch):
+    monkeypatch.setattr(settings, "auth_provider", "local")
+    monkeypatch.setattr(settings, "jwt_secret_key", "x" * 40)
+    monkeypatch.setattr(settings, "jwt_algorithm", "HS256")
+    monkeypatch.setattr(_VERIFIER_SINGLETON, None, raising=False)
+
+
+# --------------------------- external (EdDSA) -------------------------------
+
+def test_external_happy_strips_user_prefix(external_mode):
+    token = _eddsa(_access_claims(sub="user:abc-123", org_id="org-9"))
+    assert extract_api_key(f"Bearer {token}", sandbox=True) == "sandbox:org-9:abc-123"
+
+
+def test_external_sub_without_prefix(external_mode):
+    token = _eddsa(_access_claims(sub="abc-123", org_id="org-9"))
+    assert extract_api_key(f"Bearer {token}", sandbox=True) == "sandbox:org-9:abc-123"
+
+
+def test_external_org_ids_fallback(external_mode):
+    claims = _access_claims(org_ids=["orgA", "orgB"])
+    claims.pop("org_id", None)
+    token = _eddsa(claims)
+    assert extract_api_key(f"Bearer {token}", sandbox=True) == "sandbox:orgA:abc-123"
+
+
+def test_external_key_has_exactly_three_parts(external_mode):
+    # Regression: an un-stripped "user:<uuid>" sub would make 4 colon parts and
+    # break the policy engine's len(parts)==3 check.
+    token = _eddsa(_access_claims(sub="user:fa73-1356-5052", org_id="o1"))
+    assert extract_api_key(f"Bearer {token}", sandbox=True).count(":") == 2
+
+
+def test_external_invalid_signature(external_mode):
+    other = Ed25519PrivateKey.generate()
+    token = pyjwt.encode(_access_claims(), other, algorithm="EdDSA",
+                         headers={"kid": "test-key"})
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(f"Bearer {token}", sandbox=True)
+    assert e.value.status_code == 401
+    assert e.value.detail == "Invalid JWT token for sandbox mode"
+
+
+def test_external_wrong_alg_hs256_rejected(external_mode):
+    # An HS256 token must be rejected in external mode (alg != EdDSA).
+    token = pyjwt.encode(_access_claims(), "x" * 40, algorithm="HS256")
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(f"Bearer {token}", sandbox=True)
+    assert e.value.status_code == 401
+
+
+def test_external_wrong_issuer(external_mode):
+    token = _eddsa(_access_claims(iss="https://evil.test"))
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(f"Bearer {token}", sandbox=True)
+    assert e.value.status_code == 401
+
+
+def test_external_wrong_audience(external_mode):
+    token = _eddsa(_access_claims(aud="someone-else"))
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(f"Bearer {token}", sandbox=True)
+    assert e.value.status_code == 401
+
+
+def test_external_expired(external_mode):
+    now = int(time.time())
+    token = _eddsa(_access_claims(iat=now - 7200, exp=now - 3600))
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(f"Bearer {token}", sandbox=True)
+    assert e.value.status_code == 401
+
+
+def test_external_wrong_type_rejected(external_mode):
+    token = _eddsa(_access_claims(type="user"))
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(f"Bearer {token}", sandbox=True)
+    assert e.value.status_code == 401
+
+
+def test_external_length_overflow(external_mode):
+    with pytest.raises(HTTPException) as e:
+        extract_api_key("Bearer " + "x" * 9000, sandbox=True)
+    assert e.value.status_code == 401
+    assert e.value.detail == "Invalid JWT token for sandbox mode"
+
+
+def test_external_garbage_token(external_mode):
+    with pytest.raises(HTTPException) as e:
+        extract_api_key("Bearer not.a.jwt", sandbox=True)
+    assert e.value.status_code == 401
+
+
+# ----------------------------- local (HS256) --------------------------------
+
+def test_local_happy(local_mode):
+    token = pyjwt.encode(
+        {"type": "access", "org_id": "o1", "sub": "u1"}, "x" * 40, algorithm="HS256"
+    )
+    assert extract_api_key(f"Bearer {token}", sandbox=True) == "sandbox:o1:u1"
+
+
+def test_local_wrong_secret(local_mode):
+    token = pyjwt.encode(
+        {"type": "access", "org_id": "o1", "sub": "u1"}, "wrong" * 8, algorithm="HS256"
+    )
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(f"Bearer {token}", sandbox=True)
+    assert e.value.status_code == 401
+    assert e.value.detail == "Invalid JWT token for sandbox mode"
+
+
+def test_local_wrong_type(local_mode):
+    token = pyjwt.encode(
+        {"type": "refresh", "org_id": "o1", "sub": "u1"}, "x" * 40, algorithm="HS256"
+    )
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(f"Bearer {token}", sandbox=True)
+    assert e.value.status_code == 401
+    assert e.value.detail == "Invalid token type for sandbox mode"
+
+
+# ------------------------------- common -------------------------------------
+
+def test_non_sandbox_returns_raw_token(local_mode):
+    assert extract_api_key("Bearer raw-api-key-123", sandbox=False) == "raw-api-key-123"
+
+
+@pytest.mark.parametrize("hdr", [None, "", "Token abc", "abc"])
+def test_missing_or_malformed_bearer(hdr):
+    with pytest.raises(HTTPException) as e:
+        extract_api_key(hdr, sandbox=True)
+    assert e.value.status_code == 401
+    assert e.value.detail == "Invalid API Key format"

--- a/src/tests/orchestration/test/adapter_test/test_vllm_max_model_len.py
+++ b/src/tests/orchestration/test/adapter_test/test_vllm_max_model_len.py
@@ -1,0 +1,112 @@
+"""max_model_len handling for vLLM Nosana jobs.
+
+Regression for the crash where every small-context model (e.g. facebook/opt-125m,
+native context 2048) failed to deploy on Nosana: the job builder hardcoded
+``--max-model-len 8192``, and vLLM v0.16 HARD-ERRORS at config creation when the
+requested context exceeds the model's native ``max_position_embeddings`` — the
+container then crashes during model load ("endpoint never served"). Large-context
+models (Qwen3, native 40960) were unaffected, which is why only some deploys
+crashed.
+
+Fix: omit ``--max-model-len`` unless a value is known, and clamp any value down
+to the model's native context.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# nosana_adapter reads several settings at import time; a MagicMock resolves
+# them all. internal_api_key is pinned so the builder's auth header is a string.
+_mock_settings = MagicMock()
+_mock_settings.internal_api_key = "test-key"
+
+with patch("orchestration.config.settings", _mock_settings):
+    from providers.nosana.job_builder import (
+        create_vllm_job,
+        create_vllm_omni_job,
+        build_job_definition,
+    )
+    from providers.nosana.nosana_adapter import (
+        _clamp_max_model_len,
+        DEFAULT_VLLM_MAX_MODEL_LEN,
+    )
+
+MODEL = "facebook/opt-125m"
+
+
+def _cmd(job_or_def):
+    if "op" in job_or_def:
+        return job_or_def["op"]["args"]["cmd"]
+    return job_or_def["ops"][0]["args"]["cmd"]
+
+
+# --------------------------- builder: flag omission -------------------------
+
+class TestBuilderMaxModelLenFlag:
+    def test_omitted_by_default(self):
+        # Default (None) -> no --max-model-len so vLLM derives the native context.
+        assert "--max-model-len" not in _cmd(create_vllm_job(model_id=MODEL))
+
+    def test_present_when_set(self):
+        cmd = _cmd(create_vllm_job(model_id=MODEL, max_model_len=2048))
+        assert "--max-model-len" in cmd
+        assert cmd[cmd.index("--max-model-len") + 1] == "2048"
+
+    def test_omni_omitted_by_default(self):
+        assert "--max-model-len" not in _cmd(create_vllm_omni_job(model_id=MODEL))
+
+    def test_omni_present_when_set(self):
+        cmd = _cmd(create_vllm_omni_job(model_id=MODEL, max_model_len=4096))
+        assert cmd[cmd.index("--max-model-len") + 1] == "4096"
+
+    def test_build_job_definition_omits_when_none(self):
+        # build_job_definition drops None kwargs, so passing None omits the flag.
+        cmd = _cmd(build_job_definition(engine="vllm", model_id=MODEL, max_model_len=None))
+        assert "--max-model-len" not in cmd
+
+    def test_build_job_definition_passes_int(self):
+        cmd = _cmd(build_job_definition(engine="vllm", model_id=MODEL, max_model_len=2048))
+        assert cmd[cmd.index("--max-model-len") + 1] == "2048"
+
+    def test_other_flags_still_present(self):
+        # Removing --max-model-len must not disturb the rest of the command.
+        cmd = _cmd(create_vllm_job(model_id=MODEL, gpu_util=0.8))
+        assert "--gpu-memory-utilization" in cmd
+        assert cmd[cmd.index("--gpu-memory-utilization") + 1] == "0.8"
+        assert "--served-model-name" in cmd
+
+
+# ------------------------------ clamp logic ---------------------------------
+
+class TestClampMaxModelLen:
+    def test_small_model_default_capped_to_native(self):
+        # opt-125m: no request, native 2048 -> 2048 (the bug case).
+        assert _clamp_max_model_len(None, 2048) == 2048
+
+    def test_large_model_default_uses_cap(self):
+        # Qwen3: no request, native 40960 -> 8192 (unchanged from old behavior).
+        assert _clamp_max_model_len(None, 40960) == DEFAULT_VLLM_MAX_MODEL_LEN
+
+    def test_unknown_native_no_request_returns_none(self):
+        # Native unknown + no request -> omit the flag, let vLLM derive.
+        assert _clamp_max_model_len(None, None) is None
+
+    def test_requested_clamped_down_to_native(self):
+        assert _clamp_max_model_len(4096, 2048) == 2048
+
+    def test_requested_under_native_kept(self):
+        assert _clamp_max_model_len(4096, 40960) == 4096
+
+    def test_requested_kept_when_native_unknown(self):
+        assert _clamp_max_model_len(16384, None) == 16384
+
+    def test_requested_equal_native(self):
+        assert _clamp_max_model_len(2048, 2048) == 2048
+
+    @pytest.mark.parametrize("native", [2048, 8192, 40960, 128000])
+    def test_never_exceeds_native(self, native):
+        for requested in (None, 1024, 8192, 999999):
+            eff = _clamp_max_model_len(requested, native)
+            if eff is not None:
+                assert eff <= native

--- a/src/tests/orchestration/test/model_deployment/test_native_context.py
+++ b/src/tests/orchestration/test/model_deployment/test_native_context.py
@@ -1,0 +1,127 @@
+"""Native context-window resolution used to clamp vLLM max_model_len."""
+
+import httpx
+import pytest
+
+from orchestration.models.model_deployment.preflight import (
+    _native_context_from_config,
+    fetch_native_max_len,
+    check_context_length,
+)
+
+
+class TestNativeContextFromConfig:
+    def test_max_position_embeddings(self):
+        assert _native_context_from_config({"max_position_embeddings": 2048}) == 2048
+
+    def test_max_sequence_length(self):
+        assert _native_context_from_config({"max_sequence_length": 4096}) == 4096
+
+    def test_seq_length(self):
+        assert _native_context_from_config({"seq_length": 1024}) == 1024
+
+    def test_n_positions(self):
+        assert _native_context_from_config({"n_positions": 512}) == 512
+
+    def test_nested_text_config(self):
+        # Multimodal (e.g. Gemma 3): context lives under text_config.
+        cfg = {"model_type": "gemma3", "text_config": {"max_position_embeddings": 32768}}
+        assert _native_context_from_config(cfg) == 32768
+
+    def test_top_level_wins_over_nested(self):
+        cfg = {"max_position_embeddings": 8192, "text_config": {"max_position_embeddings": 4096}}
+        assert _native_context_from_config(cfg) == 8192
+
+    def test_missing_returns_none(self):
+        assert _native_context_from_config({"hidden_size": 768}) is None
+
+    def test_zero_is_invalid(self):
+        assert _native_context_from_config({"max_position_embeddings": 0}) is None
+
+    def test_non_int_ignored(self):
+        assert _native_context_from_config({"max_position_embeddings": "2048"}) is None
+
+    def test_none_and_non_dict(self):
+        assert _native_context_from_config(None) is None
+        assert _native_context_from_config("nope") is None
+
+
+class _Resp:
+    def __init__(self, status, payload=None):
+        self.status_code = status
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    def __init__(self, resp=None, exc=None):
+        self._resp, self._exc = resp, exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None):
+        if self._exc:
+            raise self._exc
+        return self._resp
+
+
+@pytest.mark.asyncio
+class TestFetchNativeMaxLen:
+    async def test_success(self, monkeypatch):
+        monkeypatch.setattr(
+            httpx, "AsyncClient",
+            lambda *a, **k: _Client(resp=_Resp(200, {"max_position_embeddings": 2048})),
+        )
+        assert await fetch_native_max_len("facebook/opt-125m") == 2048
+
+    async def test_nested_success(self, monkeypatch):
+        monkeypatch.setattr(
+            httpx, "AsyncClient",
+            lambda *a, **k: _Client(resp=_Resp(200, {"text_config": {"seq_length": 8192}})),
+        )
+        assert await fetch_native_max_len("x/y") == 8192
+
+    async def test_non_200_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            httpx, "AsyncClient", lambda *a, **k: _Client(resp=_Resp(401, None))
+        )
+        assert await fetch_native_max_len("gated/model", hf_token="t") is None
+
+    async def test_exception_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            httpx, "AsyncClient",
+            lambda *a, **k: _Client(exc=httpx.ConnectError("boom")),
+        )
+        assert await fetch_native_max_len("x/y") is None
+
+    async def test_missing_field_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            httpx, "AsyncClient",
+            lambda *a, **k: _Client(resp=_Resp(200, {"hidden_size": 1})),
+        )
+        assert await fetch_native_max_len("x/y") is None
+
+
+class TestCheckContextLengthStillWorks:
+    """The refactor must preserve check_context_length behavior."""
+
+    def test_within_limit_ok(self):
+        hf = {"config": {"max_position_embeddings": 8192}}
+        assert check_context_length(hf, 4096).ok
+
+    def test_exceeds_limit_fails(self):
+        hf = {"config": {"max_position_embeddings": 2048}}
+        res = check_context_length(hf, 8192)
+        assert not res.ok and "native" in res.error
+
+    def test_skipped_when_no_max(self):
+        assert check_context_length({"config": {}}, 8192).skipped
+
+    def test_skipped_when_no_request(self):
+        assert check_context_length({"config": {"max_position_embeddings": 2048}}, None).skipped


### PR DESCRIPTION
## Summary
Three independent production fixes from live debugging of the Nosana + InferiaAuth SSO deployment:

1. **Sandbox JWT in external auth** — the inference sandbox decoded the bearer with the local HS256 secret, so in oidc/inferiaauth mode the IdP's EdDSA token failed verification → `Invalid JWT token for sandbox mode`. Now verified via JWKS (verifier moved to `common/`, re-exported from `api_gateway.rbac` for back-compat); `user:` sub-prefix stripped so the 3-part sandbox key holds.
2. **Nosana vLLM deploy** — hardcoded `--max-model-len 8192` crashed every model whose native context is smaller (e.g. `opt-125m`=2048): vLLM hard-errors at config creation and the container crashes during model load. Now clamped to the model's native context (fetched from `config.json`), or the flag is omitted so vLLM derives it. Default vLLM image bumped `v0.16.0` → `v0.22.1` (matches the dashboard + AWS engine-AMI recipe; also resolves the LFM2.5 tokenizer crash).
3. **OAuth login resilience** — the singleton `OAuthClient` never discarded a connection the IdP proxy/tunnel had dropped, so logins failed with `Sign in service is unavailable` until a process restart. Now disables idle keep-alive and retries once on a transport error with a fresh connection (self-heals).

## Tests
- New unit tests: sandbox JWT extraction, `max_model_len` clamp + native-context resolver, OAuth self-heal/retry. All green; existing suites unaffected.
- Verified live: `opt-125m` RUNNING on Nosana; `LFM2.5-350M` loads on `v0.22.1`; sandbox accepts a real IdP-minted token; OAuth client reaches the IdP and self-heals.