### PR TITLE
fix(orchestration): AWS-bootstrap worker tag 0.2.9 → 0.2.11 (diffusion image + readiness)

### DIFF
--- a/src/orchestration/config.py
+++ b/src/orchestration/config.py
@@ -154,9 +154,10 @@ class Settings(BaseSettings):
     worker_image_tag: str = Field(
         # docker/metadata-action's semver pattern strips the leading "v"
         # from git tags, so the GHCR tag for git tag v0.2.9 is 0.2.9.
-        # 0.2.9 also drops the broken VLLM_USE_FASTOKENS default; 0.2.8 added container-name idempotency fix
+        # 0.2.11 adds the per-recipe readiness timeout (diffusion model-load-before-health); 0.2.10 fixed the inferia-diffusion image name (no-hyphen) + serve-CLI model load;
+        # 0.2.9 dropped the broken VLLM_USE_FASTOKENS default; 0.2.8 added container-name idempotency fix
         # (remove-before-create) that unsticks DEPLOYING deploys.
-        default="0.2.9",
+        default="0.2.11",
         validation_alias="INFERIA_WORKER_IMAGE_TAG",
     )
     bootstrap_token_ttl_seconds: int = Field(


### PR DESCRIPTION
## Why
Follow-up to #288. That PR bumped the **CLI** `--worker-image` default to `0.2.10`, but the **AWS pool-first provisioning** path bootstraps EC2 workers from a *different* setting — `orchestration/config.py` `worker_image_tag` (`INFERIA_WORKER_IMAGE_TAG`), which was still `0.2.9`.

**Caught by live AWS verification:** a g6.xlarge node bootstrapped worker `0.2.9` (pre-fix recipe) and the diffusion deploy `FAILED` with `pull access denied for inferiaai/inferia-diffusion, repository does not exist` — i.e. the old **hyphenated** image name that `0.2.10` fixes.

## Change
`worker_image_tag` default `0.2.9` → `0.2.10`.

Deployments that set `INFERIA_WORKER_IMAGE_TAG` in their env must also bump it to `0.2.10` (the env override wins over this default).