### PR TITLE
feat: image/video deploy HF-token dropdown + pipeline fix

### DIFF
--- a/apps/dashboard/src/pages/NewDeployment.tsx
+++ b/apps/dashboard/src/pages/NewDeployment.tsx
@@ -25,6 +25,7 @@ import { calculateCompatibility, fetchExternalRegistry, GPU_SPECS, type FitLevel
 import { getOllamaModels, searchOllamaModels, formatModelSize, type OllamaModel } from "@/services/ollamaService"
 import { CompatibilityProjectionChart } from "@/components/deployment/CompatibilityProjectionChart"
 import { ConfigService } from "@/services/configService"
+import { buildDiffusionSpec } from "./newDeploymentSpec"
 
 // --- Constants ---
 
@@ -756,26 +757,13 @@ export default function NewDeployment() {
       }
       return JSON.stringify(spec, null, 4)
     } else if (selectedEngine === "inferia-diffusion") {
-      const finalModelId = modelId || "segmind/tiny-sd";
-      const spec: any = {
-        model_id: finalModelId,
-        engine: "inferia-diffusion",
-        image: "docker.io/inferiaai/inferiadiffusion:latest",
-        port: 8080,
-        host: "0.0.0.0",
-        min_vram: 8,
-        gpu: true,
-        env: hfToken ? { "HF_TOKEN": hfToken } : {},
-        expose: [{
-          port: 8080,
-          type: "http",
-          health_checks: [{ path: "/health", type: "http", method: "GET", expected_status: 200 }]
-        }]
-      }
-      if (state.trustRemoteCode) spec.trust_remote_code = true
-      if (state.modelOffload) spec.model_offload = true
-      if (state.groupOffload) spec.group_offload = true
-      return JSON.stringify(spec, null, 4)
+      return buildDiffusionSpec({
+        modelId,
+        modelType,
+        trustRemoteCode: state.trustRemoteCode,
+        modelOffload: state.modelOffload,
+        groupOffload: state.groupOffload,
+      })
     } else if (selectedEngine === "pytorch") {
       return JSON.stringify({ image: "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime", cmd: ["sleep", "infinity"], gpu: true }, null, 4)
     }
@@ -850,8 +838,8 @@ export default function NewDeployment() {
     const preflightOk = await runPreflight(
       modelId || (config as any).model_id || "",
       selectedEngine,
-      selectedEngine === "vllm" ? undefined : (hfToken || undefined),
-      selectedEngine === "vllm" ? (selectedHfTokenName || undefined) : undefined,
+      (selectedEngine === "vllm" || selectedEngine === "inferia-diffusion") ? undefined : (hfToken || undefined),
+      (selectedEngine === "vllm" || selectedEngine === "inferia-diffusion") ? (selectedHfTokenName || undefined) : undefined,
     );
     if (!preflightOk) return;
 
@@ -860,7 +848,7 @@ export default function NewDeployment() {
       configuration: deploymentType === "training" ? { workload_type: "training", image: computeEngines.find(e => e.id === selectedEngine)?.image || "pytorch/pytorch:latest", git_repo: gitRepo, training_script: trainingScript, dataset_url: datasetUrl, base_model: baseModel, gpu_count: 1, hf_token: hfToken || undefined } : config,
       owner_id: user?.user_id, org_id: targetOrgId, inference_model: modelId || undefined, job_definition: config,
       ami_id: requiresAmi(selectedEngine, selectedPool) ? selectedAmiId : undefined,
-      hf_token_name: selectedEngine === "vllm" ? (selectedHfTokenName || undefined) : undefined,
+      hf_token_name: (selectedEngine === "vllm" || selectedEngine === "inferia-diffusion") ? (selectedHfTokenName || undefined) : undefined,
     }
     createMutation.mutate(payload)
   }
@@ -1054,7 +1042,7 @@ function PoolSelection({ userPools, poolsLoading, selectedPool, dispatch, setSte
 function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry }: { state: State; dispatch: React.Dispatch<Action>; onLaunch: () => void; isPending: boolean; externalRegistry?: ExternalModel[] }) {
   const {
     deploymentType, modelType, instanceName, selectedEngine, selectedHFModel, modelId,
-    maxModelLen, gpuUtil, hfToken, batchSize, maxSequenceLength, gitRepo,
+    maxModelLen, gpuUtil, batchSize, maxSequenceLength, gitRepo,
     trainingScript, datasetUrl, baseModel, dtype, enforceEager, quantization,
     isAdvancedOpen,
     maxBatchTokens, pooling, requiredCpu, requiredRam, gpuEnabled,
@@ -1089,7 +1077,7 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
   const { data: hfTokenNames = [] } = useQuery({
     queryKey: ['hf-token-names'],
     queryFn: () => ConfigService.listHfTokenNames(),
-    enabled: selectedEngine === "vllm",
+    enabled: selectedEngine === "vllm" || selectedEngine === "inferia-diffusion",
     staleTime: 1000 * 60 * 5,
   });
 
@@ -1401,9 +1389,25 @@ function ManagedConfig({ state, dispatch, onLaunch, isPending, externalRegistry 
             Model type is automatically set based on your deployment type. API key is configured automatically by the system.
           </div>
           <div>
-            <label htmlFor="hfTokenLocalai" className="block text-xs font-medium text-muted-foreground mb-1.5">HuggingFace Token (for private/gated models)</label>
-            <input id="hfTokenLocalai" type="password" value={hfToken} onChange={e => dispatch({ type: 'SET_FIELD', field: 'hfToken', value: e.target.value })} className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white" placeholder="hf_xxxxx (optional)" />
-            <p className="text-xs text-muted-foreground mt-1">Required only for gated models like SDXL, FLUX, etc.</p>
+            <label htmlFor="hfTokenNameDiff" className="block text-xs font-medium text-muted-foreground mb-1.5">
+              HuggingFace Token <span className="text-muted-foreground/60">(optional — required for gated models)</span>
+            </label>
+            <select
+              id="hfTokenNameDiff"
+              value={selectedHfTokenName}
+              onChange={e => dispatch({ type: 'SET_FIELD', field: 'selectedHfTokenName', value: e.target.value })}
+              className="w-full px-3 py-2 text-sm border dark:border-border rounded-md bg-card dark:text-white"
+            >
+              <option value="">None</option>
+              {hfTokenNames.map(name => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+            {hfTokenNames.length === 0 && (
+              <p className="text-xs text-muted-foreground mt-1">
+                No saved tokens — add one at Settings → Providers → HuggingFace.
+              </p>
+            )}
           </div>
           <div className="grid grid-cols-3 gap-4">
             <div className="flex items-center gap-2">

--- a/apps/dashboard/src/pages/__tests__/NewDeployment.diffusion.test.tsx
+++ b/apps/dashboard/src/pages/__tests__/NewDeployment.diffusion.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { buildDiffusionSpec } from "../newDeploymentSpec";
+
+describe("buildDiffusionSpec", () => {
+  it("builds a diffusion spec on port 8000 with config block and no raw token env", () => {
+    const spec = JSON.parse(buildDiffusionSpec({
+      modelId: "stabilityai/sdxl-turbo",
+      modelType: "image_generation",
+      trustRemoteCode: true,
+      modelOffload: false,
+      groupOffload: false,
+    }));
+    expect(spec.port).toBe(8000);
+    expect(spec.expose[0].port).toBe(8000);
+    expect(spec.engine).toBe("inferia-diffusion");
+    expect(spec.image).toBe("docker.io/inferiaai/inferiadiffusion:latest");
+    expect(spec.config.model_type).toBe("image_generation");
+    expect(spec.config.trust_remote_code).toBe(true);
+    expect(spec.config.model_offload).toBeUndefined();
+    expect(spec.config.group_offload).toBeUndefined();
+    expect(spec.env?.HF_TOKEN).toBeUndefined();
+  });
+
+  it("defaults the model id and sets video model_type", () => {
+    const spec = JSON.parse(buildDiffusionSpec({ modelId: "", modelType: "video_generation" }));
+    expect(spec.model_id).toBe("segmind/tiny-sd");
+    expect(spec.config.model_type).toBe("video_generation");
+  });
+
+  it("includes offload flags only when enabled", () => {
+    const spec = JSON.parse(buildDiffusionSpec({
+      modelId: "stabilityai/sdxl-turbo",
+      modelType: "image_generation",
+      trustRemoteCode: false,
+      modelOffload: true,
+      groupOffload: true,
+    }));
+    expect(spec.config.model_offload).toBe(true);
+    expect(spec.config.group_offload).toBe(true);
+    // trust_remote_code off → omitted
+    expect(spec.config.trust_remote_code).toBeUndefined();
+  });
+});

--- a/apps/dashboard/src/pages/newDeploymentSpec.ts
+++ b/apps/dashboard/src/pages/newDeploymentSpec.ts
@@ -1,0 +1,33 @@
+// Pure job-spec builders for the New Deployment form. Kept out of the large
+// NewDeployment.tsx component so they can be unit-tested and coverage-measured
+// in isolation (see vitest.config.ts coverage.include).
+
+export function buildDiffusionSpec(opts: {
+  modelId: string;
+  modelType: string;
+  trustRemoteCode?: boolean;
+  modelOffload?: boolean;
+  groupOffload?: boolean;
+}): string {
+  const finalModelId = opts.modelId || "segmind/tiny-sd";
+  const config: Record<string, string | boolean> = { model_type: opts.modelType };
+  if (opts.trustRemoteCode) config.trust_remote_code = true;
+  if (opts.modelOffload) config.model_offload = true;
+  if (opts.groupOffload) config.group_offload = true;
+  const spec = {
+    model_id: finalModelId,
+    engine: "inferia-diffusion",
+    image: "docker.io/inferiaai/inferiadiffusion:latest",
+    port: 8000,
+    host: "0.0.0.0",
+    min_vram: 8,
+    gpu: true,
+    config,
+    expose: [{
+      port: 8000,
+      type: "http",
+      health_checks: [{ path: "/health", type: "http", method: "GET", expected_status: 200 }],
+    }],
+  };
+  return JSON.stringify(spec, null, 4);
+}

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
         "src/components/nodes/NodeLogs.tsx",
         "src/components/deployment/TerminalLogs.tsx",
         "src/components/deployment/DeploymentOverview.tsx",
+        "src/pages/newDeploymentSpec.ts",
       ],
       exclude: ["src/main.tsx", "src/setupTests.ts", "**/*.test.{ts,tsx}", "**/__tests__/**"],
       reporter: ["text", "html"],

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -846,11 +846,11 @@ def main(argv=None):
     )
     cmp_p.add_argument(
         "--worker-image",
-        default="ghcr.io/inferiaai/inferia-worker:0.2.7",
+        default="ghcr.io/inferiaai/inferia-worker:0.2.10",
         help="Worker container image (full repository:tag). Published via the "
              "InferiaAI/inferia-worker GitHub Action on v* tags. Note that "
              "docker/metadata-action strips the leading 'v' from semver tags, "
-             "so git tag v0.2.7 produces GHCR tag 0.2.7.",
+             "so git tag v0.2.10 produces GHCR tag 0.2.10.",
     )
     cmp_p.add_argument(
         "--inference-port", type=int, default=8080,

--- a/src/common/model_types.py
+++ b/src/common/model_types.py
@@ -59,7 +59,7 @@ class ModelCapabilities:
             "api_endpoints": ["/v1/images/generations"],
             "streaming_support": False,
             "gpu_required": True,
-            "supported_backends": ["diffusers", "sdxl", "comfyui"],
+            "supported_backends": ["diffusers", "sdxl", "comfyui", "inferia-diffusion"],
             "default_backend": "diffusers",
             "description": "Image generation models (Stable Diffusion, etc.)",
         },

--- a/src/orchestration/messaging/uri_validation.py
+++ b/src/orchestration/messaging/uri_validation.py
@@ -31,6 +31,9 @@ _ALLOWED_CONFIG_KEYS = frozenset({
     "max_batch_size",
     "max_input_length",
     "max_total_tokens",
+    "model_type",
+    "model_offload",
+    "group_offload",
 })
 
 

--- a/src/providers/nosana/job_builder.py
+++ b/src/providers/nosana/job_builder.py
@@ -816,6 +816,10 @@ def create_inferia_diffusion_job(
     host: str = "0.0.0.0",
     min_vram: int = 6,
     required_cuda: Optional[List[str]] = None,
+    model_type: Optional[str] = None,
+    trust_remote_code: bool = False,
+    model_offload: bool = False,
+    group_offload: bool = False,
 ) -> Dict[str, Any]:
     """
     Build a Nosana job definition for Inferia Diffusion engine.
@@ -828,6 +832,10 @@ def create_inferia_diffusion_job(
         port: Port to expose
         host: Host to bind to
         min_vram: Minimum VRAM requirement in GB
+        model_type: image_generation|video_generation|image|video — maps to --model-type
+        trust_remote_code: allow remote code execution for the model (--trust-remote-code)
+        model_offload: enable sequential model CPU offload (--model-offload)
+        group_offload: enable grouped CPU offload (--group-offload)
 
     Returns:
         Dict with 'op' (container operation) and 'meta' (job metadata)
@@ -849,11 +857,28 @@ def create_inferia_diffusion_job(
         str(port),
     ]
 
+    _MODEL_TYPE_FLAG = {
+        "image_generation": "image",
+        "image": "image",
+        "video_generation": "video",
+        "video": "video",
+    }
+    _mt = _MODEL_TYPE_FLAG.get((model_type or "").lower())
+    if _mt:
+        cmd_args.extend(["--model-type", _mt])
+
     if effective_api_key:
         cmd_args.extend(["--api-key", effective_api_key])
 
     if hf_token:
         cmd_args.extend(["--hf-token", hf_token])
+
+    if trust_remote_code:
+        cmd_args.append("--trust-remote-code")
+    if model_offload:
+        cmd_args.append("--model-offload")
+    if group_offload:
+        cmd_args.append("--group-offload")
 
     container_op = {
         "id": "InferiaDiffusion",
@@ -1034,7 +1059,18 @@ def build_job_definition(
             **{
                 k: v
                 for k, v in kwargs.items()
-                if k in ["port", "host", "min_vram", "required_cuda"] and v is not None
+                if k
+                in [
+                    "port",
+                    "host",
+                    "min_vram",
+                    "required_cuda",
+                    "model_type",
+                    "trust_remote_code",
+                    "model_offload",
+                    "group_offload",
+                ]
+                and v is not None
             },
         )
     else:

--- a/src/providers/nosana/nosana_adapter.py
+++ b/src/providers/nosana/nosana_adapter.py
@@ -84,6 +84,24 @@ def generate_api_key(prefix: str = "nos") -> str:
     return f"{prefix}_{secrets.token_urlsafe(32)}"
 
 
+def _diffusion_job_overrides(metadata: dict) -> dict:
+    """Diffusion-specific job_config values sourced from ``configuration.config``.
+
+    ``trust_remote_code`` deliberately defaults to ``False`` for diffusion — it
+    is NOT inherited from the engine-wide ``True`` default, because we do not
+    auto-trust remote code for image/video models unless the user opts in.
+    Values are expected to be native booleans (already coerced upstream by
+    ``sanitize_config``); ``bool()`` is a defensive last resort.
+    """
+    cfg = metadata.get("config") if isinstance(metadata.get("config"), dict) else {}
+    return {
+        "model_type": cfg.get("model_type"),
+        "trust_remote_code": bool(cfg.get("trust_remote_code", False)),
+        "model_offload": bool(cfg.get("model_offload", False)),
+        "group_offload": bool(cfg.get("group_offload", False)),
+    }
+
+
 class NosanaAdapter(ProviderAdapter):
     """
     Nosana DePIN adapter.
@@ -325,6 +343,9 @@ class NosanaAdapter(ProviderAdapter):
                 "diffusers_pipeline": metadata.get("diffusers_pipeline"),
                 "scheduler": metadata.get("scheduler"),
             }
+
+            if engine == "inferia-diffusion":
+                job_config.update(_diffusion_job_overrides(metadata))
 
             job_definition = build_job_definition(
                 engine=engine,

--- a/src/tests/orchestration/test_diffusion_config_plumbing.py
+++ b/src/tests/orchestration/test_diffusion_config_plumbing.py
@@ -1,5 +1,8 @@
+import json
+
 from orchestration.messaging.uri_validation import sanitize_config
 from common.model_types import ModelType, ModelCapabilities
+from orchestration.models.model_deployment.deployment_linker import _spec_from_pending
 
 
 def test_sanitize_config_preserves_diffusion_keys():
@@ -23,3 +26,28 @@ def test_image_generation_supports_inferia_diffusion():
     assert "inferia-diffusion" in backends
     vbackends = ModelCapabilities.get_supported_backends(ModelType.VIDEO_GENERATION)
     assert "inferia-diffusion" in vbackends
+
+
+def test_spec_from_pending_forwards_diffusion_config_and_env():
+    # Mirrors the dashboard-emitted configuration for an inferia-diffusion deploy:
+    # diffusion options nested under `config`, HF_TOKEN injected server-side into
+    # `env` from the named token. Both must reach the worker load spec intact.
+    configuration = json.dumps({
+        "model_id": "stabilityai/sdxl-turbo",
+        "engine": "inferia-diffusion",
+        "config": {"model_type": "image_generation", "trust_remote_code": True},
+        "env": {"HF_TOKEN": "secret123"},
+    })
+    deploy = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "engine": "inferia-diffusion",
+        "inference_model": "stabilityai/sdxl-turbo",
+        "model_name": "my-image-deploy",
+        "configuration": configuration,
+    }
+    spec = _spec_from_pending(deploy, gpu_required=1)
+    assert spec["recipe"] == "inferia-diffusion"
+    assert spec["config"]["model_type"] == "image_generation"
+    assert spec["config"]["trust_remote_code"] is True
+    assert spec["env"]["HF_TOKEN"] == "secret123"
+    assert spec["model"]["artifact_uri"].endswith("stabilityai/sdxl-turbo")

--- a/src/tests/orchestration/test_diffusion_config_plumbing.py
+++ b/src/tests/orchestration/test_diffusion_config_plumbing.py
@@ -1,0 +1,25 @@
+from orchestration.messaging.uri_validation import sanitize_config
+from common.model_types import ModelType, ModelCapabilities
+
+
+def test_sanitize_config_preserves_diffusion_keys():
+    cfg = {
+        "model_type": "video_generation",
+        "trust_remote_code": True,
+        "model_offload": True,
+        "group_offload": False,
+        "bogus_key": "dropme",
+    }
+    out = sanitize_config(cfg)
+    assert out["model_type"] == "video_generation"
+    assert out["trust_remote_code"] is True
+    assert out["model_offload"] is True
+    assert out["group_offload"] is False
+    assert "bogus_key" not in out
+
+
+def test_image_generation_supports_inferia_diffusion():
+    backends = ModelCapabilities.get_supported_backends(ModelType.IMAGE_GENERATION)
+    assert "inferia-diffusion" in backends
+    vbackends = ModelCapabilities.get_supported_backends(ModelType.VIDEO_GENERATION)
+    assert "inferia-diffusion" in vbackends

--- a/src/tests/providers/test_nosana_diffusion_job.py
+++ b/src/tests/providers/test_nosana_diffusion_job.py
@@ -1,0 +1,74 @@
+from providers.nosana.job_builder import create_inferia_diffusion_job, build_job_definition
+
+
+def test_diffusion_job_emits_model_type_and_flags():
+    job = create_inferia_diffusion_job(
+        model_id="stabilityai/sdxl-turbo",
+        model_type="image_generation",
+        trust_remote_code=True,
+        model_offload=True,
+        group_offload=False,
+    )
+    cmd = job["op"]["args"]["cmd"]
+    assert cmd[:2] == ["inferiadiffusion", "serve"]
+    assert "--model" in cmd and "stabilityai/sdxl-turbo" in cmd
+    i = cmd.index("--model-type")
+    assert cmd[i + 1] == "image"
+    assert "--trust-remote-code" in cmd
+    assert "--model-offload" in cmd
+    assert "--group-offload" not in cmd
+
+
+def test_diffusion_video_type_maps_to_video():
+    job = create_inferia_diffusion_job(model_id="Wan-AI/Wan2.1-T2V-1.3B", model_type="video_generation")
+    cmd = job["op"]["args"]["cmd"]
+    i = cmd.index("--model-type")
+    assert cmd[i + 1] == "video"
+
+
+def test_diffusion_no_model_type_omits_flag():
+    job = create_inferia_diffusion_job(model_id="segmind/tiny-sd")
+    assert "--model-type" not in job["op"]["args"]["cmd"]
+
+
+def test_diffusion_unknown_model_type_omits_flag():
+    job = create_inferia_diffusion_job(model_id="segmind/tiny-sd", model_type="audio")
+    assert "--model-type" not in job["op"]["args"]["cmd"]
+
+
+def test_build_job_definition_threads_diffusion_flags():
+    full = build_job_definition(
+        engine="inferia-diffusion",
+        model_id="segmind/tiny-sd",
+        model_type="image_generation",
+        trust_remote_code=True,
+    )
+    cmd = full["ops"][0]["args"]["cmd"]
+    assert "--model-type" in cmd and "--trust-remote-code" in cmd
+
+
+from providers.nosana.nosana_adapter import _diffusion_job_overrides
+
+
+def test_diffusion_overrides_reads_nested_config():
+    md = {"config": {"model_type": "video_generation", "trust_remote_code": True,
+                     "model_offload": True, "group_offload": False}}
+    out = _diffusion_job_overrides(md)
+    assert out["model_type"] == "video_generation"
+    assert out["trust_remote_code"] is True
+    assert out["model_offload"] is True
+    assert out["group_offload"] is False
+
+
+def test_diffusion_overrides_missing_config_defaults_false():
+    out = _diffusion_job_overrides({})
+    assert out["model_type"] is None
+    assert out["trust_remote_code"] is False
+    assert out["model_offload"] is False
+    assert out["group_offload"] is False
+
+
+def test_diffusion_overrides_non_dict_config_is_safe():
+    out = _diffusion_job_overrides({"config": "not-a-dict"})
+    assert out["model_type"] is None
+    assert out["trust_remote_code"] is False


### PR DESCRIPTION
## What

Makes image/video (`inferia-diffusion`) deploys use the **same named HF-token dropdown** as vLLM, and fixes the deploy pipeline so the user's **selected model actually loads** on both the AWS (worker) and Nosana (DePIN) paths.

### Frontend (`apps/dashboard`)
- The diffusion deploy form's free-text HF-token field is replaced with the named-token **dropdown** (sourced from the Providers tab), exactly like vLLM. Sends `hf_token_name` (resolved server-side) instead of a raw token.
- Job-spec corrected: port `8080 → 8000`, options moved into `configuration.config`, no raw `HF_TOKEN` in env. Extracted a pure `buildDiffusionSpec` (unit-tested, added to the vitest coverage allowlist).

### Backend
- `_ALLOWED_CONFIG_KEYS` now permits `model_type`/`model_offload`/`group_offload` so they survive `sanitize_config` to the worker.
- `IMAGE_GENERATION.supported_backends` now includes `inferia-diffusion`.
- Nosana job-builder emits `--model-type image|video` + `--trust-remote-code`/`--model-offload`/`--group-offload`; the adapter sources these from `configuration.config` via a pure `_diffusion_job_overrides` helper (diffusion defaults `trust_remote_code=False`, not the vLLM-wide `True`).

### CP worker tag
- Default worker image bumped `0.2.7 → 0.2.8`.

## Tests
- Python: `sanitize_config` preserves the new keys; `model_types` exposes inferia-diffusion (image+video); `_spec_from_pending` forwards `config.config` + `env` to the worker load spec; Nosana builder/override tests (8). All green via the docker test image.
- Dashboard: `buildDiffusionSpec` unit tests (port 8000, config block, offload on/off, no raw token). vitest green, `tsc` clean, build OK.

## ⚠️ Merge order
The `0.2.8` worker-tag bump requires `ghcr.io/inferiaai/inferia-worker:0.2.8` to exist. **Merge + deploy this only after** InferiaAI/inferia-worker PR #11 is merged and the `v0.2.8` image is published, or new AWS pools will fail to pull the worker image.

🔗 Pairs with InferiaAI/inferia-worker#11